### PR TITLE
Generalise block to (theoretically) support Byron and Shelley

### DIFF
--- a/cardano-db-sync-extended/cardano-db-sync-extended.cabal
+++ b/cardano-db-sync-extended/cardano-db-sync-extended.cabal
@@ -34,28 +34,9 @@ library
   exposed-modules:      Cardano.DbSync.Plugin.Extended
 
   build-depends:        base                            >= 4.12         && < 4.13
-                      , aeson
-                      , base16-bytestring
-                      , bytestring
-                      , cardano-binary
-                      , cardano-crypto
-                      , cardano-crypto-wrapper
                       , cardano-db
                       , cardano-db-sync
-                      , containers
-                      , contra-tracer
-                      , cryptonite
-                      , extra
-                      , memory
-                      , monad-logger
-                      , network
-                      , ouroboros-consensus
-                      , ouroboros-network
-                      , persistent
-                      , prometheus
-                      , serialise
                       , text
-                      , time
                       , transformers
                       , transformers-except
 
@@ -82,4 +63,3 @@ executable cardano-db-sync-extended
                       , cardano-prelude
                       , optparse-applicative
                       , ouroboros-network
-                      , text

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -78,6 +78,7 @@ library
                       , ouroboros-consensus
                       , ouroboros-consensus-byron
                       , ouroboros-consensus-cardano
+                      , ouroboros-consensus-shelley
                       , ouroboros-network
                       , ouroboros-network-framework
                       , persistent

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -35,15 +35,18 @@ library
 
   other-modules:        Cardano.DbSync.Config
                         Cardano.DbSync.Database
+                        Cardano.DbSync.Era
+                        Cardano.DbSync.Era.Byron.Genesis
                         Cardano.DbSync.Error
-                        Cardano.DbSync.Genesis
                         Cardano.DbSync.Metrics
+                        Cardano.DbSync.Orphans
                         Cardano.DbSync.Plugin
                         Cardano.DbSync.Plugin.Default
                         Cardano.DbSync.Plugin.Default.Insert
                         Cardano.DbSync.Plugin.Default.Rollback
-                        Cardano.DbSync.Util
                         Cardano.DbSync.Tracing.ToObjectOrphans
+                        Cardano.DbSync.Types
+                        Cardano.DbSync.Util
 
   build-depends:        base                            >= 4.12         && < 4.13
                       , aeson
@@ -109,22 +112,8 @@ executable cardano-db-sync
 
   build-depends:        base                            >= 4.12         && < 4.13
                       , bytestring
-                      , cardano-crypto-wrapper
                       , cardano-db
                       , cardano-db-sync
-                      , cardano-ledger
                       , cardano-prelude
-                      , cardano-binary
-                      , cborg
-                      , formatting
-                      , cardano-shell
-                      , ouroboros-consensus
-                      , io-sim-classes
-                      , iohk-monitoring
-                      , network
                       , optparse-applicative
                       , ouroboros-network
-                      , ouroboros-network-framework
-                      , serialise
-                      , text
-                      , typed-protocols

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -29,19 +29,30 @@ import           Control.Tracer (Tracer)
 
 import qualified Cardano.BM.Setup as Logging
 import           Cardano.BM.Data.Tracer (ToLogObject (..))
-import           Cardano.BM.Trace (Trace, appendName, logError, logInfo)
+import           Cardano.BM.Trace (Trace, appendName, logInfo)
 import qualified Cardano.BM.Trace as Logging
 
 import qualified Cardano.Chain.Genesis as Ledger
-import qualified Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Chain.Update as Update
-
-import           Cardano.Crypto (decodeAbstractHash)
-import           Cardano.Crypto.Hashing (abstractHashFromDigest)
+import           Cardano.Client.Subscription (subscribe)
 import qualified Cardano.Crypto as Crypto
 
