### PR TITLE
Sync deps and bump version to 3.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -68,57 +68,57 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: df2696ad022f35a510a5295723e073ddd3c41532
-  --sha256: 1dlkavqfmal3vvhafq6v4n4c9n886s5dj47fwsg5al5l1xxaa634
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: df2696ad022f35a510a5295723e073ddd3c41532
-  --sha256: 1dlkavqfmal3vvhafq6v4n4c9n886s5dj47fwsg5al5l1xxaa634
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: iohk-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: df2696ad022f35a510a5295723e073ddd3c41532
-  --sha256: 1dlkavqfmal3vvhafq6v4n4c9n886s5dj47fwsg5al5l1xxaa634
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: plugins/backend-aggregation
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: df2696ad022f35a510a5295723e073ddd3c41532
-  --sha256: 1dlkavqfmal3vvhafq6v4n4c9n886s5dj47fwsg5al5l1xxaa634
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: plugins/backend-ekg
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: df2696ad022f35a510a5295723e073ddd3c41532
-  --sha256: 1dlkavqfmal3vvhafq6v4n4c9n886s5dj47fwsg5al5l1xxaa634
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: plugins/backend-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: df2696ad022f35a510a5295723e073ddd3c41532
-  --sha256: 1dlkavqfmal3vvhafq6v4n4c9n886s5dj47fwsg5al5l1xxaa634
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir:   plugins/backend-trace-forwarder
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: df2696ad022f35a510a5295723e073ddd3c41532
-  --sha256: 1dlkavqfmal3vvhafq6v4n4c9n886s5dj47fwsg5al5l1xxaa634
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: plugins/scribe-systemd
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: df2696ad022f35a510a5295723e073ddd3c41532
-  --sha256: 1dlkavqfmal3vvhafq6v4n4c9n886s5dj47fwsg5al5l1xxaa634
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir: tracer-transformers
 
 source-repository-package
@@ -166,216 +166,216 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: shelley/chain-and-ledger/executable-spec/test/
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9dc2eab127849ad7b7cada13c6681dda540a88fe
-  --sha256: 11wr66ckmwsa5x4pqb6c81s1wk3jprb8wc37ddbb2zg9ads3ba9k
+  tag: a790fb38cced04d8d8a9aeacc2a761717f11f94e
+  --sha256: 0j5sgx7wqf46f30r8dgmxk85y99pvn7dzrj99xi7779lllqn4ddg
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: cardano-client
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: Win32-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: ouroboros-consensus-byron
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: ouroboros-consensus-byronspec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: ouroboros-consensus-shelley
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: ouroboros-consensus-cardano
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: ouroboros-network-testing
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: ouroboros-consensus/ouroboros-consensus-mock
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fb473dca5880893d6070db2e2efc80d483ca930d
-  --sha256: 1bkgjgvdbagqp4zsc10c53s0jparlmds05i927hshhnaz721730m
+  tag: 34e380f54ed24772479763ba6d67f4893d82aac2
+  --sha256: 03gnxiq6rl6j1wnbw1nj5rix1iga406yyp1v9xxz4684qsxj5b24
   subdir: ouroboros-consensus/ouroboros-consensus-test-infra
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: b218bca02d31f22407e586ec949c7d3637e8c1d3
-  --sha256: 09xl8n91pg6k972if46nqdsg6hl8zny9h7563dc9aj6j17xanpcx
+  tag: 0191ff56d194b6ac074af0d51e67493c14e08ffa
+  --sha256: 1mwx751w6f59bhf8r4n72s0gy0fz5w4ss5jcds0fs8nvjlk7y3c6
   subdir: cardano-api
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: b218bca02d31f22407e586ec949c7d3637e8c1d3
-  --sha256: 09xl8n91pg6k972if46nqdsg6hl8zny9h7563dc9aj6j17xanpcx
+  tag: 0191ff56d194b6ac074af0d51e67493c14e08ffa
+  --sha256: 1mwx751w6f59bhf8r4n72s0gy0fz5w4ss5jcds0fs8nvjlk7y3c6
   subdir: cardano-config

--- a/cardano-db-sync-extended/CHANGELOG.md
+++ b/cardano-db-sync-extended/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for cardano-db-sync-extended
 
