### PR TITLE
Update to head of cardano node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ log-dir
 result*
 launch_*
 cabal.project.local
+
+/.vscode

--- a/cabal.project
+++ b/cabal.project
@@ -367,6 +367,6 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 8c72fc00cb75b7e7a2c9423ba50c639f6236c88b
-  --sha256: 0h08p1plyxik8wwcws2cvgkvlxlhgg33v3mfj110lzrfiwq4yygs
+  tag: a8faa35e55f9a96986cfef86d08b83050cabb659
+  --sha256: 18lpzvqpasgakrrnizacmfhp6lsz3jjj56xii6xdda4fbnschvj3
   subdir: cardano-config

--- a/cardano-db-sync/src/Cardano/DbSync/Era.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era.hs
@@ -28,8 +28,6 @@ import qualified Cardano.DbSync.Era.Shelley.Genesis as Shelley
 import           Cardano.DbSync.Error
 import           Cardano.DbSync.Types
 
-import           Cardano.Config.Shelley.Orphans ()
-
 import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT, runExceptT)

--- a/stack.yaml
+++ b/stack.yaml
@@ -59,7 +59,7 @@ extra-deps:
     commit: 2547ad1e80aeabca2899951601079408becbc92c
 
   - git: https://github.com/input-output-hk/cardano-node
-    commit: 8c72fc00cb75b7e7a2c9423ba50c639f6236c88b
+    commit: a8faa35e55f9a96986cfef86d08b83050cabb659
     subdirs:
       - cardano-config
 


### PR DESCRIPTION
Updating to head of `cardano-node` where `Cardano.Config.Shelley.Orphans` is no longer defined.