### PR TITLE
Cache previous block optimization

### DIFF
--- a/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
+++ b/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
@@ -8,7 +8,7 @@ import           Cardano.Config.Git.Rev (gitRev)
 import           Cardano.Db (MigrationDir (..))
 import           Cardano.DbSync (ConfigFile (..), DbSyncCommand (..), DbSyncNodeParams (..),
                    LedgerStateDir (..), SocketPath (..), runDbSyncNode)
-import           Cardano.DbSync.Plugin.Extended (extendedDbSyncNodePlugin)
+import           Cardano.DbSync.Plugin.Extended (mkExtendedDbSyncNodePlugin)
 
 import           Cardano.Slotting.Slot (SlotNo (..))
 
@@ -28,7 +28,9 @@ main = do
   cmd <- Opt.execParser opts
   case cmd of
     CmdVersion -> runVersionCommand
-    CmdRun params -> runDbSyncNode extendedDbSyncNodePlugin params
+    CmdRun params -> do
+      plugin <- mkExtendedDbSyncNodePlugin
+      runDbSyncNode plugin params
 
 -- -------------------------------------------------------------------------------------------------
 

--- a/cardano-db-sync-extended/src/Cardano/DbSync/Plugin/Extended.hs
+++ b/cardano-db-sync-extended/src/Cardano/DbSync/Plugin/Extended.hs
@@ -1,15 +1,16 @@
 module Cardano.DbSync.Plugin.Extended
-  ( extendedDbSyncNodePlugin
+  ( mkExtendedDbSyncNodePlugin
   ) where
 
 
-import           Cardano.DbSync (DbSyncNodePlugin (..), defDbSyncNodePlugin)
+import           Cardano.DbSync (DbSyncNodePlugin (..), mkDefDbSyncNodePlugin)
 import           Cardano.DbSync.Plugin.Epoch (epochPluginInsertBlock, epochPluginOnStartup,
                    epochPluginRollbackBlock)
 
-extendedDbSyncNodePlugin :: DbSyncNodePlugin
-extendedDbSyncNodePlugin =
-  defDbSyncNodePlugin
+mkExtendedDbSyncNodePlugin :: IO DbSyncNodePlugin
+mkExtendedDbSyncNodePlugin = do
+  defDbSyncNodePlugin <- mkDefDbSyncNodePlugin
+  return $ defDbSyncNodePlugin
     { plugOnStartup =
         plugOnStartup defDbSyncNodePlugin
           ++ [epochPluginOnStartup]

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -6,7 +6,7 @@ import           Cardano.Prelude
 import           Cardano.Config.Git.Rev (gitRev)
 import           Cardano.Db (MigrationDir (..))
 import           Cardano.DbSync (ConfigFile (..), DbSyncCommand (..), DbSyncNodeParams (..),
-                   LedgerStateDir (..), SocketPath (..), defDbSyncNodePlugin, runDbSyncNode)
+                   LedgerStateDir (..), SocketPath (..), mkDefDbSyncNodePlugin, runDbSyncNode)
 
 import           Cardano.Slotting.Slot (SlotNo (..))
 
@@ -27,7 +27,9 @@ main = do
   cmd <- Opt.execParser opts
   case cmd of
     CmdVersion -> runVersionCommand
-    CmdRun params -> runDbSyncNode defDbSyncNodePlugin params
+    CmdRun params -> do
+      plugin <- mkDefDbSyncNodePlugin
+      runDbSyncNode plugin params
 
 -- -------------------------------------------------------------------------------------------------
 

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -19,7 +19,7 @@ module Cardano.DbSync
   , SocketPath (..)
   , DB.MigrationDir (..)
 
-  , defDbSyncNodePlugin
+  , mkDefDbSyncNodePlugin
   , runDbSyncNode
   ) where
 
@@ -44,7 +44,7 @@ import           Cardano.DbSync.Error
 import           Cardano.DbSync.LedgerState
 import           Cardano.DbSync.Metrics
 import           Cardano.DbSync.Plugin (DbSyncNodePlugin (..))
-import           Cardano.DbSync.Plugin.Default (defDbSyncNodePlugin)
+import           Cardano.DbSync.Plugin.Default (mkDefDbSyncNodePlugin)
 import           Cardano.DbSync.Rollback (unsafeRollback)
 import           Cardano.DbSync.StateQuery (StateQueryTMVar, getSlotDetails, localStateQueryHandler,
                    newStateQueryTMVar)

--- a/cardano-db-sync/src/Cardano/DbSync/Plugin.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin.hs
@@ -22,8 +22,8 @@ import           Cardano.DbSync.Types
 -- actions on a block insert or rollback.
 --
 -- The insert and rollback actions are applied from the head of the list to the tail.
--- THe default DbSyncNodePlugin is 'Cardano.DbSync.Plugin.Default.defDbSyncNodePlugin'. This
--- allows clients to insert db actions both before and after the default action.
+-- THe default DbSyncNodePlugin is created in 'Cardano.DbSync.Plugin.Default.mkDefDbSyncNodePlugin'.
+-- This allows clients to insert db actions both before and after the default action.
 
 -- Plugins are free to read from the existing tables but should not modify them. Plugins however
 -- are free to operation on their own tables.

--- a/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
@@ -44,6 +44,7 @@ rollbackToSlot trce slotNo =
               [ "Deleting slots numbered: ", renderSlotList xs
               ]
         mapM_ (lift . DB.deleteCascadeSlotNo) xs
+        liftIO $ logInfo trce "Slots deleted"
 
 
 -- For testing and debugging.

--- a/cardano-db-sync/src/Cardano/DbSync/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Types.hs
@@ -6,12 +6,20 @@ module Cardano.DbSync.Types
   , EpochSlot (..)
   , SlotDetails (..)
   , SyncState (..)
+  , Cache
+  , PrevInfo (..)
+  , newCache
+  , readPrevInfo
+  , writePrevInfo
   ) where
 
 import           Cardano.DbSync.Config.Types (CardanoBlock, CardanoProtocol)
+import           Cardano.Db
 
 import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..))
 
+import           Control.Concurrent.STM
+import           Data.ByteString
 import           Data.Time.Clock (UTCTime)
 import           Data.Word (Word64)
 
@@ -36,3 +44,21 @@ data SyncState
   = SyncLagging         -- Local tip is lagging the global chain tip.
   | SyncFollowing       -- Local tip is following global chain tip.
   deriving (Eq, Show)
+
+newtype Cache = Cache
+  { _getCache :: TVar (Maybe PrevInfo)
+  }
+
+data PrevInfo = PrevInfo
+  { cachePrevBlockId :: BlockId
+  , cachePrevHash :: ByteString
+  }
+
+readPrevInfo :: Cache -> IO (Maybe PrevInfo)
+readPrevInfo (Cache cache) = readTVarIO cache
+
+writePrevInfo :: Cache -> Maybe PrevInfo -> IO ()
+writePrevInfo (Cache cache) = atomically . writeTVar cache
+
+newCache :: IO Cache
+newCache = Cache <$> newTVarIO Nothing


### PR DESCRIPTION
Everytime we add a block (happens million of times on each sync) we first query the block table for its previous block. Currently this query is done on the hash of the block, where we don't have an index. Most times this will be the last block we added, so it makes sense to cache it. If the cached hash matches the `prevBLockHash` then we it's the block we're looking for. If not we do the query as before.