### PR TITLE
add - indexes for block(time) and tx_out(address).

### DIFF
--- a/schema/migration-3-0003-20200702.sql
+++ b/schema/migration-3-0003-20200702.sql
@@ -1,0 +1,28 @@
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_three + 1 INTO next_version FROM schema_version ;
+  IF next_version <= 3 THEN
+    -- -------------------------------------------------------------------------
+    -- More hand crafted indices for performance
+
+    -- These speed up some common/simple graphql queries for lightweight wallets.
+
+    CREATE INDEX idx_block_time
+    ON block(time);
+
+    CREATE INDEX idx_tx_out_address
+    ON tx_out USING hash (address);
+
+    -- -------------------------------------------------------------------------
+
+    UPDATE schema_version SET stage_three = 3 ;
+    RAISE NOTICE 'DB has been migrated to stage_three version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
These two indexes significantly improve the performance of sql queries
generated by hasura/cardano-graphql for simple graphql queries.

For examples of such graphql queries please see

https://github.com/Emurgo/yoroi-graphql-migration-backend/blob/7c29a289f28f7038ea5071046c435231a2199774/src/services/utxoForAddress.ts

without the indexes:
![before-indexes](https://user-images.githubusercontent.com/653980/86385465-3b055200-bc88-11ea-935c-c41a03163fa3.png)

with the indexes:
![with indicies](https://user-images.githubusercontent.com/653980/86385477-40629c80-bc88-11ea-8c84-a15b9e1f63e8.png)

thanks to @xdzurman for this.
