### PR TITLE
Use threaded runtime for all executables

### DIFF
--- a/cardano-db-sync-extended/cardano-db-sync-extended.cabal
+++ b/cardano-db-sync-extended/cardano-db-sync-extended.cabal
@@ -72,6 +72,7 @@ executable cardano-db-sync-extended
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
                         -Wno-unsafe
+                        -threaded
 
   build-depends:        base                            >= 4.12         && < 4.13
                       , bytestring

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -103,6 +103,7 @@ executable cardano-db-sync
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
                         -Wno-unsafe
+                        -threaded
 
   build-depends:        base                            >= 4.12         && < 4.13
                       , bytestring


### PR DESCRIPTION
All code that links to 'ouroboros-network' needs to be linked with
'-threaded' since that is needed on OXS.

Closes: https://github.com/input-output-hk/cardano-db-sync/issues/10