### PR TITLE
db: Allow calculation of Epoch with zero blocks in it

### DIFF
--- a/cardano-db/src/Cardano/Db/Query.hs
+++ b/cardano-db/src/Cardano/Db/Query.hs
@@ -568,6 +568,9 @@ maybeToEither :: e -> (a -> b) -> Maybe a -> Either e b
 maybeToEither e f =
   maybe (Left e) (Right . f)
 
+-- metaSlotsPerEpoch :: Meta -> Word64
+-- metaSlotsPerEpoch meta = 10 * metaProtocolConst meta
+
 slotPosixTime :: Meta -> Word64 -> POSIXTime
 slotPosixTime meta =
   utcTimeToPOSIXSeconds . slotUtcTime meta


### PR DESCRIPTION
This happened on the Shelley F&F testnet.