### PR TITLE
Add required Stack dependecy for building with Stack.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,10 @@ ghc-options:
   cardano-db-sync-extended: -Wall -Werror -fwarn-redundant-constraints
 
 extra-deps:
+
+  - git: https://github.com/input-output-hk/cardano-crypto
+    commit: 2547ad1e80aeabca2899951601079408becbc92c
+
   - binary-0.8.7.0
   - bimap-0.4.0
   - brick-0.47.1


### PR DESCRIPTION
Not sure if https://github.com/input-output-hk/cardano-db-sync/pull/27 is going to be merged, but this PR enables building with Stack. Otherwise:
```
stack build --fast -j`nproc`      
WARNING: Ignoring persistent-template's bounds on th-lift-instances (>=0.1.14 && <0.2); using th-lift-instances-0.1.12.
Reason: allow-newer enabled.
WARNING: Ignoring io-streams's bounds on network (>=2.3 && <3.1); using network-3.1.1.1.
Reason: allow-newer enabled.
WARNING: Ignoring io-streams-haproxy's bounds on network (>=2.3 && <3.1); using network-3.1.1.1.
Reason: allow-newer enabled.

Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for cardano-crypto-wrapper-1.3.0:
    cardano-crypto needed, but the stack configuration has no specified version (no package with that name found, perhaps there is a typo in a package's build-depends or an omission from the
                   stack.yaml packages list?)
needed due to cardano-db-sync-1.4.0 -> cardano-crypto-wrapper-1.3.0

In the dependencies for cardano-db-sync-1.4.0:
    cardano-crypto needed, but the stack configuration has no specified version (no package with that name found, perhaps there is a typo in a package's build-depends or an omission from the
                   stack.yaml packages list?)
needed since cardano-db-sync is a build target.

In the dependencies for cardano-db-sync-extended-1.4.0:
    cardano-crypto needed, but the stack configuration has no specified version (no package with that name found, perhaps there is a typo in a package's build-depends or an omission from the
                   stack.yaml packages list?)
needed since cardano-db-sync-extended is a build target.

In the dependencies for cardano-ledger-0.1.0.0:
    cardano-crypto needed, but the stack configuration has no specified version (no package with that name found, perhaps there is a typo in a package's build-depends or an omission from the
                   stack.yaml packages list?)
needed due to cardano-db-1.4.0 -> cardano-ledger-0.1.0.0

Some different approaches to resolving this:


Plan construction failed.
```