+import           Cardano.Db (LogFileDir (..))
+import qualified Cardano.Db as DB
+import           Cardano.DbSync.Config
+import           Cardano.DbSync.Database
+import           Cardano.DbSync.Era
+import           Cardano.DbSync.Error
+import qualified Cardano.DbSync.Era.Byron.Genesis as Byron
+import           Cardano.DbSync.Metrics
+import           Cardano.DbSync.Orphans ()
+import           Cardano.DbSync.Plugin (DbSyncNodePlugin (..))
+import           Cardano.DbSync.Plugin.Default (defDbSyncNodePlugin)
+import           Cardano.DbSync.Plugin.Default.Rollback (unsafeRollback)
+import           Cardano.DbSync.Tracing.ToObjectOrphans ()
+import           Cardano.DbSync.Types
+import           Cardano.DbSync.Util
+
 import           Cardano.Prelude hiding (atomically, option, (%), Nat)
-import           Cardano.Shell.Lib (GeneralException (ConfigurationError))
 
 import           Cardano.Slotting.Slot (WithOrigin (..))
 
@@ -50,8 +61,7 @@ import           Control.Monad.Class.MonadSTM.Strict (MonadSTM, StrictTMVar,
                     atomically, newEmptyTMVarM, readTMVar)
 import           Control.Monad.Class.MonadTimer (MonadTimer)
 import           Control.Monad.IO.Class (liftIO)
-
-import           Crypto.Hash (digestFromByteString)
+import           Control.Monad.Trans.Except.Exit (orDie)
 
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Functor.Contravariant (contramap)
@@ -59,51 +69,30 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Void (Void)
 
-import           Cardano.Db (LogFileDir (..), MigrationDir)
-import qualified Cardano.Db as DB
-import           Cardano.DbSync.Config
-import           Cardano.DbSync.Database
-import           Cardano.DbSync.Error
-import           Cardano.DbSync.Genesis
-import           Cardano.DbSync.Metrics
-import           Cardano.DbSync.Plugin (DbSyncNodePlugin (..))
-import           Cardano.DbSync.Plugin.Default (defDbSyncNodePlugin)
-import           Cardano.DbSync.Plugin.Default.Rollback (unsafeRollback)
-import           Cardano.DbSync.Util
-import           Cardano.DbSync.Tracing.ToObjectOrphans ()
-
 import           Network.Socket (SockAddr (..))
 import           Network.Mux (MuxTrace, WithMuxBearer)
 
 import           Ouroboros.Network.Driver.Simple (runPipelinedPeer)
 import           Network.TypedProtocol.Pipelined (Nat(Zero, Succ))
 
-import           Ouroboros.Consensus.Byron.Ledger (ByronHash (..), GenTx)
-import           Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion (
-                    ByronNodeToClientVersion(..) )
-import           Ouroboros.Consensus.Cardano (Protocol (..), protocolInfo)
+import           Ouroboros.Consensus.Byron.Ledger (GenTx)
 import           Ouroboros.Consensus.Config (TopLevelConfig)
+import           Ouroboros.Consensus.HardFork.Combinator.Unary (FromRawHash (..))
 import           Ouroboros.Consensus.Network.NodeToClient (ClientCodecs,
                     cChainSyncCodec, cStateQueryCodec, cTxSubmissionCodec)
-
 import           Ouroboros.Consensus.Node.ErrorPolicy (consensusErrorPolicy)
-import           Ouroboros.Consensus.Node.NetworkProtocolVersion (
-                    nodeToClientProtocolVersion, supportedNodeToClientVersions)
-import           Ouroboros.Consensus.Node.ProtocolInfo (pInfoConfig)
-import           Ouroboros.Consensus.Node.Run (RunNode, nodeDecodeHeaderHash)
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion (NodeToClientVersion)
+import           Ouroboros.Consensus.Node.Run (RunNode)
+import qualified Ouroboros.Network.NodeToClient.Version as Network
 
