### PR TITLE
[CAD-2060] Adding a SMASH executable alongside db-sync.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -137,8 +137,8 @@ jobs:
           cache-cabal-store-v1-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
           cache-cabal-store-v1-${{ runner.os }}-${{ matrix.ghc }}-
 
-    - name: Build dependencies
-      run: cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies
+          #    - name: Build dependencies
+          #      run: cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies
 
     - name: Build
       run: cabal build all --builddir="$CABAL_BUILDDIR"

--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,7 @@ packages:
   cardano-db/test
   cardano-db-sync
   cardano-db-sync-extended
+  cardano-db-sync-smash
   cardano-db-tool
   cardano-sync
 
@@ -23,6 +24,9 @@ package cardano-db-sync
   ghc-options: -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wunused-imports -Wunused-packages
 
 package cardano-db-sync-extended
+  ghc-options: -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wunused-imports -Wunused-packages
+
+package cardano-db-sync-smash
   ghc-options: -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wunused-imports -Wunused-packages
 
 package cardano-sync
@@ -170,6 +174,16 @@ source-repository-package
     plutus-tx
     prettyprinter-configurable
 
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/smash
+  tag: 4caf5c150f0dd8c024898cf15ca59bdbd896f810
+  --sha256: 1550rxlmg32vza5agndlph89b45g4a42dxkvrq3qkqxs2jdaf7in
+  subdir:
+    smash
+    smash-servant-types
+
 allow-newer:
   monoidal-containers:aeson,
   size-based:template-haskell
+

--- a/cardano-db-sync-smash/CHANGELOG.md
+++ b/cardano-db-sync-smash/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for cardano-db-sync-smash
+
+## 8.0.0
+* Initial release.
+

--- a/cardano-db-sync-smash/LICENSE
+++ b/cardano-db-sync-smash/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cardano-db-sync-smash/NOTICE
+++ b/cardano-db-sync-smash/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2019-2020 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cardano-db-sync-smash/Setup.hs
+++ b/cardano-db-sync-smash/Setup.hs
@@ -1,0 +1,2 @@
+import           Distribution.Simple
+main = defaultMain

