### PR TITLE
epoch: Fix one more corner case in Epoch table update

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Epoch.hs
@@ -93,6 +93,10 @@ epochPluginInsertBlock trce rawBlk _tip =
               updateEpochNum (lastCachedEpoch + 1) trce
           | epochNum == chainTipEpoch && lastCachedEpoch < chainTipEpoch ->
               updateEpochNum (lastCachedEpoch + 1) trce
+          | epochNum > chainTipEpoch ->
+              -- Must just have started a new epoch, so call this which will
+              -- update chainTipEpoch.
+              updateEpochNum epochNum trce
           | otherwise ->
               pure $ Right ()
 


### PR DESCRIPTION
When the Epoch rolled over, the extended node failed to start
updating the row for the new epoch. This is now caught by a special
case where the epoch of the current block is greater than the
cached chain tip epoch.

This looks right, but will not know for certain if this fixes it until the epoch rolls over again in about 5 days.