-import           Ouroboros.Network.Block (BlockNo (..), HeaderHash (..), Point (..), SlotNo (..),
+import           Ouroboros.Network.Block (BlockNo (..), HeaderHash, Point (..), SlotNo (..),
                     Tip, genesisPoint, getTipBlockNo, blockNo)
-import           Ouroboros.Network.Mux (AppType (..), MuxPeer (..), OuroborosApplication,
-                    RunMiniProtocol (..))
+import           Ouroboros.Network.Mux (AppType (..), MuxPeer (..),  RunMiniProtocol (..))
 import           Ouroboros.Network.NodeToClient (IOManager, ClientSubscriptionParams (..),
                     ConnectionId, ErrorPolicyTrace (..), Handshake, LocalAddress,
                     NetworkSubscriptionTracers (..), NodeToClientProtocols (..),
-                    NodeToClientVersion (..) , NodeToClientVersionData (..),
-                    TraceSendRecv, WithAddr (..), ncSubscriptionWorker,
-                    networkErrorPolicies, newNetworkMutableState, withIOManager, localSnocket,
-                    localStateQueryPeerNull, versionedNodeToClientProtocols)
-import           Ouroboros.Consensus.HardFork.Combinator.Unary (FromRawHash (..))
+                    TraceSendRecv, WithAddr (..),
+                    networkErrorPolicies, withIOManager, localSnocket, localStateQueryPeerNull)
 
 import qualified Ouroboros.Network.Point as Point
 import           Ouroboros.Network.Point (withOrigin)
@@ -121,35 +110,12 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult
 import qualified Ouroboros.Network.Snocket as Snocket
 import           Ouroboros.Network.Subscription (SubscriptionTrace)
 
-import           Cardano.Client.Subscription (subscribe)
-
 import           Prelude (String)
 import qualified Prelude
 
 import qualified System.Metrics.Prometheus.Metric.Gauge as Gauge
 
 data Peer = Peer SockAddr SockAddr deriving Show
-
--- | The product type of all command line arguments
-data DbSyncNodeParams = DbSyncNodeParams
-  { enpConfigFile :: !ConfigFile
-  , enpGenesisFile :: !GenesisFile
-  , enpSocketPath :: !SocketPath
-  , enpMigrationDir :: !MigrationDir
-  , enpMaybeRollback :: !(Maybe SlotNo)
-  }
-
-newtype ConfigFile = ConfigFile
-  { unConfigFile :: FilePath
-  }
-
-newtype GenesisFile = GenesisFile
-  { unGenesisFile :: FilePath
-  }
-
-newtype SocketPath = SocketPath
-  { unSocketPath :: FilePath
-  }
 
 
 runDbSyncNode :: DbSyncNodePlugin -> DbSyncNodeParams -> IO ()
@@ -159,64 +125,41 @@ runDbSyncNode plugin enp =
 
     enc <- readDbSyncNodeConfig (unConfigFile $ enpConfigFile enp)
 
-    trce <- mkTracer enc
+    trce <- if not (encEnableLogging enc)
+              then pure Logging.nullTracer
+              else liftIO $ Logging.setupTrace (Right $ encLoggingConfig enc) "db-sync-node"
 
     -- For testing and debugging.
     case enpMaybeRollback enp of
       Just slotNo -> void $ unsafeRollback trce slotNo
       Nothing -> pure ()
 
-    gc <- readGenesisConfig enp enc
-    logProtocolMagic trce $ Ledger.configProtocolMagic gc
+    orDie renderDbSyncNodeError $ do
+      gc <- readByronGenesisConfig enp enc
+      logProtocolMagic trce $ Ledger.configProtocolMagic gc
 
-    -- If the DB is empty it will be inserted, otherwise it will be validated (to make
-    -- sure we are on the right chain).
-    res <- insertValidateGenesisDistribution trce (unNetworkName $ encNetworkName enc) gc
-    case res of
-      Left err -> logError trce $ renderDbSyncNodeError err
-      Right () -> pure ()
+      -- If the DB is empty it will be inserted, otherwise it will be validated (to make
+      -- sure we are on the right chain).
+      Byron.insertValidateGenesisDistribution trce (unNetworkName $ encNetworkName enc) gc
 
-    runDbStartup trce plugin
-    void $ runDbSyncNodeNodeClient iomgr trce plugin (mkConsensusConfig gc) (enpSocketPath enp)
+      liftIO $ runDbStartup trce plugin
+      liftIO $ runDbSyncNodeNodeClient iomgr trce plugin (mkByronConsensusConfig gc) (enpSocketPath enp)
 
