### PR TITLE
schema: Do not drop 'pg_stat_*' views on migration

### DIFF
--- a/schema/migration-1-0002-20190912.sql
+++ b/schema/migration-1-0002-20190912.sql
@@ -11,7 +11,9 @@ BEGIN
   for vname in
       select '"' || table_name || '"'
 	    from information_schema.views
-        where table_catalog = current_database () and table_schema = 'public'
+        where table_catalog = current_database ()
+          and table_schema = 'public'
+          and table_name !~* 'pg_stat_.*'
     loop
       execute format ('drop view if exists %s cascade ;', vname) ;
       raise notice 'Dropping view : %', vname ;


### PR DESCRIPTION
I will not merge this until @johnalotoski has confirmed that it works as required.