### PR TITLE
Keep older snapshots

### DIFF
--- a/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
+++ b/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
@@ -33,23 +33,23 @@ main = do
 
 -- -------------------------------------------------------------------------------------------------
 
-opts :: ParserInfo DbSyncCommand
+opts :: ParserInfo SyncCommand
 opts =
   Opt.info (pCommandLine <**> Opt.helper)
     ( Opt.fullDesc
     <> Opt.progDesc "Extended Cardano POstgreSQL sync node."
     )
 
-pCommandLine :: Parser DbSyncCommand
+pCommandLine :: Parser SyncCommand
 pCommandLine =
   asum
     [ pVersionCommand
     , CmdRun <$> pRunDbSyncNode
     ]
 
-pRunDbSyncNode :: Parser DbSyncNodeParams
+pRunDbSyncNode :: Parser SyncNodeParams
 pRunDbSyncNode =
-  DbSyncNodeParams
+  SyncNodeParams
     <$> pConfigFile
     <*> pSocketPath
     <*> pLedgerStateDir
@@ -100,7 +100,7 @@ pSlotNo =
     <> Opt.metavar "WORD"
     )
 
-pVersionCommand :: Parser DbSyncCommand
+pVersionCommand :: Parser SyncCommand
 pVersionCommand =
   asum
     [ Opt.subparser

--- a/cardano-db-sync-extended/src/Cardano/DbSync/Plugin/Extended.hs
+++ b/cardano-db-sync-extended/src/Cardano/DbSync/Plugin/Extended.hs
@@ -6,11 +6,11 @@ import           Cardano.DbSync.Plugin.Default (defDbSyncNodePlugin)
 import           Cardano.DbSync.Plugin.Epoch (epochPluginInsertBlock, epochPluginOnStartup,
                    epochPluginRollbackBlock)
 
-import           Cardano.Sync (DbSyncNodePlugin (..))
+import           Cardano.Sync (SyncNodePlugin (..))
 
 import           Database.Persist.Sql (SqlBackend)
 
-extendedDbSyncNodePlugin :: SqlBackend -> DbSyncNodePlugin
+extendedDbSyncNodePlugin :: SqlBackend -> SyncNodePlugin
 extendedDbSyncNodePlugin backend =
   let defPlugin = defDbSyncNodePlugin backend
   in  defPlugin

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -33,23 +33,23 @@ main = do
 
 -- -------------------------------------------------------------------------------------------------
 
-opts :: ParserInfo DbSyncCommand
+opts :: ParserInfo SyncCommand
 opts =
   Opt.info (pCommandLine <**> Opt.helper)
     ( Opt.fullDesc
     <> Opt.progDesc "Cardano PostgreSQL sync node."
     )
 
-pCommandLine :: Parser DbSyncCommand
+pCommandLine :: Parser SyncCommand
 pCommandLine =
   asum
     [ pVersionCommand
     , CmdRun <$> pRunDbSyncNode
     ]
 
-pRunDbSyncNode :: Parser DbSyncNodeParams
+pRunDbSyncNode :: Parser SyncNodeParams
 pRunDbSyncNode =
-  DbSyncNodeParams
+  SyncNodeParams
     <$> pConfigFile
     <*> pSocketPath
     <*> pLedgerStateDir
@@ -100,7 +100,7 @@ pSlotNo =
     <> Opt.metavar "WORD"
     )
 