-
-mkTracer :: DbSyncNodeConfig -> IO (Trace IO Text)
-mkTracer enc =
-  if not (encEnableLogging enc)
-    then pure Logging.nullTracer
-    else liftIO $ Logging.setupTrace (Right $ encLoggingConfig enc) "db-sync-node"
-
-mkConsensusConfig :: Genesis.Config -> TopLevelConfig blk
-mkConsensusConfig gc =
-  pInfoConfig . protocolInfo $ ProtocolRealPBFT gc Nothing (Update.ProtocolVersion 0 2 0)
-      (Update.SoftwareVersion (Update.ApplicationName "cardano-sl") 1) Nothing
-
-readGenesisConfig :: DbSyncNodeParams -> DbSyncNodeConfig -> IO Genesis.Config
-readGenesisConfig enp enc = do
-    genHash <- either (throwIO . ConfigurationError) pure $
-                decodeAbstractHash (unGenesisHash $ encGenesisHash enc)
-    convert =<< runExceptT (Genesis.mkConfigFromFile (encRequiresNetworkMagic enc)
-                            (unGenesisFile $ enpGenesisFile enp) genHash)
-  where
-    convert :: Either Genesis.ConfigurationError Genesis.Config -> IO Genesis.Config
-    convert =
-      \case
-        Left err -> panic $ show err
-        Right x -> pure x
+-- -------------------------------------------------------------------------------------------------
 
 runDbSyncNodeNodeClient
-    :: forall blk. RunNode blk
+    :: forall blk. (FromRawHash blk, MkDbAction blk, RunNode blk, Show blk)
     => IOManager -> Trace IO Text -> DbSyncNodePlugin -> TopLevelConfig blk -> SocketPath
-    -> IO Void
+    -> IO ()
 runDbSyncNodeNodeClient iomgr trce plugin topLevelConfig (SocketPath socketPath) = do
   logInfo trce $ "localInitiatorNetworkApplication: connecting to node via " <> textShow socketPath
   txv <- newEmptyTMVarM @_ @(GenTx blk)
-  subscribe
+  void $ subscribe
     (localSnocket iomgr socketPath)
     topLevelConfig
     networkSubscriptionTracers
     clientSubscriptionParams
-    (const $ dbSyncProtocols trce plugin txv)
+    (dbSyncProtocols trce plugin topLevelConfig txv)
   where
     clientSubscriptionParams = ClientSubscriptionParams {
         cspAddress = Snocket.localAddressFromPath socketPath,
@@ -242,18 +185,20 @@ runDbSyncNodeNodeClient iomgr trce plugin topLevelConfig (SocketPath socketPath)
 
     handshakeTracer :: Tracer IO (WithMuxBearer
                           (ConnectionId LocalAddress)
-                          (TraceSendRecv (Handshake NodeToClientVersion CBOR.Term)))
+                          (TraceSendRecv (Handshake Network.NodeToClientVersion CBOR.Term)))
     handshakeTracer = toLogObject $ appendName "Handshake" trce
 
 dbSyncProtocols
-  :: NodeToClientVersion
-  -> Trace IO Text
+  :: forall blk. (FromRawHash blk, MkDbAction blk, RunNode blk, Show blk)
+  => Trace IO Text
   -> DbSyncNodePlugin
   -> TopLevelConfig blk
   -> StrictTMVar IO (GenTx blk)
+  -> NodeToClientVersion blk
+  -> ClientCodecs blk IO
   -> ConnectionId LocalAddress
   -> NodeToClientProtocols 'InitiatorApp BSL.ByteString IO () Void