--- a/cardano-db-sync-smash/app/cardano-db-sync-smash.hs
+++ b/cardano-db-sync-smash/app/cardano-db-sync-smash.hs
@@ -1,0 +1,164 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import           Cardano.Prelude
+
+import           Cardano.Config.Git.Rev (gitRev)
+
+import qualified Cardano.SMASH.DB as DB
+import           Cardano.SMASH.Lib (defaultConfiguration, runApp)
+
+import           Cardano.DbSync (ConfigFile (..), LedgerStateDir (..), SocketPath (..),
+                   SyncNodeParams (..), runDbSyncNode)
+import           Cardano.DbSync.Metrics (withMetricSetters)
+import           Cardano.DbSync.Plugin.Smash (smashExtendedDbSyncNodePlugin)
+
+import           Cardano.Sync.Config (configureLogging, dncPrometheusPort, readSyncNodeConfig)
+import           Cardano.Sync.Config.Types (MigrationDir (..))
+
+import           Cardano.Slotting.Slot (SlotNo (..))
+
+import           Data.String (String)
+import qualified Data.Text as Text
+import           Data.Version (showVersion)
+
+import           Options.Applicative (Parser, ParserInfo)
+import qualified Options.Applicative as Opt
+
+import           Paths_cardano_db_sync_smash (version)
+
+import           System.Info (arch, compilerName, compilerVersion, os)
+
+main :: IO ()
+main = do
+  cmd <- Opt.execParser opts
+  case cmd of
+    CmdVersion -> runVersionCommand
+    CmdRun params smashMigrationDir -> do
+        prometheusPort <- dncPrometheusPort <$> readSyncNodeConfig (enpConfigFile params)
+
+        smashTracer <- configureLogging params "smash"
+
+        DB.runMigrations smashTracer identity smashMigrationDir (Just $ DB.SmashLogFileDir "/tmp")
+
+        let smashDataLayer = DB.postgresqlDataLayer (Just smashTracer)
+        let smashPlugin = smashExtendedDbSyncNodePlugin smashDataLayer
+
+        race_
+            (runApp smashDataLayer defaultConfiguration)
+            (withMetricSetters prometheusPort $ \metricsSetters -> runDbSyncNode metricsSetters smashPlugin params)
+
+---------------------------------------------------------------------------------------------------
+
+data SmashSyncCommand
+  = CmdRun !SyncNodeParams !DB.SmashMigrationDir
+  | CmdVersion
+
+---------------------------------------------------------------------------------------------------
+
+opts :: ParserInfo SmashSyncCommand
+opts =
+  Opt.info (pCommandLine <**> Opt.helper)
+    ( Opt.fullDesc
+    <> Opt.progDesc "SMASH Cardano POstgreSQL sync node."
+    )
+
+pCommandLine :: Parser SmashSyncCommand
+pCommandLine =
+  asum
+    [ pVersionCommand
+    , CmdRun <$> pRunDbSyncNode <*> pSmashMigrationDir
+    ]
+
+pSmashMigrationDir :: Parser DB.SmashMigrationDir
+pSmashMigrationDir =
+  DB.SmashMigrationDir <$> Opt.strOption
+    ( Opt.long "smash-migration-dir"
+    <> Opt.help "Path to the smash schema migrations folder"
+    <> Opt.completer (Opt.bashCompleter "file")
+    <> Opt.metavar "FILEPATH"
+    )
+
+pRunDbSyncNode :: Parser SyncNodeParams
+pRunDbSyncNode =
+  SyncNodeParams
+    <$> pConfigFile
+    <*> pSocketPath
+    <*> pLedgerStateDir
+    <*> pMigrationDir
+    <*> optional pSlotNo
+
+pConfigFile :: Parser ConfigFile
+pConfigFile =
+  ConfigFile <$> Opt.strOption
+    ( Opt.long "config"
+    <> Opt.help "Path to the db-sync node config file"
+    <> Opt.completer (Opt.bashCompleter "file")
+    <> Opt.metavar "FILEPATH"
+    )
+
+pLedgerStateDir :: Parser LedgerStateDir
+pLedgerStateDir =
+  LedgerStateDir <$> Opt.strOption
+    (  Opt.long "state-dir"
+    <> Opt.help "The directory for persistung ledger state."
+    <> Opt.completer (Opt.bashCompleter "directory")
+    <> Opt.metavar "FILEPATH"
+    )
+
+pMigrationDir :: Parser MigrationDir
+pMigrationDir =
+  MigrationDir <$> Opt.strOption
+    (  Opt.long "schema-dir"
+    <> Opt.help "The directory containing the migrations."
+    <> Opt.completer (Opt.bashCompleter "directory")
+    <> Opt.metavar "FILEPATH"
+    )
+
+pSocketPath :: Parser SocketPath
+pSocketPath =
+  SocketPath <$> Opt.strOption
+    ( Opt.long "socket-path"
+    <> Opt.help "Path to a cardano-node socket"
+    <> Opt.completer (Opt.bashCompleter "file")
+    <> Opt.metavar "FILEPATH"
+    )
+
+pSlotNo :: Parser SlotNo
+pSlotNo =
+  SlotNo <$> Opt.option Opt.auto
+    (  Opt.long "rollback-to-slot"
+    <> Opt.help "Force a rollback to the specified slot (mainly for testing and debugging)."
+    <> Opt.metavar "WORD"
+    )
+
+pVersionCommand :: Parser SmashSyncCommand
+pVersionCommand =
+  asum
+    [ Opt.subparser
+        ( mconcat
+          [ command' "version" "Show the program version" (pure CmdVersion) ]
+        )
+    , Opt.flag' CmdVersion
+        (  Opt.long "version"
+        <> Opt.help "Show the program version"
+        <> Opt.hidden
+        )
+    ]
+
+command' :: String -> String -> Parser a -> Opt.Mod Opt.CommandFields a
+command' c descr p =
+  Opt.command c
+    $ Opt.info (p <**> Opt.helper)
+    $ mconcat [ Opt.progDesc descr ]
+
+runVersionCommand :: IO ()
+runVersionCommand = do
+    liftIO . putTextLn $ mconcat
+                [ "cardano-db-sync-extended ", renderVersion version
+                , " - ", Text.pack os, "-", Text.pack arch
+                , " - ", Text.pack compilerName, "-", renderVersion compilerVersion
+                , "\ngit revision ", gitRev
+                ]
+  where
+    renderVersion = Text.pack . showVersion

--- a/cardano-db-sync-smash/cardano-db-sync-smash.cabal
+++ b/cardano-db-sync-smash/cardano-db-sync-smash.cabal
@@ -1,0 +1,69 @@
+cabal-version:          2.2
+
+-- http://haskell.org/cabal/users-guide/
+
+name:                   cardano-db-sync-smash
+version:                8.0.0
+synopsis:               The SMASH Cardano DB Sync node
+description:            A Cardano node that follows the Cardano chain and inserts data from the
+                        chain into a PostgresQL database. It also contains the SMASH module inside.
+homepage:               https://github.com/input-output-hk/cardano-db-sync
+bug-reports:            https://github.com/input-output-hk/cardano-db-sync/issues
+license:                Apache-2.0
+license-file:           LICENSE
+author:                 IOHK Engineering Team
+maintainer:             operations@iohk.io
+copyright:              (c) 2019 IOHK
+category:               Cryptocurrency
+build-type:             Simple
+extra-source-files:     CHANGELOG.md
+
+library
+  default-language:     Haskell2010
+  hs-source-dirs:       src
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wredundant-constraints
+                        -Wincomplete-patterns
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wunused-imports
+                        -Wunused-packages
+
+  exposed-modules:      Cardano.DbSync.Plugin.Smash
+
+  build-depends:        base                            >= 4.12         && < 4.15
+                      , cardano-db-sync
+                      , cardano-sync
+                      , smash
+                      , persistent
+
+executable cardano-db-sync-smash
+  default-language:     Haskell2010
+  main-is:              cardano-db-sync-smash.hs
+  hs-source-dirs:       app
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wredundant-constraints
+                        -Wincomplete-patterns
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wunused-imports
+                        -Wunused-packages
+                        -Wno-unsafe
+                        -threaded
+
+  other-modules:        Paths_cardano_db_sync_smash
+
+  build-depends:        base                            >= 4.12         && < 4.15
+                      , cardano-config
+                      , cardano-db-sync
+                      , cardano-db-sync-smash
+                      , cardano-sync
+                      , smash
+                      , cardano-prelude
+                      , cardano-slotting
+                      , optparse-applicative
+                      , text

--- a/cardano-db-sync-smash/src/Cardano/DbSync/Plugin/Smash.hs
+++ b/cardano-db-sync-smash/src/Cardano/DbSync/Plugin/Smash.hs
@@ -1,0 +1,30 @@
+module Cardano.DbSync.Plugin.Smash
+  ( smashExtendedDbSyncNodePlugin
+  ) where
+
+import           Cardano.DbSync.Plugin.Default (defDbSyncNodePlugin)
+import           Cardano.DbSync.Plugin.Epoch (epochPluginInsertBlock, epochPluginOnStartup,
+                   epochPluginRollbackBlock)
+
+import           Cardano.SMASH.DB (DataLayer)
+import           Cardano.SMASH.DBSyncPlugin (poolMetadataDbSyncNodePlugin)
+
+import           Cardano.Sync (SyncNodePlugin (..))
+
+import           Database.Persist.Sql (SqlBackend)
+
+smashExtendedDbSyncNodePlugin :: DataLayer -> SqlBackend -> SyncNodePlugin
+smashExtendedDbSyncNodePlugin dataLayer backend =
+  let defPlugin = defDbSyncNodePlugin backend
+      smashPlugin = poolMetadataDbSyncNodePlugin dataLayer
+  in  defPlugin
+        { plugOnStartup =
+            plugOnStartup defPlugin
+              ++ [epochPluginOnStartup backend] ++ plugOnStartup smashPlugin
+        , plugInsertBlock =
+            plugInsertBlock defPlugin
+                ++ [epochPluginInsertBlock backend] ++ plugInsertBlock smashPlugin
+        , plugRollbackBlock =
+            plugRollbackBlock defPlugin
+              ++ [epochPluginRollbackBlock] ++ plugRollbackBlock smashPlugin
+        }

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -126,6 +126,7 @@ let
         # systemd can't be statically linked
         packages.cardano-config.flags.systemd = !pkgs.stdenv.hostPlatform.isMusl;
         packages.cardano-node.flags.systemd = !pkgs.stdenv.hostPlatform.isMusl;
+        packages.smash.flags.systemd = !pkgs.stdenv.hostPlatform.isMusl;
       })
     ];
   };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "43cb0fc8957be7ab027f8bd5d48bc22479032c1f",
