### PR TITLE
Update resolver to cardano-1.21.1.yaml

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -84,7 +84,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 4f44b01f190030dd56f40edb462a2addb6df4061
+  tag: a819311473563cb2ab3cd91543cf0f63facdf43e
   --sha256: 0pglk1fnj17c36r35dqhfnnksff6vpi3ng6jqq7vc8bxhhh41z51
   subdir:
     cardano-api
@@ -129,7 +129,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: f6466b6473df52a42316061e495f0defa2a71442
+  tag: 9e498e0962044c582df0cbf2f81fa0450a67d5f7
   --sha256: 0wvqrnhhlgx90cccsdgj94qgnvy6yb41x63gihdascx1cnhxzkik
   subdir:
     cardano-client

--- a/cardano-db-sync/src/Cardano/DbSync/Config/Cardano.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config/Cardano.hs
@@ -115,14 +115,14 @@ mkProtocolCardano ge =
           Nothing                                   -- Maybe PBftSignatureThreshold
           (dncByronProtocolVersion dnc)
           (dncByronSoftwareVersion dnc)
-          []                                        -- [ByronLeaderCredentials]
+          Nothing                                   -- Maybe ByronLeaderCredentials
 
           -- Shelley parameters
           (scConfig shelleyGenesis)
           (shelleyPraosNonce shelleyGenesis)
           (shelleyProtVer dnc)
           (Consensus.MaxMajorProtVer $ dncShelleyMaxProtocolVersion dnc)
-          []                                        -- [TPraosLeaderCredentials StandardShelley]
+          Nothing                                   -- Maybe (TPraosLeaderCredentials StandardShelley)
 
           -- Hard fork parameters
           (dncShelleyHardForkNotBeforeEpoch dnc)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/0c5b0a6619fadf22f4d62a12154e181a6d035c1c/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/aaf316ac9c39466a6eccf53f2f3aabb5a266b62e/snapshots/cardano-1.21.1.yaml
 compiler: ghc-8.6.5
 
 allow-newer: true
@@ -61,78 +61,14 @@ extra-deps:
   - time-compat-1.9.2.2
   - quiet-0.2
 
-  - git: https://github.com/input-output-hk/cardano-crypto
-    commit: 2547ad1e80aeabca2899951601079408becbc92c
-
-  - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 0c5b0a6619fadf22f4d62a12154e181a6d035c1c
-    subdirs:
-      - .
-      - test
-
-  - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: d4bb653fcef181befe3883490c66faed46b6197d
-    subdirs:
-      - contra-tracer
-      - iohk-monitoring
-      - plugins/backend-aggregation
-      - plugins/backend-ekg
-      - plugins/backend-monitoring
-      - plugins/backend-trace-forwarder
-      - plugins/scribe-systemd
-      - tracer-transformers
-
-  - git: https://github.com/input-output-hk/cardano-base
-    commit: 13f44ad35d2762dbf98b3d3be56b7ba2adf515f4
-    subdirs:
-      - binary
-      - cardano-crypto-praos
-      - binary/test
-      - cardano-crypto-class
-      - slotting
-
-  - git: https://github.com/input-output-hk/goblins
-    commit: cde90a2b27f79187ca8310b6549331e59595e7ba
-
-  - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-    subdirs:
-      - byron/crypto
-      - byron/crypto/test
-      - byron/chain/executable-spec
-      - byron/ledger/executable-spec
-      - byron/ledger/impl
-      - byron/ledger/impl/test
-      - semantics/executable-spec
-      - shelley/chain-and-ledger/dependencies/non-integer
-      - shelley/chain-and-ledger/executable-spec
-      - shelley/chain-and-ledger/executable-spec/test
-
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: f6466b6473df52a42316061e495f0defa2a71442
+    commit: 9e498e0962044c582df0cbf2f81fa0450a67d5f7
     subdirs:
       - cardano-client
-      - io-sim
-      - io-sim-classes
-      - network-mux
-      - ouroboros-network
-      - ouroboros-network-framework
-      - Win32-network
-      - ouroboros-consensus
-      - ouroboros-consensus-byron
       - ouroboros-consensus-byronspec
-      - ouroboros-consensus-shelley
-      - ouroboros-consensus-cardano
-      - typed-protocols
-      - typed-protocols-examples
       - ouroboros-network-testing
-      - ouroboros-consensus/ouroboros-consensus-mock
-      - ouroboros-consensus/ouroboros-consensus-test-infra
-
-  - git: https://github.com/input-output-hk/cardano-node
-    commit: 4f44b01f190030dd56f40edb462a2addb6df4061
-    subdirs:
-      - cardano-config
+      - ouroboros-consensus-mock
+      - ouroboros-consensus-test
 
 flags:
   # Bundle VRF crypto in libsodium and do not rely on an external fork to have it.


### PR DESCRIPTION
This is needed so the dependencies are properly in sync
and cardano-db-sync or smash can be used from within
the wallet.

----

Related: https://github.com/input-output-hk/cardano-wallet/pull/2249

1. I don't know what those sha256 hashes are and they aren't documented, so I didn't update it :man_shrugging: 
2. I didn't update nix expressions, since `nix/regenerate.sh` removes cabal.project and does nothing else on my machine :sweat_smile: 