### PR TITLE
Make sure we never keep more than 1 ledger state in memory

### DIFF
--- a/cardano-sync/src/Cardano/Sync/Api.hs
+++ b/cardano-sync/src/Cardano/Sync/Api.hs
@@ -55,8 +55,7 @@ data SyncDataLayer = SyncDataLayer
 
 mkSyncEnv :: SyncDataLayer -> ProtocolInfo IO CardanoBlock -> Ledger.Network -> NetworkMagic -> SystemStart -> LedgerStateDir -> IO SyncEnv
 mkSyncEnv dataLayer protocolInfo network networkMagic systemStart dir = do
-  latestSlot <- sdlGetLatestSlotNo dataLayer
-  ledgerEnv <- mkLedgerEnv protocolInfo dir network latestSlot True
+  ledgerEnv <- mkLedgerEnv protocolInfo dir network
   pure $ SyncEnv
           { envProtocol = SyncProtocolCardano
           , envNetworkMagic = networkMagic

--- a/cardano-sync/src/Cardano/Sync/LedgerState.hs
+++ b/cardano-sync/src/Cardano/Sync/LedgerState.hs
@@ -174,10 +174,9 @@ data LedgerStateSnapshot = LedgerStateSnapshot
   , lssEvents :: ![LedgerEvent]
   }
 
-mkLedgerEnv :: Consensus.ProtocolInfo IO CardanoBlock
-            -> LedgerStateDir
-            -> Ledger.Network
-            -> IO LedgerEnv
+mkLedgerEnv
+    :: Consensus.ProtocolInfo IO CardanoBlock -> LedgerStateDir -> Ledger.Network
+    -> IO LedgerEnv
 mkLedgerEnv protocolInfo dir network = do
     svar <- newTVarIO Nothing
     evar <- newTVarIO initLedgerEventState
@@ -439,6 +438,10 @@ cleanupLedgerStateFiles env slotNo = do
 
 loadLedgerAtPoint :: LedgerEnv -> CardanoPoint -> Bool -> IO (Either [LedgerStateFile] CardanoLedgerState)
 loadLedgerAtPoint env point delFiles = do
+    -- Ledger states are growing to become very big in memory.
+    -- Before parsing the new ledger state we need to make sure the old ledger state
+    -- is or can be garbage collected.
+    writeLedgerState env Nothing
     mst <- findStateFromPoint env point delFiles
     case mst of
       Right st -> do

--- a/cardano-sync/src/Cardano/Sync/LedgerState.hs
+++ b/cardano-sync/src/Cardano/Sync/LedgerState.hs
@@ -99,6 +99,8 @@ import qualified Shelley.Spec.Ledger.UTxO as Shelley
 
 import           System.Directory (listDirectory, removeFile)
 import           System.FilePath (dropExtension, takeExtension, (</>))
+import           System.Mem (performMajorGC)
+
 
 -- Note: The decision on whether a ledger-state is written to disk is based on the block number
 -- rather than the slot number because while the block number is fully populated (for every block
@@ -442,6 +444,7 @@ loadLedgerAtPoint env point delFiles = do
     -- Before parsing the new ledger state we need to make sure the old ledger state
     -- is or can be garbage collected.
     writeLedgerState env Nothing
+    performMajorGC
     mst <- findStateFromPoint env point delFiles
     case mst of
       Right st -> do


### PR DESCRIPTION
Ledger states have grown to take a lot of memory and we must be very careful with handling them. On rollbacks, db-sync parses a new ledger state from a file. We have to make sure that we don't keep a pointer to the old ledger state while parsing the new ledger state or this can cause big memory spikes.

Rollbacks also happen on startups. We have fixed startups in a slightly different way. Since the first message is always a `MsgRollBackward` we don't parse any ledger state before this message.

![spike](https://user-images.githubusercontent.com/11467473/121408607-44ec0680-c969-11eb-83f4-38989aafab2c.png)

After the fix the spike disappears:
![no-spike](https://user-images.githubusercontent.com/11467473/121409398-21758b80-c96a-11eb-9d34-1b1de94a080d.png)

