### PR TITLE
[SRE-113] Update Release Type Trigger to published

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Post Release
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
     test-job:


### PR DESCRIPTION
Release type `published` is a more appropriate trigger than `created`.