-dbSyncProtocols version trce plugin txv  codecs _connectionId =
+dbSyncProtocols trce plugin _topLevelConfig txv _version codecs _connectionId =
     NodeToClientProtocols {
           localChainSyncProtocol = localChainSyncProtocol
         , localTxSubmissionProtocol = localTxSubmissionProtocol
@@ -262,8 +207,6 @@ dbSyncProtocols version trce plugin txv  codecs _connectionId =
   where
     localChainSyncTracer :: Tracer IO (TraceSendRecv (ChainSync blk (Tip blk)))
     localChainSyncTracer = toLogObject $ appendName "ChainSync" trce
-
-    codecs = clientCodecs (getCodecConfig $ configBlock topLevelConfig) version
 
     localChainSyncProtocol :: RunMiniProtocol 'InitiatorApp BSL.ByteString IO () Void
     localChainSyncProtocol = InitiatorProtocolOnly $ MuxPeerRaw $ \channel ->
@@ -318,20 +261,20 @@ logDbState trce = do
         (Nothing, Nothing) -> "empty (genesis)"
 
 
-getLatestPoints :: RunNode blk => IO [Point blk]
+getLatestPoints :: forall blk. FromRawHash blk => IO [Point blk]
 getLatestPoints =
     -- Blocks (and the transactions they contain) are inserted within an SQL transaction.
     -- That means that all the blocks (including their transactions) returned by the query
     -- have been completely inserted.
     mapMaybe convert <$> DB.runDbNoLogging (DB.queryCheckPoints 200)
   where
-    convert :: RunNode blk => (Word64, ByteString) -> Maybe (Point blk)
+    convert :: (Word64, ByteString) -> Maybe (Point blk)
     convert (slot, hashBlob) =
       fmap (Point . Point.block (SlotNo slot)) (convertHashBlob hashBlob)
 
     -- in Maybe because the bytestring may not be the right size.
-    convertHashBlob :: RunNode blk => ByteString -> Maybe (HeaderHash blk)
-    convertHashBlob = fmap (fromRawHash . abstractHashFromDigest) . digestFromByteString
+    convertHashBlob :: ByteString -> Maybe (HeaderHash blk)
+    convertHashBlob = Just . fromRawHash (Proxy @blk)
 
 getCurrentTipBlockNo :: IO (WithOrigin BlockNo)
 getCurrentTipBlockNo = do
@@ -392,8 +335,7 @@ chainSyncClient trce metrics latestPoints currentTip actionQueue =
   where
     policy = pipelineDecisionLowHighMark 1000 10000
 
-    go :: forall blk m n. (MonadTimer m, MonadIO m, RunNode blk, MkDbAction blk)
-        => MkPipelineDecision -> Nat n -> WithOrigin BlockNo -> WithOrigin BlockNo
+    go :: MkPipelineDecision -> Nat n -> WithOrigin BlockNo -> WithOrigin BlockNo
         -> ClientPipelinedStIdle n blk (Tip blk) m ()
     go mkPipelineDecision n clientTip serverTip =
       case (n, runPipelineDecision mkPipelineDecision n clientTip serverTip) of
@@ -413,8 +355,7 @@ chainSyncClient trce metrics latestPoints currentTip actionQueue =
             Nothing
             (mkClientStNext $ \clientBlockNo newServerTip -> go mkPipelineDecision' n' clientBlockNo (getTipBlockNo newServerTip))
 
-    mkClientStNext :: MkDbAction blk
-                    => (WithOrigin BlockNo -> Tip blk -> ClientPipelinedStIdle n blk (Tip blk) m a)
+    mkClientStNext :: (WithOrigin BlockNo -> Tip blk -> ClientPipelinedStIdle n blk (Tip blk) m a)
                     -> ClientStNext n blk (Tip blk) m a
     mkClientStNext finish =
       ClientStNext
@@ -438,7 +379,7 @@ chainSyncClient trce metrics latestPoints currentTip actionQueue =
                 pure $ finish newTip tip
         }
 
