### PR TITLE
[ADP-286] Enable tagging latest container

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: Post Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+    test-job:
+      name: "Tag / Build / Push Container"
+      runs-on: ubuntu-latest
+      steps:
+      - name: Trigger Buildkite Pipeline
+        uses: buildkite/trigger-pipeline-action@v1.2.0
+        env:
+          BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.Buildkite_Token }}
+          PIPELINE: ${{ github.repository }}
+          COMMIT: "HEAD"
+          BRANCH: "master"
+          MESSAGE: ":github: Triggered from a GitHub Action"
+          BUILD_ENV_VARS: "{\"GITHUB_REF\": \"${{ github.ref }}\", \"GITHUB_EVENT_NAME\": \"${{ github.event_name }}\" }"


### PR DESCRIPTION
- https://jira.iohk.io/browse/ADP-286
- Adds a GitHub action that, on release, triggers a BuildKite build
  job, passing through information about the GITHUB_REF and
  GITHUB_EVENT_NAME.
- Slightly modified the docker-build-push.nix. It still:
    - Pushes a docker image with the "$gitRevision" tag always.
    - Pushes a docker image with the "master" tag when the master
      branch is updated.
  But now also:
    - If the GITHUB_EVENT_NAME is "release", pushes a docker image with
      the tag "$version" (retrieved from the GITHUB_REF variable) AND
      pushes a docker image with the tag "latest".
- Updated the documentation in docker-build-push.nix.
- Change the way the creation date is set to the current time, to be
  the same as the way "cardano-wallet" does it.