### PR TITLE
Bump version to 2.0.0 and update changelog

### DIFF
--- a/cardano-db-sync-extended/CHANGELOG.md
+++ b/cardano-db-sync-extended/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for cardano-db-sync-extended
 
+## 2.0.0 -- April 2020
+
+* Schema change to removes SQL views previously used by by Cardano GraphQL (#92)
+
 ## 1.5.0 -- April 2020
 
 * Update dependencies to latest versions (#39, #78)

--- a/cardano-db-sync-extended/cardano-db-sync-extended.cabal
+++ b/cardano-db-sync-extended/cardano-db-sync-extended.cabal
@@ -3,7 +3,7 @@ cabal-version:          >= 1.10
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-db-sync-extended
-version:                1.5.0
+version:                2.0.0
 synopsis:               The Extended Cardano DB Sync node
 description:            A Cardano node that follows the Cardano chain and inserts data from the
                         chain into a PostgresQL database. It is "extended" because it maintains an

--- a/cardano-db-sync/CHANGELOG.md
+++ b/cardano-db-sync/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for cardano-db-sync node
 
+## 2.0.0 -- April 2020
+
+* Schema change to removes SQL views previously used by by Cardano GraphQL (#92)
+
 ## 1.5.0 -- April 2020
 
 * Fix a bug related to block rollback (#61)

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -3,7 +3,7 @@ cabal-version:          >= 1.10
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-db-sync
-version:                1.5.0
+version:                2.0.0
 synopsis:               The Cardano DB Sync node
 description:            A Cardano node that follows the Cardano chain and inserts data from the
                         chain into a PostgresQL database.

--- a/cardano-db/CHANGELOG.md
+++ b/cardano-db/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Revision history for cardano-db
 
-## vNext
-* Removes SQL Views required by Cardano GraphQL, as they are now managed by the application directly (#92)
+## 2.0.0 -- April 2020
+
+* Schema change to removes SQL views previously used by by Cardano GraphQL (#92)
 
 ## 1.5.0 -- April 2020
 

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -3,7 +3,7 @@ cabal-version:          >= 1.10
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-db
-version:                1.5.0
+version:                2.0.0
 synopsis:               A base PostgreSQL component for the cardano-db-sync node.
 description:            Code for the Cardano DB Sync node that is shared between the
                         cardano-db-node and other components.


### PR DESCRIPTION
No changes in the code. Schema change to remove SQL views previously
used by the GraphQL db client.