-logProtocolMagic :: Trace IO Text -> Crypto.ProtocolMagic -> IO ()
+logProtocolMagic :: Trace IO Text -> Crypto.ProtocolMagic -> ExceptT DbSyncNodeError IO ()
 logProtocolMagic tracer pm =
   liftIO . logInfo tracer $ mconcat
     [ "NetworkMagic: ", textShow (Crypto.getRequiresNetworkMagic pm), " "

--- a/cardano-db-sync/src/Cardano/DbSync/Database.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Database.hs
@@ -142,7 +142,7 @@ checkDbState trce xs =
     validateBlock :: ByronBlock -> ExceptT DbSyncNodeError IO NextState
     validateBlock bblk = do
       case byronBlockRaw bblk of
-        Ledger.ABOBBoundary _ -> left $ ENEError "checkDbState got a boundary block"
+        Ledger.ABOBBoundary _ -> left $ NEError "checkDbState got a boundary block"
         Ledger.ABOBBlock chBlk -> do
           mDbBlk <- liftIO $ DB.runDbAction (Just trce) $ DB.queryBlockNo (blockNumber chBlk)
           case mDbBlk of
@@ -151,7 +151,7 @@ checkDbState trce xs =
               when (DB.blockHash dbBlk /= blockHash chBlk) $ do
                 liftIO $ logInfo trce (textShow chBlk)
                 -- liftIO $ logInfo trce (textShow dbBlk)
-                left $ ENEBlockMismatch (blockNumber chBlk) (DB.blockHash dbBlk) (blockHash chBlk)
+                left $ NEBlockMismatch (blockNumber chBlk) (DB.blockHash dbBlk) (blockHash chBlk)
 
               liftIO . logInfo trce $
                 mconcat [ "checkDbState: Block no ", textShow (blockNumber chBlk), " present" ]

--- a/cardano-db-sync/src/Cardano/DbSync/Era.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+module Cardano.DbSync.Era
+  ( GenesisEra (..)
+  , MkConsensusConfig (..)
+  , mkByronConsensusConfig
+  , readByronGenesisConfig
+  ) where
+
+import qualified Cardano.Chain.Genesis as Byron
+import qualified Cardano.Chain.Update as Byron
+import           Cardano.Crypto (decodeAbstractHash)
+
+import           Cardano.DbSync.Config
+import           Cardano.DbSync.Error
+import           Cardano.DbSync.Types
+
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
+
+import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
+import           Ouroboros.Consensus.Cardano (Protocol (..), protocolInfo)
+import           Ouroboros.Consensus.Config (TopLevelConfig)
+import           Ouroboros.Consensus.Node.ProtocolInfo (pInfoConfig)
+
+
+data GenesisEra
+  = ByronGenesis !Byron.Config
+  | ShelleyGenesis
+
+
+
+readByronGenesisConfig :: DbSyncNodeParams -> DbSyncNodeConfig -> ExceptT DbSyncNodeError IO Byron.Config
+readByronGenesisConfig enp enc = do
+    genHash <- firstExceptT NEError
+                  . hoistEither $ decodeAbstractHash (unGenesisHash $ encGenesisHash enc)
+    firstExceptT BEByronConfig
+                  $ Byron.mkConfigFromFile (encRequiresNetworkMagic enc)
+                      (unGenesisFile $ enpGenesisFile enp) genHash
+
+
+mkByronConsensusConfig :: Byron.Config -> TopLevelConfig ByronBlock
+mkByronConsensusConfig bgc =
+  pInfoConfig . protocolInfo $ ProtocolRealPBFT bgc Nothing (Byron.ProtocolVersion 0 2 0)
+      (Byron.SoftwareVersion (Byron.ApplicationName "cardano-sl") 1) Nothing
+
+
+class MkConsensusConfig cfg blk where
+  mkConsensusConfig :: cfg -> TopLevelConfig blk
+
+instance MkConsensusConfig Byron.Config ByronBlock where
+  mkConsensusConfig = mkByronConsensusConfig

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Cardano.DbSync.Genesis
+module Cardano.DbSync.Era.Byron.Genesis
   ( insertValidateGenesisDistribution
   ) where
 
@@ -24,7 +24,7 @@ import qualified Cardano.Chain.UTxO as Ledger
 
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (MonadIO)
-import           Control.Monad.Trans.Except.Extra (runExceptT)
+import           Control.Monad.Trans.Except.Extra (newExceptT, runExceptT)
 import           Control.Monad.Trans.Reader (ReaderT)
 
 import qualified Data.ByteString.Char8 as BS
@@ -45,13 +45,13 @@ import           Cardano.DbSync.Util
 -- If these transactions are already in the DB, they are validated.
 insertValidateGenesisDistribution
     :: Trace IO Text -> Text -> Ledger.Config
-    -> IO (Either DbSyncNodeError ())
+    -> ExceptT DbSyncNodeError IO ()
 insertValidateGenesisDistribution tracer networkName cfg = do
     -- Setting this to True will log all 'Persistent' operations which is great
     -- for debugging, but otherwise *way* too chatty.
     if False
-      then DB.runDbIohkLogging tracer insertAction
-      else DB.runDbNoLogging insertAction
+      then newExceptT $ DB.runDbIohkLogging tracer insertAction
+      else newExceptT $ DB.runDbNoLogging insertAction
   where
     insertAction :: MonadIO m => ReaderT SqlBackend m (Either DbSyncNodeError ())
     insertAction = do

--- a/cardano-db-sync/src/Cardano/DbSync/Orphans.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Orphans.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.DbSync.Orphans
+  (
+  ) where
+
+import           Cardano.Crypto (abstractHashFromDigest)
+
+import           Crypto.Hash (digestFromByteString)
+
+import           Data.Maybe (fromMaybe)
+
+import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock, ByronHash (..))
+import           Ouroboros.Consensus.HardFork.Combinator.Unary (FromRawHash (..))
+
+
+instance FromRawHash ByronBlock where
+  fromRawHash _ bs =
+    ByronHash
+      . abstractHashFromDigest
+      . fromMaybe (error $ "Cardano.DbSync.Era.FromRawHash ByronHash: " <> show bs)
+      $ digestFromByteString bs

