### PR TITLE
db: Allow calculation of row for Epoch with zero blocks in it

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Default/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Default/Byron/Insert.hs
@@ -84,7 +84,7 @@ insertABOBBoundary tracer blk = do
               , DB.blockMerkelRoot = Nothing -- No merkelRoot for a boundary block
               , DB.blockSlotLeader = slid
               , DB.blockSize = fromIntegral $ Byron.boundaryBlockLength blk
-              , DB.blockTime = DB.epochUtcTime meta (maybe 0 (+1) mle)
+              , DB.blockTime = DB.epochUtcStartTime meta (maybe 0 (+1) mle)
               , DB.blockTxCount = 0
               }
 


### PR DESCRIPTION
This happened on the Shelley F&F testnet.