### PR TITLE
adds txMetadata as cbor into a bytea column on the tx_metadata table.

### DIFF
--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -245,7 +245,8 @@ share
 
   TxMetadata
     key                 DbWord64            sqltype=word64type
-    json                Text                sqltype=jsonb
+    json                Text Maybe          sqltype=jsonb
+    bytes               ByteString          sqltype=bytea
     txId                TxId
     UniqueTxMetadata    key txId
 

--- a/schema/migration-2-0002-20201027.sql
+++ b/schema/migration-2-0002-20201027.sql
@@ -1,0 +1,20 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 2 THEN
+    EXECUTE 'ALTER TABLE "tx_metadata" ALTER COLUMN "json" DROP NOT NULL' ;
+    EXECUTE 'ALTER TABLE "tx_metadata" ADD COLUMN "bytes" bytea NOT NULL' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = 2 ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
Yoroi requires this for Catalyst.

as the unique key on this table is (key, txid), it continues to split
up the tx_metadata by key.  it recreates the TxMetadata value for
each key.