--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Default/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Default/Insert.hs
@@ -170,7 +170,7 @@ insertTx tracer blkId (tx, blockIndex) = do
     annotateTx :: DbSyncNodeError -> DbSyncNodeError
     annotateTx ee =
       case ee of
-        ENEInvariant loc ei -> ENEInvariant loc (annotateInvariantTx (Ledger.taTx tx) ei)
+        NEInvariant loc ei -> NEInvariant loc (annotateInvariantTx (Ledger.taTx tx) ei)
         _other -> ee
 
 insertTxOut
@@ -205,7 +205,7 @@ insertTxIn _tracer txInId (Ledger.TxInUtxo txHash inIndex) = do
 calculateTxFee :: MonadIO m => Ledger.Tx -> ReaderT SqlBackend m (Either DbSyncNodeError ValueFee)
 calculateTxFee tx =
     runExceptT $ do
-      outval <- firstExceptT (\e -> ENEError $ "calculateTxFee: " <> textShow e) $ hoistEither output
+      outval <- firstExceptT (\e -> NEError $ "calculateTxFee: " <> textShow e) $ hoistEither output
       when (null inputs) $
         dbSyncNodeError "calculateTxFee: List of transaction inputs is zero."
       inval <- sum <$> mapMExceptT (liftLookupFail "calculateTxFee" . DB.queryTxOutValue) inputs

--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Epoch.hs
@@ -57,7 +57,7 @@ epochPluginOnStartup trce = do
     eMeta <- DB.queryMeta
     case eMeta of
       Left err ->
-        liftIO . logError trce $ "epochPluginInsertBlock: " <> renderDbSyncNodeError (ENELookup "epochPluginInsertBlock" err)
+        liftIO . logError trce $ "epochPluginInsertBlock: " <> renderDbSyncNodeError (NELookup "epochPluginInsertBlock" err)
       Right meta ->
         liftIO $ atomicWriteIORef slotsPerEpochVar (10 * DB.metaProtocolConst meta)
     mlbe <- queryLatestEpochNo
@@ -148,7 +148,7 @@ updateEpochNum epochNum trce = do
     updateEpoch epochId = do
       eEpoch <- DB.queryCalcEpochEntry epochNum
       case eEpoch of