+## 3.0.0 -- July 2020
+
+* Note that this release requires the database to be dropped and recreated.
+  It requires cardano-node 1.16 or later.
+* Fix to support very large values of per-epoch aggregate tc outputs (#201)
+
 ## 2.1.0 -- July 2020
 
 * Note that this release requires the database to be dropped and recreated

--- a/cardano-db-sync-extended/cardano-db-sync-extended.cabal
+++ b/cardano-db-sync-extended/cardano-db-sync-extended.cabal
@@ -3,7 +3,7 @@ cabal-version:          >= 1.10
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-db-sync-extended
-version:                2.1.0
+version:                3.0.0
 synopsis:               The Extended Cardano DB Sync node
 description:            A Cardano node that follows the Cardano chain and inserts data from the
                         chain into a PostgresQL database. It is "extended" because it maintains an

--- a/cardano-db-sync/CHANGELOG.md
+++ b/cardano-db-sync/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for cardano-db-sync node
 
+## 3.0.0 -- July 2020
+
+* Note that this release requires the database to be dropped and recreated.
+  It requires cardano-node 1.16 or later.
+* Add support for the cardano-node in Cardano mode (#186, #188, #196)
+
 ## 2.1.0 -- July 2020
 
 * Note that this release requires the database to be dropped and recreated

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -3,7 +3,7 @@ cabal-version:          >= 1.10
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-db-sync
-version:                2.1.0
+version:                3.0.0
 synopsis:               The Cardano DB Sync node
 description:            A Cardano node that follows the Cardano chain and inserts data from the
                         chain into a PostgresQL database.

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Util.hs
@@ -67,11 +67,11 @@ import           Shelley.Spec.Ledger.Coin (Coin (..))
 import qualified Shelley.Spec.Ledger.Crypto as Shelley
 import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
 import qualified Shelley.Spec.Ledger.BlockChain as Shelley
+import qualified Shelley.Spec.Ledger.Hashing as Shelley
 import qualified Shelley.Spec.Ledger.Keys as Shelley
 import qualified Shelley.Spec.Ledger.OCert as Shelley
 import qualified Shelley.Spec.Ledger.Tx as Shelley
 import qualified Shelley.Spec.Ledger.TxData as Shelley
-import qualified Shelley.Spec.Ledger.UTxO as Shelley
 
 blockBody :: Shelley.ShelleyBlock TPraosStandardCrypto -> Shelley.BHBody TPraosStandardCrypto
 blockBody = Shelley.bhbody . Shelley.bheader . Shelley.shelleyBlockRaw
@@ -184,7 +184,7 @@ txFee :: ShelleyTx -> Word64
 txFee = fromIntegral . unCoin . Shelley._txfee . Shelley._body
 
 txHash :: ShelleyTx -> ByteString
-txHash = Crypto.hashToBytes . Shelley.hashTxBody . Shelley._body
+txHash = Crypto.hashToBytes . Shelley.hashAnnotated . Shelley._body
 
 txInputList :: ShelleyTx -> [ShelleyTxIn]
 txInputList = toList . Shelley._inputs . Shelley._body

--- a/cardano-db/CHANGELOG.md
+++ b/cardano-db/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Revision history for cardano-db
 
+## 3.0.0 -- July 2020
+
+* Note that this release requires the database to be dropped and recreated
+* Further Shelley schema additions and changes (#173, #174, #199)
+* Fix to support very large values of per-epoch aggregate tc outputs (#201)
+* Support Word64 column types properly (#203)
+
 ## 2.1.0 -- July 2020
 
 * Note that this release requires the database to be dropped and recreated
-* The database schema has been accepted to accept the superset of Byron and Shelley
-  era information
+* The database schema has been adjusted to accept the superset of Byron and
+  Shelley era information
 * Shelley is still not fully supported
 * Remove last hard coded values for slots per epoch
 

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -3,7 +3,7 @@ cabal-version:          >= 1.10
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-db
-version:                2.1.0
+version:                3.0.0
 synopsis:               A base PostgreSQL component for the cardano-db-sync node.
 description:            Code for the Cardano DB Sync node that is shared between the
                         cardano-db-node and other components.

--- a/stack.yaml
+++ b/stack.yaml
@@ -76,7 +76,7 @@ extra-deps:
       - test
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: df2696ad022f35a510a5295723e073ddd3c41532
+    commit: efa4b5ecd7f0a13124616b12679cd42517cd905a
     subdirs:
       - contra-tracer
       - iohk-monitoring
@@ -100,7 +100,7 @@ extra-deps:
     commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 9dc2eab127849ad7b7cada13c6681dda540a88fe
+    commit: a790fb38cced04d8d8a9aeacc2a761717f11f94e
     subdirs:
       - byron/crypto
       - byron/crypto/test
@@ -114,7 +114,7 @@ extra-deps:
       - shelley/chain-and-ledger/executable-spec/test
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: fb473dca5880893d6070db2e2efc80d483ca930d
+    commit: 34e380f54ed24772479763ba6d67f4893d82aac2
     subdirs:
       - cardano-client
       - io-sim
@@ -135,7 +135,7 @@ extra-deps:
       - ouroboros-consensus/ouroboros-consensus-test-infra
 
   - git: https://github.com/input-output-hk/cardano-node
-    commit: b218bca02d31f22407e586ec949c7d3637e8c1d3
+    commit: 0191ff56d194b6ac074af0d51e67493c14e08ffa
     subdirs:
       - cardano-config
 


### PR DESCRIPTION
Sync deps to those used by cardano-node-1.17.0


Bump versions to 3.0.0 and update changelogs 