### PR TITLE
Nix build cardano-node binary for the revision used by db-sync

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,7 @@ let
   };
 
   packages = {
-    inherit haskellPackages cardano-db-sync cardano-db-sync-extended scripts;
+    inherit haskellPackages cardano-db-sync cardano-db-sync-extended cardano-node scripts;
 
     # NixOS tests
     #nixosTests = import ./nix/nixos/tests {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -12,6 +12,8 @@ pkgs: _: with pkgs;
       cardano-db-sync;
   inherit (cardanoDbSyncHaskellPackages.cardano-db-sync-extended.components.exes)
       cardano-db-sync-extended;
+  inherit (cardanoDbSyncHaskellPackages.cardano-node.components.exes)
+      cardano-node;
 
   inherit ((haskell-nix.hackage-package {
     name = "hlint";

--- a/release.nix
+++ b/release.nix
@@ -110,6 +110,7 @@ let
       collectTests jobs.native.benchmarks ++ [
       jobs.native.cardano-db-sync.x86_64-linux
       jobs.native.cardano-db-sync-extended.x86_64-linux
+      jobs.native.cardano-node.x86_64-linux
     ]));
 
 in jobs


### PR DESCRIPTION
 it is the rev used alongside db-sync for deployment, so we need it
 cached by hydra.