### PR TITLE
Rationalize imports/usage of SlotNo

### DIFF
--- a/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
+++ b/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
@@ -7,10 +7,10 @@ import           Cardano.DbSync (ConfigFile (..), DbSyncNodeParams (..), Genesis
                     SocketPath (..), runDbSyncNode)
 import           Cardano.DbSync.Plugin.Extended (extendedDbSyncNodePlugin)
 
+import           Cardano.Slotting.Slot (SlotNo (..))
+
 import           Options.Applicative (Parser, ParserInfo)
 import qualified Options.Applicative as Opt
-
-import           Ouroboros.Network.Block (SlotNo (..))
 
 
 main :: IO ()

--- a/cardano-db-sync-extended/cardano-db-sync-extended.cabal
+++ b/cardano-db-sync-extended/cardano-db-sync-extended.cabal
@@ -61,5 +61,6 @@ executable cardano-db-sync-extended
                       , cardano-db-sync
                       , cardano-db-sync-extended
                       , cardano-prelude
+                      , cardano-slotting
                       , optparse-applicative
                       , ouroboros-network

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -6,10 +6,10 @@ import           Cardano.Db (MigrationDir (..))
 import           Cardano.DbSync (ConfigFile (..), DbSyncNodeParams (..), GenesisFile (..),
                     SocketPath (..), defDbSyncNodePlugin, runDbSyncNode)
 
+import           Cardano.Slotting.Slot (SlotNo (..))
+
 import           Options.Applicative (Parser, ParserInfo)
 import qualified Options.Applicative as Opt
-
-import           Ouroboros.Network.Block (SlotNo (..))
 
 
 main :: IO ()

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -126,5 +126,6 @@ executable cardano-db-sync
                       , cardano-db
                       , cardano-db-sync
                       , cardano-prelude
+                      , cardano-slotting
                       , optparse-applicative
                       , ouroboros-network

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -51,7 +51,7 @@ import           Cardano.DbSync.Util
 
 import           Cardano.Prelude hiding (atomically, option, (%), Nat)
 