-        "sha256": "0m7h9y3rwdgnwmcyjlkrzf8pf1jbrymvxfc5lmzv0i832r1nc318",
+        "rev": "72beef11fc6ec32a98f1dd0d4dcd072c89595b43",
+        "sha256": "0ckgssxp43iayp2qn4wf0f06hlfmqwwqvfmak836a7niznj8xz0s",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/43cb0fc8957be7ab027f8bd5d48bc22479032c1f.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/72beef11fc6ec32a98f1dd0d4dcd072c89595b43.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "5b86d63a0b59b7666d19901b654d8fbde27d9500",
-        "sha256": "1mfb93nnw0x4gyq93v6lh6h7imliw4j0wp5l9gpdafy3rw621xzb",
+        "rev": "bc4216c5b0e14dbde5541763f4952f99c3c712fa",
+        "sha256": "0y5n3limj5dg1vgxyxafg0ky35qq7w97rr00gr3yl16xx5jrhs6w",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/5b86d63a0b59b7666d19901b654d8fbde27d9500.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/bc4216c5b0e14dbde5541763f4952f99c3c712fa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/release.nix
+++ b/release.nix
@@ -71,8 +71,9 @@ let
     ["checks" "hlint"] ["checks" "stylish-haskell"] ["dockerImage"]
   ];
   # Paths or prefix of paths for which musl64 are disabled:
-  noMusl64Build = [ ["shell"] ["checks"] ["tests"] ["benchmarks"] ["haskellPackages"] ["roots"] ["plan-nix"] ]
-    ++ onlyBuildOnDefaultSystem;
+  noMusl64Build = [ ["shell"] ["checks"] ["tests"] ["benchmarks"] ["haskellPackages"] ["roots"] ["plan-nix"]
+    [ "haskellPackages" "cardano-db-sync-smash" ] [ "exes" "cardano-db-sync-smash" ]
+  ] ++ onlyBuildOnDefaultSystem;
 
   # Remove build jobs for which cross compiling does not make sense.
   filterProject = noBuildList: mapAttrsRecursiveCond (a: !(isDerivation a)) (path: value:


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-2060

The added executable that allows SMASH to be run alongside `db-sync`.

Synced up to `Mary` on `mainnet`.
Two things still missing:
- re-fetching of the unavailable metadata, but that can be added easily after we fix the release of `smash`
- fetching of the unique tickers (it was added recently), but we need to create a new release of `smash` and deploy that

Disabled the Github Cabal building only dependencies, because of an issue I run into - https://github.com/input-output-hk/cardano-db-sync/pull/551/files#diff-c09cc8dc973415b1221308559b96942a1c4b872e690bf360fc22d9b42822d519R140

