### PR TITLE
schema: Restore table indices

### DIFF
--- a/schema/migration-3-0002-20200521.sql
+++ b/schema/migration-3-0002-20200521.sql
@@ -1,0 +1,52 @@
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_three + 1 INTO next_version FROM schema_version ;
+  IF next_version <= 2 THEN
+    -- -------------------------------------------------------------------------
+    -- Hand crafted indices for performance
+
+    -- Without these indices 'cardano-db-tool validate' will put a heavy load
+    -- on Postgres.
+
+    CREATE INDEX idx_block_slot_no
+    ON block(slot_no);
+
+    CREATE INDEX idx_block_block_no
+    ON block(block_no);
+
+    CREATE INDEX idx_block_epoch_no
+    ON block(epoch_no);
+
+    CREATE INDEX idx_block_previous
+    ON block(previous);
+
+    CREATE INDEX idx_block_hash
+    ON block(hash);
+
+    CREATE INDEX idx_tx_block
+    ON tx(block);
+
+    CREATE INDEX idx_tx_hash
+    ON tx(hash);
+
+    CREATE INDEX idx_tx_in_source_tx
+    ON tx_in(tx_in_id);
+
+    CREATE INDEX idx_tx_in_consuming_tx
+    ON tx_in(tx_out_id);
+
+    CREATE INDEX idx_tx_out_tx
+    ON tx_out(tx_id);
+    -- -------------------------------------------------------------------------
+
+    UPDATE schema_version SET stage_three = 2 ;
+    RAISE NOTICE 'DB has been migrated to stage_three version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
These should always have been stage_three migrations (due to being
manually written) and are needed to improve DB performance. They
were deleted by mistake when the schema was flattened.