### PR TITLE
docs: update interesting queries (current valid pools)

### DIFF
--- a/doc/interesting-queries.md
+++ b/doc/interesting-queries.md
@@ -69,15 +69,15 @@ retire. Therefore to get the latest pool registration for every pool that is sti
 valid:
 ```
 cexplorer=# select * from pool_update
-              where registered_tx_id in (select max(registered_tx_id) from pool_update group by reward_addr)
-              and not exists (select * from pool_retire where pool_retire.hash_id = pool_update.id);
+              where registered_tx_id in (select max(registered_tx_id) from pool_update group by hash_id)
+              and not exists (select * from pool_retire where pool_retire.hash_id = pool_update.hash_id and pool_retire.retiring_epoch <= (select max(no) from epoch));
 
 ```
 To include the pool hash in the query output:
 ```
 cexplorer=# select * from pool_update inner join pool_hash on pool_update.hash_id = pool_hash.id
-              where registered_tx_id in (select max(registered_tx_id) from pool_update group by reward_addr)
-              and not exists (select * from pool_retire where pool_retire.hash_id = pool_update.id);
+              where registered_tx_id in (select max(registered_tx_id) from pool_update group by hash_id)
+              and not exists (select * from pool_retire where pool_retire.hash_id = pool_update.hash_id and pool_retire.retiring_epoch <= (select max(no) from epoch));
 ```
 
 ### Transaction fee for specified transaction hash:


### PR DESCRIPTION
Sorry if I got this wrong - should this query list all active (non-retired) pools? If yes, then this PR could be an improvement. Grouping by `hash_id` rather than `reward_addr` will get rid of duplicates, when a pool starts using new address. There seems to be a typo? in the last  `where` clause matching `pool_retire.hash_id` with `pool_update.id`. And last but not least, it could be further improved by introducing `retiring_epoch` into the query, since a pool can post a deregistration message yet still be active in the current or upcoming one(s).