### PR TITLE
Use the API from the cardano-client package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -232,6 +232,13 @@ source-repository-package
   location: https://github.com/input-output-hk/ouroboros-network
   tag: 9d9754c9ddcfff82b27c371a545aa4680d86d996
   --sha256: 18ws841jn6hhmm3pqd22lmy20cgnp430dk3s07jzw3d5bpf3i34v
+  subdir: cardano-client
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: 9d9754c9ddcfff82b27c371a545aa4680d86d996
+  --sha256: 18ws841jn6hhmm3pqd22lmy20cgnp430dk3s07jzw3d5bpf3i34v
   subdir: io-sim
 
 source-repository-package

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -50,6 +50,7 @@ library
                       , base16-bytestring
                       , bytestring
                       , cardano-binary
+                      , cardano-client
                       , cardano-config
                       , cardano-crypto
                       , cardano-crypto-wrapper

--- a/stack.yaml
+++ b/stack.yaml
@@ -133,6 +133,7 @@ extra-deps:
       - ouroboros-network-framework
       - ouroboros-network-testing
       - typed-protocols-examples
+      - cardano-client
 
 nix:
   pure: true


### PR DESCRIPTION
Refactor DbSync.hs for the new network API.
* Use Cardano.Client.Subscription(subscribe) from the cardano-client package.
* Remove imports that are no longer needed.