### PR TITLE
Revert "validation: Only run BlockTx validation when DB fully synced"

### DIFF
--- a/cardano-db/app/Cardano/Db/App/Validate/BlockTxs.hs
+++ b/cardano-db/app/Cardano/Db/App/Validate/BlockTxs.hs
@@ -24,11 +24,10 @@ import qualified System.Random as Random
 
 validateEpochBlockTxs :: IO ()
 validateEpochBlockTxs = do
-  fullySynced <- runDbNoLogging queryIsFullySynced
   mLatestEpoch <- runDbNoLogging queryLatestCachedEpochNo
   case mLatestEpoch of
     Nothing -> putStrLn "Epoch table is empty"
-    Just latest -> validateLatestBlockTxs fullySynced latest
+    Just latest -> validateLatestBlockTxs latest
 
 -- -----------------------------------------------------------------------------
 
@@ -38,15 +37,10 @@ data ValidateError = ValidateError
   , veTxCountExpected :: !Word64
   }
 
-validateLatestBlockTxs :: Bool -> Word64 -> IO ()
-validateLatestBlockTxs fullySynced latestEpoch = do
-  if not fullySynced
-    then putStrLn "Not fully synced so not running BlockTx validation"
-    else do
-      -- This validation seems to be quite DB intensive, so only run it
-      -- when the DB is fully synced.
-      validateBlockTxs latestEpoch
-      validateBlockTxs =<< Random.randomRIO (0, latestEpoch - 1)
+validateLatestBlockTxs :: Word64 -> IO ()
+validateLatestBlockTxs latestEpoch = do
+  validateBlockTxs latestEpoch
+  validateBlockTxs =<< Random.randomRIO (0, latestEpoch - 1)
 
 validateBlockTxs :: Word64 -> IO ()
 validateBlockTxs epoch = do


### PR DESCRIPTION
If the validation runs grindingly slow, then it is likely that
the generation of table indices is missing.

This reverts commit 1a8dbc9dce75a7d03b27e11465e2f02c8f6e708c.