### PR TITLE
docker image: do not retag master on release

### DIFF
--- a/.buildkite/docker-build-push.nix
+++ b/.buildkite/docker-build-push.nix
@@ -49,10 +49,6 @@ in
     echo "Loading $fullrepo:$gitrev"
     docker load -i ${image}
 
-    # An image is built on each commit
-    echo "Pushing $fullrepo:$gitrev"
-    docker push "$fullrepo:$gitrev"
-
     # If a release event, apply two tags to the image
     # e.g. "1.0.0" AND "latest"
     if [[ "$event" = release ]]; then
@@ -68,10 +64,8 @@ in
       docker tag $fullrepo:$version $fullrepo:latest
       echo "Pushing $fullrepo:latest"
       docker push "$fullrepo:latest"
-    fi
-
     # Every commit to master needs to be tagged with master
-    if [[ "$branch" = master ]]; then
+    elif [[ "$branch" = master ]]; then
       echo "Tagging as master"
       docker tag $fullrepo:$gitrev $fullrepo:$branch
       echo "Pushing $fullrepo:$branch"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,5 +18,6 @@ steps:
     command:
       - "nix-build .buildkite/docker-build-push.nix --argstr dockerHubRepoName inputoutput/$BUILDKITE_PIPELINE_NAME -o docker-build-push"
       - "./docker-build-push"
+    branches: master
     agents:
       system: x86_64-linux

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         env:
           BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.Buildkite_Token }}
           PIPELINE: ${{ github.repository }}
-          COMMIT: "HEAD"
+          COMMIT: ${{ github.sha }}
           BRANCH: "master"
           MESSAGE: ":github: Triggered from a GitHub Action"
           BUILD_ENV_VARS: "{\"GITHUB_REF\": \"${{ github.ref }}\", \"GITHUB_EVENT_NAME\": \"${{ github.event_name }}\" }"


### PR DESCRIPTION
- A release shouldn't trigger the retagging of a master image.