-        Left err -> pure $ Left (ENELookup "updateEpochNum.updateEpoch" err)
+        Left err -> pure $ Left (NELookup "updateEpochNum.updateEpoch" err)
         Right epoch -> Right <$> replace epochId epoch
 
     insertEpoch :: MonadIO m => ReaderT SqlBackend m (Either DbSyncNodeError ())
@@ -156,7 +156,7 @@ updateEpochNum epochNum trce = do
       eEpoch <- DB.queryCalcEpochEntry epochNum
       liftIO . logInfo trce $ "epochPluginInsertBlock: Inserting row in epoch table for epoch " <> textShow epochNum
       case eEpoch of
-        Left err -> pure $ Left (ENELookup "updateEpochNum.insertEpoch" err)
+        Left err -> pure $ Left (NELookup "updateEpochNum.insertEpoch" err)
         Right epoch -> do
           void $ DB.insertEpoch epoch
           pure $ Right ()

--- a/cardano-db-sync/src/Cardano/DbSync/Tracing/ToObjectOrphans.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Tracing/ToObjectOrphans.hs
@@ -10,21 +10,29 @@ import           Data.Text (Text)
 import           Data.Aeson ((.=))
 
 import           Cardano.BM.Data.Tracer
+import           Cardano.TracingOrphanInstances.Network ()
 
-import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
-import           Ouroboros.Network.Block (Tip)
+import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
+
+import           Ouroboros.Network.Block (Tip, StandardHash)
 import           Ouroboros.Network.Codec (AnyMessage)
 import           Ouroboros.Network.NodeToClient (TraceSendRecv)
 import           Ouroboros.Network.Protocol.ChainSync.Type (ChainSync)
 
-import           Cardano.TracingOrphanInstances.Network ()
 
-instance HasTextFormatter (TraceSendRecv (ChainSync ByronBlock (Tip ByronBlock)))
-instance Transformable Text IO (TraceSendRecv (ChainSync ByronBlock (Tip ByronBlock))) where
-  trTransformer = trStructuredText
+instance HasTextFormatter (TraceSendRecv (ChainSync tip (Tip blk)))
 
-instance ToObject (AnyMessage (ChainSync ByronBlock (Tip ByronBlock))) where
+instance (StandardHash blk, Show blk) => ToObject (AnyMessage (ChainSync blk (Tip blk))) where
   toObject _verb msg =
     mkObject [ "kind" .= ("TraceSendRecv" :: String)
              , "event" .= show msg
              ]
+
+instance ToObject ByronBlock where
+  toObject _verb msg =
+    mkObject [ "kind" .= ("ByronBlock" :: String)
+             , "event" .= show msg
+             ]
+
+instance (StandardHash blk, Show blk) => Transformable Text IO (TraceSendRecv (ChainSync blk (Tip blk))) where
+  trTransformer = trStructuredText

--- a/cardano-db-sync/src/Cardano/DbSync/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Types.hs
@@ -1,0 +1,31 @@
+module Cardano.DbSync.Types
+  ( ConfigFile (..)
+  , DbSyncNodeParams (..)
+  , GenesisFile (..)
+  , SocketPath (..)
+  ) where
+
+import Cardano.Db (MigrationDir (..))
+
+import Ouroboros.Network.Block (SlotNo (..))
+
+-- | The product type of all command line arguments
+data DbSyncNodeParams = DbSyncNodeParams
+  { enpConfigFile :: !ConfigFile
+  , enpGenesisFile :: !GenesisFile
+  , enpSocketPath :: !SocketPath
+  , enpMigrationDir :: !MigrationDir
+  , enpMaybeRollback :: !(Maybe SlotNo)
+  }
+
+newtype ConfigFile = ConfigFile
+  { unConfigFile :: FilePath
+  }
+
+newtype GenesisFile = GenesisFile
+  { unGenesisFile :: FilePath
+  }
+
+newtype SocketPath = SocketPath
+  { unSocketPath :: FilePath
+  }


### PR DESCRIPTION
This still only supports Byron, but Byron is specified at the very top level using 'mkByronConsensusConfig'.

Tested locally on my mainnet and testnet nodes.