### PR TITLE
Adds Epoch transformation view

### DIFF
--- a/schema/migration-3-0001-20200320.sql
+++ b/schema/migration-3-0001-20200320.sql
@@ -1,0 +1,10 @@
+-- START: cardano-graphql views
+create view "Epoch" as
+select
+  epoch.out_sum as "output",
+  epoch.no as "number",
+  epoch.tx_count as "transactionsCount",
+  epoch.start_time as "startedAt",
+  epoch.end_time as "lastBlockTime"
+from epoch
+-- END: cardano-graphql views


### PR DESCRIPTION
Adds Epoch transformation View to align with [GraphQL schema](https://github.com/input-output-hk/cardano-graphql/blob/fcf1d9be1b7d601afaf2bf4d90736cc8496836e1/src/schema.graphql#L239-L252), restoring previous functionality prior to `cardano-db-sync-extended`. This is just an extension of the current design, mostly defined in the [previous migration](https://github.com/input-output-hk/cardano-db-sync/blob/master/schema/migration-3-0001-20190816.sql)