### PR TITLE
Docker: Clarify node-ipc volume mount and add docker-compose with secrets examples

### DIFF
--- a/config/secrets/.gitignore
+++ b/config/secrets/.gitignore
@@ -1,0 +1,3 @@
+postgres_db
+postgres_password
+postgres_user

--- a/config/secrets/postgres_db_example
+++ b/config/secrets/postgres_db_example
@@ -1,0 +1,1 @@
+cexplorer

--- a/config/secrets/postgres_password_example
+++ b/config/secrets/postgres_password_example
@@ -1,0 +1,1 @@
+doNotUseThis!

--- a/config/secrets/postgres_user_example
+++ b/config/secrets/postgres_user_example
@@ -1,0 +1,1 @@
+postgres

--- a/default.nix
+++ b/default.nix
@@ -36,10 +36,9 @@ let
     };
 
     dockerImage = let
-      stateDir = "/data";
       defaultConfig = rec {
         services.cardano-db-sync = {
-          socketPath = lib.mkDefault (stateDir + "/node.socket");
+          socketPath = lib.mkDefault ("/node-ipc/node.socket");
           postgres.generatePGPASS = false;
         };
       };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+version: "3.5"
+
+services:
+  postgres:
+    image: postgres:11.5-alpine
+    environment:
+      - POSTGRES_LOGGING=true
+      - POSTGRES_DB_FILE=/run/secrets/postgres_db
+      - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
+      - POSTGRES_USER_FILE=/run/secrets/postgres_user
+    secrets:
+      - postgres_password
+      - postgres_user
+      - postgres_db
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    restart: on-failure
+
+  cardano-node:
+    image: inputoutput/cardano-node:master
+    environment:
+      - NETWORK=${NETWORK}
+    volumes:
+      - node-db:/data/db
+      - node-ipc:/ipc
+    restart: on-failure
+
+  cardano-db-sync:
+    image: inputoutput/cardano-db-sync:master
+    environment:
+      - NETWORK=${NETWORK}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+    depends_on:
+      - cardano-node
+      - postgres
+    secrets:
+      - postgres_password
+      - postgres_user
+      - postgres_db
+    volumes:
+      - node-ipc:/node-ipc
+    restart: on-failure
+
+secrets:
+  postgres_db:
+    file: ./config/secrets/postgres_db
+  postgres_password:
+    file: ./config/secrets/postgres_password
+  postgres_user:
+    file: ./config/secrets/postgres_user
+
+volumes:
+  postgres:
+  node-db:
+  node-ipc:


### PR DESCRIPTION
Align with changes presented in https://github.com/input-output-hk/cardano-node/pull/779/files to enable mounting of the IPC socket into client containers without the node db coming along for the ride. Although this is primarily an upstream fix, I've taken the opportunity to align with the recent change in `cardano-node` to use the more verbose _configuration_ term so we don't end up with a variation.

- changes `data` to `node-ipc` for clarity on what is being mounted.
- Use `configuration` over `config` to conform with style in `cardano-node`
- Adds docker-compose as a getting started resource