### PR TITLE
[CD-14] Determining order of transaction inputs.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -38,6 +38,9 @@ package cardano-db
 package cardano-db-sync
   tests: True
 
+package ouroboros-consensus-cardano
+  tests: False
+
 -- ---------------------------------------------------------
 
 source-repository-package
@@ -274,13 +277,6 @@ source-repository-package
   location: https://github.com/input-output-hk/ouroboros-network
   tag: ef38818aa434aaafb82bc7ae4d1fee11523c3ad8
   --sha256: 04ldvkqwy48fh974761q2asmcn163awsrbk9xfy4hm67n4hafkjb
-  subdir: ouroboros-network-testing
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: ef38818aa434aaafb82bc7ae4d1fee11523c3ad8
-  --sha256: 04ldvkqwy48fh974761q2asmcn163awsrbk9xfy4hm67n4hafkjb
   subdir: Win32-network
 
 source-repository-package
@@ -289,20 +285,6 @@ source-repository-package
   tag: ef38818aa434aaafb82bc7ae4d1fee11523c3ad8
   --sha256: 04ldvkqwy48fh974761q2asmcn163awsrbk9xfy4hm67n4hafkjb
   subdir: ouroboros-consensus
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: ef38818aa434aaafb82bc7ae4d1fee11523c3ad8
-  --sha256: 04ldvkqwy48fh974761q2asmcn163awsrbk9xfy4hm67n4hafkjb
-  subdir: ouroboros-consensus/ouroboros-consensus-mock
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: ef38818aa434aaafb82bc7ae4d1fee11523c3ad8
-  --sha256: 04ldvkqwy48fh974761q2asmcn163awsrbk9xfy4hm67n4hafkjb
-  subdir: ouroboros-consensus/ouroboros-consensus-test-infra
 
 source-repository-package
   type: git
@@ -345,6 +327,27 @@ source-repository-package
   tag: ef38818aa434aaafb82bc7ae4d1fee11523c3ad8
   --sha256: 04ldvkqwy48fh974761q2asmcn163awsrbk9xfy4hm67n4hafkjb
   subdir: typed-protocols-examples
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: ef38818aa434aaafb82bc7ae4d1fee11523c3ad8
+  --sha256: 04ldvkqwy48fh974761q2asmcn163awsrbk9xfy4hm67n4hafkjb
+  subdir: ouroboros-network-testing
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: ef38818aa434aaafb82bc7ae4d1fee11523c3ad8
+  --sha256: 04ldvkqwy48fh974761q2asmcn163awsrbk9xfy4hm67n4hafkjb
+  subdir: ouroboros-consensus/ouroboros-consensus-mock
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: ef38818aa434aaafb82bc7ae4d1fee11523c3ad8
+  --sha256: 04ldvkqwy48fh974761q2asmcn163awsrbk9xfy4hm67n4hafkjb
+  subdir: ouroboros-consensus/ouroboros-consensus-test-infra
 
 source-repository-package
   type: git

--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Default/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Default/Insert.hs
@@ -166,7 +166,7 @@ insertTx tracer blkId tx blockIndex = do
     -- Insert outputs for a transaction before inputs in case the inputs for this transaction
     -- references the output (not sure this can even happen).
     lift $ zipWithM_ (insertTxOut tracer txId) [0 ..] (toList . Byron.txOutputs $ Byron.taTx tx)
-    mapMVExceptT (insertTxIn tracer txId) (toList . Byron.txInputs $ Byron.taTx tx)
+    void $ zipWithM_ (insertTxIn tracer txId) [0 ..] (toList . Byron.txInputs $ Byron.taTx tx)
   where
     annotateTx :: DbSyncNodeError -> DbSyncNodeError
     annotateTx ee =
@@ -176,7 +176,7 @@ insertTx tracer blkId tx blockIndex = do
 
 insertTxOut
     :: MonadIO m
-    => Trace IO Text -> DB.TxId -> Word32 -> Byron.TxOut
+    => Trace IO Text -> DB.TxId -> Word16 -> Byron.TxOut
     -> ReaderT SqlBackend m ()
 insertTxOut _tracer txId index txout =
   void . DB.insertTxOut $
@@ -190,13 +190,14 @@ insertTxOut _tracer txId index txout =
 
 insertTxIn
     :: MonadIO m
-    => Trace IO Text -> DB.TxId -> Byron.TxIn
+    => Trace IO Text -> DB.TxId -> Word16 -> Byron.TxIn
     -> ExceptT DbSyncNodeError (ReaderT SqlBackend m) ()
-insertTxIn _tracer txInId (Byron.TxInUtxo txHash inIndex) = do
+insertTxIn _tracer txInId txInIndex (Byron.TxInUtxo txHash inIndex) = do
   txOutId <- liftLookupFail "insertTxIn" $ DB.queryTxId (Byron.unTxHash txHash)
   void . lift . DB.insertTxIn $
             DB.TxIn
               { DB.txInTxInId = txInId
+              , DB.txInTxIndex = txInIndex
               , DB.txInTxOutId = txOutId
               , DB.txInTxOutIndex = fromIntegral inIndex
               }