-pVersionCommand :: Parser DbSyncCommand
+pVersionCommand :: Parser SyncCommand
 pVersionCommand =
   asum
     [ Opt.subparser

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -9,9 +9,9 @@
 
 module Cardano.DbSync
   ( ConfigFile (..)
-  , DbSyncCommand (..)
-  , DbSyncNodeParams (..)
-  , DbSyncNodePlugin (..)
+  , SyncCommand (..)
+  , SyncNodeParams (..)
+  , SyncNodePlugin (..)
   , GenesisFile (..)
   , LedgerStateDir (..)
   , NetworkName (..)
@@ -45,7 +45,7 @@ import           Database.Persist.Postgresql (withPostgresqlConn)
 import           Database.Persist.Sql (SqlBackend)
 
 
-runDbSyncNode :: (SqlBackend -> DbSyncNodePlugin) -> DbSyncNodeParams -> IO ()
+runDbSyncNode :: (SqlBackend -> SyncNodePlugin) -> SyncNodeParams -> IO ()
 runDbSyncNode mkPlugin params = do
     let MigrationDir migrationDir = enpMigrationDir params
     DB.runMigrations identity True (DB.MigrationDir migrationDir) (Just $ DB.LogFileDir "/tmp")

--- a/cardano-db-sync/src/Cardano/DbSync/Era.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era.hs
@@ -21,7 +21,7 @@ import           Database.Persist.Sql (SqlBackend)
 
 insertValidateGenesisDist
     :: SqlBackend -> Trace IO Text -> NetworkName -> GenesisConfig
-    -> ExceptT DbSyncNodeError IO ()
+    -> ExceptT SyncNodeError IO ()
 insertValidateGenesisDist backend trce nname genCfg =
   case genCfg of
     GenesisCardano _ bCfg sCfg -> do

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
@@ -44,7 +44,7 @@ import           Database.Persist.Sql (SqlBackend)
 -- If these transactions are already in the DB, they are validated.
 insertValidateGenesisDist
     :: SqlBackend -> Trace IO Text -> Text -> Byron.Config
-    -> ExceptT DbSyncNodeError IO ()
+    -> ExceptT SyncNodeError IO ()
 insertValidateGenesisDist backend tracer networkName cfg = do
     -- Setting this to True will log all 'Persistent' operations which is great
     -- for debugging, but otherwise *way* too chatty.
@@ -52,7 +52,7 @@ insertValidateGenesisDist backend tracer networkName cfg = do
       then newExceptT $ DB.runDbIohkLogging backend tracer insertAction
       else newExceptT $ DB.runDbIohkNoLogging backend insertAction
   where
-    insertAction :: (MonadBaseControl IO m, MonadIO m) => ReaderT SqlBackend m (Either DbSyncNodeError ())
+    insertAction :: (MonadBaseControl IO m, MonadIO m) => ReaderT SqlBackend m (Either SyncNodeError ())
     insertAction = do
       ebid <- DB.queryBlockId (configGenesisHash cfg)
       case ebid of
@@ -111,7 +111,7 @@ insertValidateGenesisDist backend tracer networkName cfg = do
 validateGenesisDistribution
     :: (MonadBaseControl IO m, MonadIO m)
     => Trace IO Text -> Text -> Byron.Config -> DB.BlockId
-    -> ReaderT SqlBackend m (Either DbSyncNodeError ())
+    -> ReaderT SqlBackend m (Either SyncNodeError ())
 validateGenesisDistribution tracer networkName cfg bid =
   runExceptT $ do
     meta <- liftLookupFail "validateGenesisDistribution" DB.queryMeta

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Util.hs
@@ -55,11 +55,11 @@ import qualified Shelley.Spec.Ledger.Scripts as Shelley
 import qualified Shelley.Spec.Ledger.Tx as Shelley
 
 
-annotateStakingCred :: DbSyncEnv -> Shelley.StakeCredential era -> Shelley.RewardAcnt era
+annotateStakingCred :: SyncEnv -> Shelley.StakeCredential era -> Shelley.RewardAcnt era
 annotateStakingCred env cred =
   let network =
         case envProtocol env of
-          DbSyncProtocolCardano -> leNetwork $ envLedger env
+          SyncProtocolCardano -> leNetwork $ envLedger env
   in Shelley.RewardAcnt network cred
 
 coinToDbLovelace :: Coin -> DbLovelace
@@ -104,7 +104,7 @@ renderAddress addr = Api.serialiseAddress (Api.fromShelleyAddr addr :: Api.Addre
 renderRewardAcnt :: Shelley.RewardAcnt StandardCrypto -> Text
 renderRewardAcnt = Api.serialiseAddress . Api.fromShelleyStakeAddr
 
-stakingCredHash :: DbSyncEnv -> Shelley.StakeCredential era -> ByteString
+stakingCredHash :: SyncEnv -> Shelley.StakeCredential era -> ByteString
 stakingCredHash env = Shelley.serialiseRewardAcnt . annotateStakingCred env
 
 unitIntervalToDouble :: Shelley.UnitInterval -> Double

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
@@ -51,7 +51,7 @@ import qualified Shelley.Spec.Ledger.UTxO as Shelley
 -- If these transactions are already in the DB, they are validated.
 insertValidateGenesisDist
     :: SqlBackend -> Trace IO Text -> Text -> ShelleyGenesis StandardShelley
-    -> ExceptT DbSyncNodeError IO ()
+    -> ExceptT SyncNodeError IO ()
 insertValidateGenesisDist backend tracer networkName cfg = do
     -- Setting this to True will log all 'Persistent' operations which is great
     -- for debugging, but otherwise *way* too chatty.
@@ -59,7 +59,7 @@ insertValidateGenesisDist backend tracer networkName cfg = do
       then newExceptT $ DB.runDbIohkLogging backend tracer insertAction
       else newExceptT $ DB.runDbIohkNoLogging backend insertAction
   where
-    insertAction :: (MonadBaseControl IO m, MonadIO m) => ReaderT SqlBackend m (Either DbSyncNodeError ())
+    insertAction :: (MonadBaseControl IO m, MonadIO m) => ReaderT SqlBackend m (Either SyncNodeError ())
     insertAction = do
       ebid <- DB.queryBlockId (configGenesisHash cfg)
       case ebid of
@@ -121,7 +121,7 @@ insertValidateGenesisDist backend tracer networkName cfg = do
 validateGenesisDistribution
     :: (MonadBaseControl IO m, MonadIO m)
     => Trace IO Text -> Text -> ShelleyGenesis StandardShelley -> DB.BlockId
-    -> ReaderT SqlBackend m (Either DbSyncNodeError ())
+    -> ReaderT SqlBackend m (Either SyncNodeError ())
 validateGenesisDistribution tracer networkName cfg bid =
   runExceptT $ do
     liftIO $ logInfo tracer "Validating Genesis distribution"

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Util.hs
@@ -11,7 +11,7 @@ import qualified Cardano.Db as DB
 
 import           Cardano.Sync.Error
 
-liftLookupFail :: Monad m => Text -> m (Either DB.LookupFail a) -> ExceptT DbSyncNodeError m a
+liftLookupFail :: Monad m => Text -> m (Either DB.LookupFail a) -> ExceptT SyncNodeError m a
 liftLookupFail loc =
   firstExceptT (\lf -> NEError $ loc <> DB.renderLookupFail lf) . newExceptT
 

--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Default.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Default.hs
@@ -68,6 +68,6 @@ insertDefaultBlock backend tracer env blockDetails =
                 BlockMary blk ->
                   insertShelleyBlock tracer env (Generic.fromMaryBlock blk) lStateSnap details
       -- Now we update it in ledgerStateVar and (possibly) store it to disk.
-      liftIO $ saveLedgerState (envLedger env)
+      liftIO $ saveLedgerStateMaybe (envLedger env)
                     lStateSnap (isSyncedWithinSeconds details 60)
       pure res

--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Default.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Default.hs
@@ -31,12 +31,12 @@ import           Database.Persist.Sql (SqlBackend)
 
 import           Ouroboros.Consensus.Cardano.Block (HardForkBlock (..))
 
--- | The default DbSyncNodePlugin.
+-- | The default SyncNodePlugin.
 -- Does exactly what the cardano-db-sync node did before the plugin system was added.
 -- The non-default node takes this structure and extends the lists.
-defDbSyncNodePlugin :: SqlBackend -> DbSyncNodePlugin
+defDbSyncNodePlugin :: SqlBackend -> SyncNodePlugin
 defDbSyncNodePlugin backend =
-  DbSyncNodePlugin
+  SyncNodePlugin
     { plugOnStartup = []
     , plugInsertBlock = [insertDefaultBlock backend]
     , plugRollbackBlock = [rollbackToSlot backend]
@@ -45,15 +45,15 @@ defDbSyncNodePlugin backend =
 -- -------------------------------------------------------------------------------------------------
 
 insertDefaultBlock
-    :: SqlBackend -> Trace IO Text -> DbSyncEnv -> [BlockDetails]
-    -> IO (Either DbSyncNodeError ())
+    :: SqlBackend -> Trace IO Text -> SyncEnv -> [BlockDetails]
+    -> IO (Either SyncNodeError ())
 insertDefaultBlock backend tracer env blockDetails =
     DB.runDbAction backend (Just tracer) $
       traverseMEither insert blockDetails
   where
     insert
         :: BlockDetails
-        -> ReaderT SqlBackend (LoggingT IO) (Either DbSyncNodeError ())
+        -> ReaderT SqlBackend (LoggingT IO) (Either SyncNodeError ())
     insert (BlockDetails cblk details) = do
       -- Calculate the new ledger state to pass to the DB insert functions but do not yet
       -- update ledgerStateVar.

--- a/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
@@ -25,11 +25,11 @@ import           Ouroboros.Network.Point
 
 -- Rollbacks are done in an Era generic way based on the 'Point' we are
 -- rolling back to.
-rollbackToSlot :: SqlBackend -> Trace IO Text -> CardanoPoint -> IO (Either DbSyncNodeError ())
+rollbackToSlot :: SqlBackend -> Trace IO Text -> CardanoPoint -> IO (Either SyncNodeError ())
 rollbackToSlot backend trce point =
     DB.runDbIohkNoLogging backend $ runExceptT action
   where
-    action :: MonadIO m => ExceptT DbSyncNodeError (ReaderT SqlBackend m) ()
+    action :: MonadIO m => ExceptT SyncNodeError (ReaderT SqlBackend m) ()
     action = do
         liftIO $ logInfo trce msg
         xs <- lift $ slotsToDelete (pointSlot point)
@@ -57,7 +57,7 @@ rollbackToSlot backend trce point =
                   ]
 
 -- For testing and debugging.
-unsafeRollback :: Trace IO Text -> SlotNo -> IO (Either DbSyncNodeError ())
+unsafeRollback :: Trace IO Text -> SlotNo -> IO (Either SyncNodeError ())
 unsafeRollback trce slotNo = do
   logInfo trce $ "Forced rollback to slot " <> textShow slotNo
   Right <$> DB.runDbNoLogging (void $ DB.deleteCascadeSlotNo slotNo)

--- a/cardano-db-tool/src/Cardano/Db/Tool/Validate/Ledger.hs
+++ b/cardano-db-tool/src/Cardano/Db/Tool/Validate/Ledger.hs
@@ -34,8 +34,8 @@ data LedgerValidationParams = LedgerValidationParams
 validateLedger :: LedgerValidationParams -> IO ()
 validateLedger params =
   withIOManager $ \ _ -> do
-    enc <- readDbSyncNodeConfig (vpConfigFile params)
-    genCfg <- orDie renderDbSyncNodeError $ readCardanoGenesisConfig enc
+    enc <- readSyncNodeConfig (vpConfigFile params)
+    genCfg <- orDie renderSyncNodeError $ readCardanoGenesisConfig enc
     ledgerFiles <- listLedgerStateFilesOrdered (vpLedgerStateDir params)
     slotNo <- SlotNo <$> DB.runDbNoLogging DB.queryLatestSlotNo
     validate params genCfg slotNo ledgerFiles

--- a/cardano-sync/src/Cardano/Sync/Config/Byron.hs
+++ b/cardano-sync/src/Cardano/Sync/Config/Byron.hs
@@ -17,8 +17,8 @@ import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
 
 readByronGenesisConfig
-        :: DbSyncNodeConfig
-        -> ExceptT DbSyncNodeError IO Byron.Config
+        :: SyncNodeConfig
+        -> ExceptT SyncNodeError IO Byron.Config
 readByronGenesisConfig enc = do
   let file = unGenesisFile $ dncByronGenesisFile enc
   genHash <- firstExceptT NEError

--- a/cardano-sync/src/Cardano/Sync/Config/Cardano.hs
+++ b/cardano-sync/src/Cardano/Sync/Config/Cardano.hs
@@ -39,7 +39,7 @@ import qualified Shelley.Spec.Ledger.PParams as Shelley
 
 -- Usually only one constructor, but may have two when we are preparing for a HFC event.
 data GenesisConfig
-  = GenesisCardano !DbSyncNodeConfig !Byron.Config !ShelleyConfig
+  = GenesisCardano !SyncNodeConfig !Byron.Config !ShelleyConfig
 
 genesisProtocolMagicId :: GenesisConfig -> ProtocolMagicId
 genesisProtocolMagicId ge =
@@ -50,11 +50,11 @@ genesisProtocolMagicId ge =
     shelleyProtocolMagicId sCfg = ProtocolMagicId (sgNetworkMagic sCfg)
 
 readCardanoGenesisConfig
-        :: DbSyncNodeConfig
-        -> ExceptT DbSyncNodeError IO GenesisConfig
+        :: SyncNodeConfig
+        -> ExceptT SyncNodeError IO GenesisConfig
 readCardanoGenesisConfig enc =
   case dncProtocol enc of
-    DbSyncProtocolCardano ->
+    SyncProtocolCardano ->
       GenesisCardano enc <$> readByronGenesisConfig enc <*> readShelleyGenesisConfig enc
 
 -- -------------------------------------------------------------------------------------------------
@@ -108,7 +108,7 @@ mkProtocolCardano ge =
 shelleyPraosNonce :: ShelleyConfig -> Nonce
 shelleyPraosNonce sCfg = Nonce (Crypto.castHash . unGenesisHashShelley $ scGenesisHash sCfg)
 
-shelleyProtVer :: DbSyncNodeConfig -> Shelley.ProtVer
+shelleyProtVer :: SyncNodeConfig -> Shelley.ProtVer
 shelleyProtVer dnc =
   let bver = dncByronProtocolVersion dnc in
   Shelley.ProtVer (fromIntegral $ Byron.pvMajor bver) (fromIntegral $ Byron.pvMinor bver)

--- a/cardano-sync/src/Cardano/Sync/Config/Node.hs
+++ b/cardano-sync/src/Cardano/Sync/Config/Node.hs
@@ -33,7 +33,7 @@ import qualified Ouroboros.Consensus.Cardano as Consensus
 import qualified Ouroboros.Consensus.Cardano.CanHardFork as Shelley
 
 data NodeConfig = NodeConfig
-  { ncProtocol :: !DbSyncProtocol
+  { ncProtocol :: !SyncProtocol
   , ncPBftSignatureThreshold :: !(Maybe Double)
   , ncByronGenesisFile :: !GenesisFile
   , ncByronGenesisHash :: !GenesisHashByron

--- a/cardano-sync/src/Cardano/Sync/Config/Shelley.hs
+++ b/cardano-sync/src/Cardano/Sync/Config/Shelley.hs
@@ -38,8 +38,8 @@ data ShelleyConfig = ShelleyConfig
   }
 
 readShelleyGenesisConfig
-    :: DbSyncNodeConfig
-    -> ExceptT DbSyncNodeError IO ShelleyConfig
+    :: SyncNodeConfig
+    -> ExceptT SyncNodeError IO ShelleyConfig
 readShelleyGenesisConfig enc = do
   let file = unGenesisFile $ dncShelleyGenesisFile enc
   firstExceptT (NEShelleyConfig file . renderShelleyGenesisError)

--- a/cardano-sync/src/Cardano/Sync/Config/Types.hs
+++ b/cardano-sync/src/Cardano/Sync/Config/Types.hs
@@ -12,14 +12,14 @@ module Cardano.Sync.Config.Types
   , CardanoBlock
   , CardanoProtocol
   , ConfigFile (..)
-  , DbSyncCommand (..)
-  , DbSyncNodeParams (..)
-  , DbSyncProtocol (..)
+  , SyncCommand (..)
+  , SyncNodeParams (..)
+  , SyncProtocol (..)
   , GenesisFile (..)
   , GenesisHashShelley (..)
   , GenesisHashByron (..)
-  , DbSyncNodeConfig (..)
-  , DbSyncPreConfig (..)
+  , SyncNodeConfig (..)
+  , SyncPreConfig (..)
   , LedgerStateDir (..)
   , MigrationDir (..)
   , LogFileDir (..)
@@ -86,12 +86,12 @@ newtype ConfigFile = ConfigFile
   { unConfigFile :: FilePath
   }
 
-data DbSyncCommand
-  = CmdRun !DbSyncNodeParams
+data SyncCommand
+  = CmdRun !SyncNodeParams
   | CmdVersion
 
 -- | The product type of all command line arguments
-data DbSyncNodeParams = DbSyncNodeParams
+data SyncNodeParams = SyncNodeParams
   { enpConfigFile :: !ConfigFile
   , enpSocketPath :: !SocketPath
   , enpLedgerStateDir :: !LedgerStateDir
@@ -100,15 +100,15 @@ data DbSyncNodeParams = DbSyncNodeParams
   }
 
 -- May have other constructors when we are preparing for a HFC event.
-data DbSyncProtocol
-  = DbSyncProtocolCardano
+data SyncProtocol
+  = SyncProtocolCardano
   deriving Show
 
-data DbSyncNodeConfig = DbSyncNodeConfig
+data SyncNodeConfig = SyncNodeConfig
   { dncNetworkName :: !NetworkName
   , dncLoggingConfig :: !Logging.Configuration
   , dncNodeConfigFile :: !NodeConfigFile
-  , dncProtocol :: !DbSyncProtocol
+  , dncProtocol :: !SyncProtocol
   , dncRequiresNetworkMagic :: !RequiresNetworkMagic
   , dncEnableLogging :: !Bool
   , dncEnableMetrics :: !Bool
@@ -130,7 +130,7 @@ data DbSyncNodeConfig = DbSyncNodeConfig
   , dncAllegraToMary :: !AllegraToMary
   }
 
-data DbSyncPreConfig = DbSyncPreConfig
+data SyncPreConfig = SyncPreConfig
   { pcNetworkName :: !NetworkName
   , pcLoggingConfig :: !Logging.Representation
   , pcNodeConfigFile :: !NodeConfigFile
@@ -173,18 +173,18 @@ adjustGenesisFilePath f (GenesisFile p) = GenesisFile (f p)
 adjustNodeConfigFilePath :: (FilePath -> FilePath) -> NodeConfigFile -> NodeConfigFile
 adjustNodeConfigFilePath f (NodeConfigFile p) = NodeConfigFile (f p)
 
-pcNodeConfigFilePath :: DbSyncPreConfig -> FilePath
+pcNodeConfigFilePath :: SyncPreConfig -> FilePath
 pcNodeConfigFilePath = unNodeConfigFile . pcNodeConfigFile
 
 -- -------------------------------------------------------------------------------------------------
 
-instance FromJSON DbSyncPreConfig where
+instance FromJSON SyncPreConfig where
   parseJSON o =
-    Aeson.withObject "top-level" parseGenDbSyncNodeConfig o
+    Aeson.withObject "top-level" parseGenSyncNodeConfig o
 
-parseGenDbSyncNodeConfig :: Object -> Parser DbSyncPreConfig
-parseGenDbSyncNodeConfig o =
-  DbSyncPreConfig
+parseGenSyncNodeConfig :: Object -> Parser SyncPreConfig
+parseGenSyncNodeConfig o =
+  SyncPreConfig
     <$> fmap NetworkName (o .: "NetworkName")
     <*> parseJSON (Object o)
     <*> fmap NodeConfigFile (o .: "NodeConfigFile")
@@ -192,8 +192,8 @@ parseGenDbSyncNodeConfig o =
     <*> o .: "EnableLogMetrics"
     <*> fmap (fromMaybe 8080) (o .:? "PrometheusPort")
 
-instance FromJSON DbSyncProtocol where
+instance FromJSON SyncProtocol where
   parseJSON o =
     case o of
-      String "Cardano" -> pure DbSyncProtocolCardano
+      String "Cardano" -> pure SyncProtocolCardano
       x -> typeMismatch "Protocol" x

--- a/cardano-sync/src/Cardano/Sync/Era/Shelley/Generic/EpochUpdate.hs
+++ b/cardano-sync/src/Cardano/Sync/Era/Shelley/Generic/EpochUpdate.hs
@@ -1,5 +1,6 @@
 module Cardano.Sync.Era.Shelley.Generic.EpochUpdate
-  ( EpochUpdate (..)
+  ( NewEpoch (..)
+  , EpochUpdate (..)
   , allegraEpochUpdate
   , maryEpochUpdate
   , shelleyEpochUpdate
@@ -11,12 +12,19 @@ import           Cardano.Sync.Era.Shelley.Generic.StakeDist
 
 import           Data.Maybe (fromMaybe)
 
+import           Ouroboros.Consensus.Block (EpochNo)
 import           Ouroboros.Consensus.Cardano.Block (LedgerState (..), StandardAllegra, StandardMary,
                    StandardShelley)
 import           Ouroboros.Consensus.Cardano.CanHardFork ()
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 
 import qualified Shelley.Spec.Ledger.BaseTypes as Shelley
+
+data NewEpoch = NewEpoch
+  { epoch :: !EpochNo
+  , isEBB :: !Bool
+  , epochUpdate :: !(Maybe EpochUpdate)
+  }
 
 data EpochUpdate = EpochUpdate
   { euProtoParams :: !ProtoParams

--- a/cardano-sync/src/Cardano/Sync/Plugin.hs
+++ b/cardano-sync/src/Cardano/Sync/Plugin.hs
@@ -1,5 +1,5 @@
 module Cardano.Sync.Plugin
-  ( DbSyncNodePlugin (..)
+  ( SyncNodePlugin (..)
   ) where
 
 import           Cardano.BM.Trace (Trace)
@@ -15,7 +15,7 @@ import           Cardano.Sync.Types
 -- actions on a block insert or rollback.
 --
 -- The insert and rollback actions are applied from the head of the list to the tail.
--- THe default DbSyncNodePlugin is 'Cardano.Sync.Plugin.Default.defDbSyncNodePlugin'. This
+-- The default SyncNodePlugin is 'defDbSyncNodePlugin'. This
 -- allows clients to insert db actions both before and after the default action.
 
 -- Plugins are free to read from the existing tables but should not modify them. Plugins however
@@ -28,16 +28,16 @@ import           Cardano.Sync.Types
 
 -- TODO(KS): If required, we can unfiy the plugin system to be sequence based, rather then list based.
 -- We can switch the types to be like the `plugInsertBlock`, not lists.
-data DbSyncNodePlugin = DbSyncNodePlugin
+data SyncNodePlugin = SyncNodePlugin
   { -- A function run each time the application starts. Can be used to do a one time update/setup
     -- of a table.
-    plugOnStartup :: [Trace IO Text -> IO (Either DbSyncNodeError ())]
+    plugOnStartup :: [Trace IO Text -> IO (Either SyncNodeError ())]
     -- Called for each block recieved from the network.
     -- This will not be called for the original genesis block, but will be called for
     -- all subsequent blocks.
     -- Blocks (including epoch boundary blocks) are called in sequence from the oldest to the newest.
-  , plugInsertBlock :: [Trace IO Text -> DbSyncEnv -> [BlockDetails] -> IO (Either DbSyncNodeError ())]
+  , plugInsertBlock :: [Trace IO Text -> SyncEnv -> [BlockDetails] -> IO (Either SyncNodeError ())]
 
     -- Rollback to the specified Point.
-  , plugRollbackBlock :: [Trace IO Text -> CardanoPoint -> IO (Either DbSyncNodeError ())]
+  , plugRollbackBlock :: [Trace IO Text -> CardanoPoint -> IO (Either SyncNodeError ())]
   }

--- a/cardano-sync/src/Cardano/Sync/StateQuery.hs
+++ b/cardano-sync/src/Cardano/Sync/StateQuery.hs
@@ -65,7 +65,7 @@ newStateQueryTMVar = StateQueryTMVar <$> newEmptyTMVarIO
 -- If the history interpreter does not exist, get one.
 -- If the existing history interpreter returns an error, get a new one and try again.
 getSlotDetails
-    :: Trace IO Text -> DbSyncEnv
+    :: Trace IO Text -> SyncEnv
     -> StateQueryTMVar (HardForkBlock (CardanoEras StandardCrypto)) (Interpreter (CardanoEras StandardCrypto))
     -> SlotNo
     -> IO SlotDetails


### PR DESCRIPTION
Fix for https://github.com/input-output-hk/cardano-db-sync/issues/511
Will become relevant after https://github.com/input-output-hk/cardano-db-sync/pull/520 is merged

We keep 2 additional older ledger snapshots: the last 2 epoch boundaries. Their filenames are <slot>-<hash>-epoch.lstate to distinguish them from other ledger snapshots which we only keep 8 of.