-import           Cardano.Slotting.Slot (WithOrigin (..))
+import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
 
 import qualified Codec.CBOR.Term as CBOR
 import           Control.Monad.Class.MonadSTM.Strict (MonadSTM, StrictTMVar,
@@ -83,7 +83,7 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion (NodeToClientVe
 import           Ouroboros.Consensus.Node.Run (RunNode)
 import qualified Ouroboros.Network.NodeToClient.Version as Network
 
-import           Ouroboros.Network.Block (BlockNo (..), HeaderHash, Point (..), SlotNo (..),
+import           Ouroboros.Network.Block (BlockNo (..), HeaderHash, Point (..),
                     Tip, genesisPoint, getTipBlockNo, blockNo)
 import           Ouroboros.Network.Mux (MuxPeer (..),  RunMiniProtocol (..))
 import           Ouroboros.Network.NodeToClient (IOManager, ClientSubscriptionParams (..),

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Util.hs
@@ -37,9 +37,11 @@ import qualified Cardano.Crypto as Crypto
 import qualified Cardano.Chain.Block as Byron
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.Genesis as Byron
-import qualified Cardano.Chain.Slotting as Byron
+import qualified Cardano.Chain.Slotting as ByronInsanity
 import qualified Cardano.Chain.Update as Byron
 import qualified Cardano.Chain.UTxO as Byron
+
+import           Cardano.Slotting.Slot (SlotNo (..))
 
 import           Crypto.Hash (Blake2b_256)
 
@@ -53,7 +55,7 @@ import qualified Cardano.Db as DB
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock, ByronHash (..))
 import           Ouroboros.Network.Point (WithOrigin (..))
 import qualified Ouroboros.Network.Point as Point
-import           Ouroboros.Network.Block (Point (..), SlotNo (..))
+import           Ouroboros.Network.Block (Point (..))
 
 
 blockHash :: Byron.ABlock ByteString -> ByteString
@@ -97,11 +99,11 @@ mkSlotLeader blk =
 
 
 -- | Convert from Ouroboros 'Point' to `Byron' types.
-pointToSlotHash :: Point ByronBlock -> Maybe (Byron.SlotNumber, Byron.HeaderHash)
+pointToSlotHash :: Point ByronBlock -> Maybe (SlotNo, Byron.HeaderHash)
 pointToSlotHash (Point x) =
   case x of
     Origin -> Nothing
-    At blk -> Just (Byron.SlotNumber . unSlotNo $ Point.blockPointSlot blk, unByronHash $ Point.blockPointHash blk)
+    At blk -> Just (Point.blockPointSlot blk, unByronHash $ Point.blockPointHash blk)
 
 renderAbstractHash :: Crypto.AbstractHash algo a -> Text
 renderAbstractHash =
@@ -113,7 +115,7 @@ slotLeaderHash =
 
 slotNumber :: Byron.ABlock ByteString -> Word64
 slotNumber =
-  Byron.unSlotNumber . Byron.headerSlot . Byron.blockHeader
+  ByronInsanity.unSlotNumber . Byron.headerSlot . Byron.blockHeader
 
 unAbstractHash :: Crypto.Hash Raw -> ByteString
 unAbstractHash = Crypto.abstractHashToBytes

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Util.hs
@@ -26,8 +26,8 @@ module Cardano.DbSync.Era.Shelley.Util
 
 import           Cardano.Prelude
 
-import           Cardano.Chain.Slotting (SlotNumber (..))
 import qualified Cardano.Crypto.Hash as Crypto
+import           Cardano.Slotting.Slot (SlotNo (..))
 
 import qualified Cardano.Db as Db
 import           Cardano.DbSync.Types
@@ -38,7 +38,7 @@ import           Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Text.Encoding as Text
 
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
-import           Ouroboros.Network.Block (BlockNo (..), Point (..), SlotNo (..))
+import           Ouroboros.Network.Block (BlockNo (..), Point (..))
 import           Ouroboros.Network.Point (WithOrigin (..))
 import qualified Ouroboros.Network.Point as Point
 
@@ -89,11 +89,11 @@ mkSlotLeader blk =
                 $ Shelley.shelleyBlockHeaderHash blk
 
 -- | Convert from Ouroboros 'Point' to `Shelley' types.
-pointToSlotHash :: Point ShelleyBlock -> Maybe (SlotNumber, ShelleyHash)
+pointToSlotHash :: Point ShelleyBlock -> Maybe (SlotNo, ShelleyHash)
 pointToSlotHash (Point x) =
   case x of
     Origin -> Nothing
-    At blk -> Just (SlotNumber . unSlotNo $ Point.blockPointSlot blk, Point.blockPointHash blk)
+    At blk -> Just (Point.blockPointSlot blk, Point.blockPointHash blk)
 
 renderHash :: ShelleyHash -> Text
 renderHash = Text.decodeUtf8 . unHeaderHash

--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Default/Rollback.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Default/Rollback.hs
@@ -18,7 +18,7 @@ import qualified Cardano.DbSync.Plugin.Default.Shelley.Rollback as Shelley
 import           Cardano.DbSync.Types
 import           Cardano.DbSync.Util
 
-import           Ouroboros.Network.Block (SlotNo (..))
+import           Cardano.Slotting.Slot (SlotNo (..))
 
 
 rollbackToPoint :: Trace IO Text -> CardanoPoint -> IO (Either DbSyncNodeError ())

--- a/cardano-db-sync/src/Cardano/DbSync/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Types.hs
@@ -17,10 +17,12 @@ module Cardano.DbSync.Types
 
 import           Cardano.Db (MigrationDir (..))
 
+import           Cardano.Slotting.Slot (SlotNo (..))
+
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock (..))
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
 import qualified Ouroboros.Consensus.Shelley.Protocol as Shelley
-import           Ouroboros.Network.Block (Point (..), SlotNo (..), Tip)
+import           Ouroboros.Network.Block (Point (..), Tip)
 
 import qualified Shelley.Spec.Ledger.Address as Shelley
 import qualified Shelley.Spec.Ledger.BlockChain as Shelley


### PR DESCRIPTION
There were two types (SlotNo and SlotNumber) used to defined slot numbers
and these were defined in three different place (cardano-base,
cardano-ledger-specs and ouroboros-network (reexport)). This commits
reduced as many of these to use the one cardano-base.