@@ -233,9 +234,3 @@ mapMExceptT action xs =
     [] -> pure []
     (y:ys) -> (:) <$> action y <*> mapMExceptT action ys
 
--- | An 'ExceptT' version of 'mapM_' which will 'left' the first 'Left' it finds.
-mapMVExceptT :: Monad m => (a -> ExceptT e m ()) -> [a] -> ExceptT e m ()
-mapMVExceptT action xs =
-  case xs of
-    [] -> pure ()
-    (y:ys) -> action y >> mapMVExceptT action ys

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -92,6 +92,7 @@ share
 
   TxIn
     txInId              TxId                -- The transaction where this is used as an input.
+    txIndex             Word16              sqltype=txindex -- Index within the Tx
     txOutId             TxId                -- The transaction where this was created as an output.
     txOutIndex          Word16              sqltype=txindex
     UniqueTxin          txOutId txOutIndex

--- a/cardano-db/test/Test/IO/Cardano/Db/Rollback.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Rollback.hs
@@ -105,7 +105,7 @@ createAndInsertBlocks blockCount =
                 -- they are associcated with are deleted.
 
                 txId <- head <$> mapM insertTx (mkTxs blkId 8)
-                void $ insertTxIn (TxIn txId txOutId 0)
+                void $ insertTxIn (mkTxIn txId txOutId)
                 void $ insertTxOut (mkTxOut blkId txId)
             _ -> pure ()
         pure (indx + 1, Just blkId, Just newBlock, newMTxOutId)

--- a/cardano-db/test/Test/IO/Cardano/Db/TotalSupply.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/TotalSupply.hs
@@ -37,7 +37,7 @@ initialSupplyTest =
     -- Spend from the Utxo set.
     bid1 <- insertBlock (mkBlock 1 slid)
     tx1Id <- insertTx (Tx (mkTxHash bid1 1) bid1 0 500000000 100 123)
-    _ <- insertTxIn (TxIn tx1Id (head tx0Ids) 0)
+    _ <- insertTxIn $ TxIn tx1Id 0 (head tx0Ids) 0
     _ <- insertTxOut $ TxOut tx1Id 0 (mkAddressHash bid1 tx1Id) 500000000
     supply1 <- queryTotalSupply
     assertBool ("Total supply should be < " ++ show supply0) (supply1 < supply0)

--- a/cardano-db/test/Test/IO/Cardano/Db/Util.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Util.hs
@@ -11,6 +11,7 @@ module Test.IO.Cardano.Db.Util
   , mkMerkelRoot
   , mkTxHash
   , mkTxs
+  , mkTxIn
   , mkTxOut
   , testSlotLeader
   , unBlockId
@@ -77,6 +78,12 @@ mkTxs blkId count =
 testSlotLeader :: SlotLeader
 testSlotLeader =
   SlotLeader (BS.pack . take 28 $ "test slot leader" ++ replicate 28 ' ') "Dummy test slot leader"
+
+-- TODO(KS): Maybe it would be wise to differentiate @TxId@ from input and output with types?
+-- This is the one situation where you don't want to be one off.
+mkTxIn :: TxId -> TxId -> TxIn
+mkTxIn txInId txOutId =
+  TxIn txInId 0 txOutId 0
 
 mkTxOut :: BlockId -> TxId -> TxOut
 mkTxOut blkId txId =

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "29e42da7fb7d8836a0354dc194cdd2a6a955979c",
-        "sha256": "0p2vb6da3gr74sjwm2dkzx985l5394g2axz2dyr5189i5fqifam1",
+        "rev": "e5a052243b25003adabc7e046caff72a40a2c5d7",
+        "sha256": "0f6dcgi7ajh9z9cf0asg0hb58zy7ychgmz9gn4kvbma19l8kqjwy",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/29e42da7fb7d8836a0354dc194cdd2a6a955979c.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/e5a052243b25003adabc7e046caff72a40a2c5d7.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/schema/migration-2-0002-20200528.sql
+++ b/schema/migration-2-0002-20200528.sql
@@ -1,0 +1,19 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 2 THEN
+    EXECUTE 'ALTER TABLE "tx_in" ADD COLUMN "tx_index" txindex NOT NULL' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = 2 ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;

--- a/stack.yaml
+++ b/stack.yaml
@@ -128,10 +128,8 @@ extra-deps:
       - ouroboros-consensus-shelley
       - ouroboros-consensus-cardano
       - ouroboros-consensus/ouroboros-consensus-mock
-      - ouroboros-consensus/ouroboros-consensus-test-infra
       - typed-protocols
       - ouroboros-network-framework
-      - ouroboros-network-testing
       - typed-protocols-examples
       - cardano-client
 


### PR DESCRIPTION
https://jira.iohk.io/browse/CD-14
https://github.com/input-output-hk/cardano-db-sync/issues/106

Determining order of transaction inputs.
Maybe we need to add types to the transaction index so we can differentiate `TxIn` from `TxOut`.