### PR TITLE
Fix Stack build.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -56,6 +56,7 @@ extra-deps:
   - connection-0.3.1
   - http-api-data-0.4.1.1
   - time-compat-1.9.2.2
+  - quiet-0.2
 
   - git: https://github.com/input-output-hk/cardano-node
     commit: bffd717f466f787b38e497d5d73bb58b76b47166
@@ -99,7 +100,7 @@ extra-deps:
   - git: https://github.com/input-output-hk/cardano-ledger-specs
     commit: b0f4b024962eb834af55151697c8da72b6df4df8
     subdirs:
-      - byron/semantics/executable-spec
+      - semantics/executable-spec
       - byron/ledger/executable-spec
       - byron/chain/executable-spec
       - shelley/chain-and-ledger/dependencies/non-integer


### PR DESCRIPTION
Fixing the Stack build, was failing with:
```
Cloning b0f4b024962eb834af55151697c8da72b6df4df8 from https://github.com/input-output-hk/cardano-ledger-specs
No cabal file found for Repo from https://github.com/input-output-hk/cardano-ledger-specs, commit b0f4b024962eb834af55151697c8da72b6df4df8 in subdir byron/semantics/executable-spec
```
And:
```
Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for cardano-ledger-0.1.0.0:
    quiet needed, but the stack configuration has no specified version  (latest matching version is 0.2)
needed due to cardano-db-1.4.0 -> cardano-ledger-0.1.0.0

Some different approaches to resolving this:

  * Recommended action: try adding the following to your extra-deps in /home/ksaric/projects/haskell/cardano-db-sync/stack.yaml:

- quiet-0.2@sha256:60bb3cb8dd4a225557351b6d622147a4e541f1564847e05a81621365a155ad6c,1413

Plan construction failed.
```