### PR TITLE
Remove owner from snapshot

### DIFF
--- a/scripts/postgresql-setup.sh
+++ b/scripts/postgresql-setup.sh
@@ -126,7 +126,7 @@ function create_snapshot {
 	ledger_file=$2
 	tmp_dir=$(mktemp --directory -t db-sync-snapshot-XXXXXXXXXX)
 	echo $"Working directory: ${tmp_dir}"
-	pg_dump "${databasename}" > "${tmp_dir}/$1.sql"
+	pg_dump --no-owner "${databasename}" > "${tmp_dir}/$1.sql"
 	cp "$ledger_file" "$tmp_dir/$(basename "${ledger_file}")"
 	tar zcvf "${tgz_file}" --directory "${tmp_dir}" "${dbfile}" "$(basename "${ledger_file}")"
 	rm -rf "${tmp_dir}"


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-db-sync/issues/636

Without the `--no-owner` flag the db dump includes command like
```
--
-- Name: asset32type; Type: DOMAIN; Schema: public; Owner: nix
--

ALTER DOMAIN public.asset32type OWNER TO nix;

```
because it tries to create the same db with the same owners. The flag removes this command and changes the comment. 

```
--
-- Name: asset32type; Type: DOMAIN; Schema: public; Owner: -
--

```
