### PR TITLE
fixed: Fail to run migration if postgresql port number is not default (5432)

### DIFF
--- a/cardano-db/src/Cardano/Db/Migration.hs
+++ b/cardano-db/src/Cardano/Db/Migration.hs
@@ -86,6 +86,7 @@ applyMigration quiet pgconfig mLogFilename logHandle (version, script) = do
             , "--quiet"
             , "--username=" <> BS.unpack (pgcUser pgconfig)
             , "--host=" <> BS.unpack (pgcHost pgconfig)
+            , "--port=" <> BS.unpack (pgcPort pgconfig)
             , "--no-psqlrc"                     -- Ignore the ~/.psqlrc file.
             , "--single-transaction"            -- Run the file as a transaction.
             , "--set ON_ERROR_STOP=on"          -- Exit with non-zero on error.


### PR DESCRIPTION
## Expected Behavior

PGPASSFILE file should be able to use port number other than default.

## Current Behavior

Change PGPASSFILE connection string, port number to anything other than default (5432). The application still reference to default port number.

## To reproduce
_config/pgpass-mainnet_
`/var/run/postgresql:5432:cexplorer:*:*`

change to :
`host:<port number other than 5432>:db:username:password`


then execute:
```
PGPASSFILE=config/pgpass-mainnet db-sync-node/bin/cardano-db-sync \
    --config config/mainnet-config.yaml \
    --socket-path ../cardano-node/state-node-mainnet/node.socket \
    --state-dir ledger-state/mainnet \
    --schema-dir schema/

```
