### PR TITLE
Insert epoch rewards and stakes in chunks

### DIFF
--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -124,6 +124,7 @@ library
                       , small-steps
                       , serialise
                       , shelley-spec-ledger
+                      , split
                       , stm
                       , text
                       , time


### PR DESCRIPTION
Recent epochs, especially after Allegra cause a very big delay on epoch boundaries as reported https://github.com/input-output-hk/cardano-db-sync/issues/478. For me it's around 20mins for the last epochs.

The main cause of the delay is that we add each reward on a separate query, even if there are >100000 rewards. A better approach is to group these rewards and insert them in chunks. The same applies to stakes, but they created a smaller delay.

With chunks of 10000 the delay drops to 5mins. I tried to add all of them in a single chunk but it was taking 10mins. Maybe it's worth investigating more options.

This is expected to save hours in total sync time. 