### PR TITLE
Align Docker images with source service definition

### DIFF
--- a/.buildkite/docker-build-push-db-sync-extended.nix
+++ b/.buildkite/docker-build-push-db-sync-extended.nix
@@ -29,7 +29,7 @@ with hostPkgs;
 with hostPkgs.lib;
 
 let
-  image = impureCreated dbSyncPackages.dockerImage;
+  image = impureCreated dbSyncPackages.dockerImage.dbSyncExtended;
 
   # Override Docker image, setting its creation date to the current time rather than the unix epoch.
   impureCreated = image: image // { inherit (image) version; };

--- a/.buildkite/docker-build-push-db-sync.nix
+++ b/.buildkite/docker-build-push-db-sync.nix
@@ -1,0 +1,74 @@
+# This script will load nix-built docker image of cardano-db-sync applications
+# into the Docker daemon (must be running), and then push to the Docker Hub.
+# Credentials for the hub must already be installed with # "docker login".
+#
+# There is a little bit of bash logic to replace the default repo and
+# tag from the nix-build (../nix/docker.nix).
+#
+# 1. The repo (default "inputoutput/cardano-db-sync") is changed to match
+#    the logged in Docker user's credentials.
+#
+# 2. The tag (default "VERSION") is changed to reflect the
+#    branch which is being built under this Buildkite pipeline.
+#
+#    - All commits are tagged with commit hash.
+#    - If the branch is master then master tag is updated
+#    - If there is a tag associated with the commit then that tag is pushed as well
+
+{ dbSyncPackages ?  import ../. {}
+
+# Build system's Nixpkgs. We use this so that we have the same docker
+# version as the docker daemon.
+, hostPkgs ? import <nixpkgs> {}
+
+# Dockerhub repository for image tagging.
+, dockerHubRepoName ? null
+}:
+
+with hostPkgs;
+with hostPkgs.lib;
+
+let
+  image = impureCreated dbSyncPackages.dockerImage.dbSync;
+
+  # Override Docker image, setting its creation date to the current time rather than the unix epoch.
+  impureCreated = image: image // { inherit (image) version; };
+
+in
+  writeScript "docker-build-push" ''
+    #!${runtimeShell}
+
+    set -euo pipefail
+
+    export PATH=${lib.makeBinPath [ docker gnused ]}
+
+    fullrepo="${dockerHubRepoName}"
+
+    echo '~~~ Pushing docker images'
+
+    ${concatMapStringsSep "\n" (image: ''
+      branch="''${BUILDKITE_BRANCH:-}"
+      tag="''${BUILDKITE_TAG:-}"
+      tagged="$fullrepo:$tag"
+      gitrev="${image.imageTag}"
+      echo "Loading $fullrepo:$gitrev"
+      docker load -i ${image}
+      echo "Pushing $fullrepo:$gitrev"
+      docker push "$fullrepo:$gitrev"
+      if [[ "$branch" = master ]]; then
+        echo "Tagging as master"
+        docker tag $fullrepo:$gitrev $fullrepo:$branch
+        echo "Pushing $fullrepo:$branch"
+        docker push "$fullrepo:$branch"
+      fi
+      if [[ "$tag" ]]; then
+        echo "Tagging as $tag"
+        docker tag $fullrepo:$gitrev $fullrepo:$tag
+        echo "Pushing $fullrepo:$tag"
+        docker push "$fullrepo:$tag"
+      fi
+      echo "Cleaning up with docker system prune"
+      docker system prune -f
+    '') [ image ]}
+
+  ''

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,13 @@ steps:
 
   - label: 'cardano-db-sync Docker image'
     command:
-      - "nix-build .buildkite/docker-build-push.nix --argstr dockerHubRepoName inputoutput/$BUILDKITE_PIPELINE_NAME -o docker-build-push"
+      - "nix-build .buildkite/docker-build-push-db-sync.nix --argstr dockerHubRepoName inputoutput/cardano-db-sync -o docker-build-push"
       - "./docker-build-push"
     agents:
       system: x86_64-linux
+  - label: 'cardano-db-sync-extended Docker image'
+      command:
+        - "nix-build .buildkite/docker-build-push-db-sync-extended.nix --argstr dockerHubRepoName inputoutput/cardano-db-sync-extended -o docker-build-push"
+        - "./docker-build-push"
+      agents:
+        system: x86_64-linux

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ log-dir
 result*
 launch_*
 cabal.project.local
+
+### Docker ###
+config/docker
+tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.7"
+services:
+  cardano-node:
+    image: inputoutput/cardano-node:master
+    environment:
+      - NETWORK=${NETWORK}
+    volumes:
+      - node-db:/data/db
+      - node-socket:/data/node.socket
+    restart: on-failure
+  cardano-db-sync:
+    image: inputoutput/cardano-db-sync:master
+    environment:
+      - NETWORK=${NETWORK}
+    depends_on:
+      - cardano-node
+      - postgres
+    volumes:
+      - ./config/docker/pgpass:/config/pgpass
+      - ./tmp:/tmp # cardano-db-sync logs migration errors to disk, and then exits. Without the container running, we can't access the logs. Writing them to the host works around the limitation.
+      - node-socket:/data/node.socket
+    restart: on-failure
+  postgres:
+    image: postgres:11.5-alpine
+    environment:
+      - POSTGRES_LOGGING=true
+      - POSTGRES_DB_FILE=/run/secrets/postgres_db
+      - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
+      - POSTGRES_USER_FILE=/run/secrets/postgres_user
+    secrets:
+      - postgres_password
+      - postgres_user
+      - postgres_db
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    restart: on-failure
+secrets:
+  postgres_db:
+    file: ./config/docker/secrets/postgres_db
+  postgres_password:
+    file: ./config/docker/secrets/postgres_password
+  postgres_user:
+    file: ./config/docker/secrets/postgres_user
+volumes:
+  postgres-data:
+  node-db:
+  node-socket:


### PR DESCRIPTION
Aligns `cardano-db-sync` and `cardano-db-sync-extended` Docker image interface to conform with service-scoped requirement, and adds a docker-compose file for reference. Also fixes invalid config path, previously nested under `data`.

The practice of defining a _build and push_ script in each repo should be abandoned in favour of a central iohk-nix solution. For this reason, I've left any refactors to improve the design from what was implemented in https://github.com/input-output-hk/cardano-rest/tree/master/.buildkite to avoid a variance that introduces a false sense of comfort. 

**_Draft_** until Docker Hub repository is setup.