### PR TITLE
Bulk insert optimisation

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs
@@ -40,7 +40,7 @@ import           Data.List.Split.Internals (chunksOf)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
-import           Database.Persist.Sql (SqlBackend, putMany)
+import           Database.Persist.Sql (SqlBackend)
 
 import           Ouroboros.Consensus.Cardano.Block (StandardCrypto)
 
@@ -118,7 +118,7 @@ insertEpochStake
     -> ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertEpochStake _tracer icache epochNo stakeChunk = do
     dbStakes <- mapM mkStake stakeChunk
-    lift $ putMany dbStakes
+    lift $ DB.insertManyEpochStakes dbStakes
   where
     mkStake
         :: MonadBaseControl IO m
@@ -141,7 +141,7 @@ insertRewards
     -> ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertRewards epoch icache rewardsChunk = do
     dbRewards <- concatMapM mkRewards rewardsChunk
-    lift $ putMany dbRewards
+    lift $ DB.insertManyRewards dbRewards
   where
     mkRewards
         :: MonadBaseControl IO m
@@ -165,7 +165,7 @@ insertOrphanedRewards
     -> ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertOrphanedRewards epoch icache orphanedRewardsChunk = do
     dbRewards <- concatMapM mkOrphanedReward orphanedRewardsChunk
-    lift $ putMany dbRewards
+    lift $ DB.insertManyOrphanedRewards dbRewards
   where
     mkOrphanedReward
         :: MonadBaseControl IO m


### PR DESCRIPTION
We use `putMany` utility from persistent to insert stakes and rewards in chunks of 1000. Before inserting, persistent uses nubBy to check that there are no duplicated values https://github.com/yesodweb/persistent/blob/master/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs#L70. For us this is an unnecessary sanity check, which profiling shows that it causes huge delays (see `persistUniqueKeyValues` below). 

```
	Tue Jun  8 03:11 2021 Time and Allocation Profiling Report  (Final)

	   cardano-db-sync-extended +RTS -N3 -p -hc -l-agu -i1 -RTS --config /home/kostas/programming/database-paths/configuration/mainnet/mainnet-db-sync-config.json --socket-path ../../../cardano-node/node.socket --state-dir ledger-state/prof-4 --schema-dir schema

	total time  =       32.58 secs   (97740 ticks @ 1000 us, 3 processors)
	total alloc = 223,470,076,976 bytes  (excludes profiling overheads)

COST CENTRE                      MODULE                                  SRC                                                              %time %alloc

persistUniqueKeyValues           Database.Persist.Class.PersistUnique    Database/Persist/Class/PersistUnique.hs:698:1-76                  32.0   67.0
insertEpochStake                 Cardano.DbSync.Era.Shelley.Insert.Epoch src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs:(119,1)-(136,11)   14.4    0.3
matchSize                        Cardano.Binary.FromCBOR                 src/Cardano/Binary/FromCBOR.hs:(128,1)-(132,14)                    3.1    2.5
deserialiseIncremental           Codec.CBOR.Read                         src/Codec/CBOR/Read.hs:(170,1)-(172,46)                            2.4    1.7
decodeRecordNamed                Data.Coders                             src/Data/Coders.hs:(147,1)-(155,8)                                 2.4    2.8
decodeRecordSum                  Data.Coders                             src/Data/Coders.hs:(158,1)-(167,8)                                 2.2    3.7
addBack                          Control.Iterate.SetAlgebra              src/Control/Iterate/SetAlgebra.hs:197:1-68                         2.1    0.4
decodeCollectionWithLen          Data.Coders                             src/Data/Coders.hs:(231,1)-(239,73)                                2.0    1.6
toRawSql                         Database.Esqueleto.Internal.Internal    src/Database/Esqueleto/Internal/Internal.hs:(2700,1)-(2732,9)      1.9    0.7
connEscapeRawName                Database.Persist.Sql.Types.Internal     Database/Persist/Sql/Types/Internal.hs:160:7-23                    1.7    2.0
exec                             Database.PostgreSQL.LibPQ               src/Database/PostgreSQL/LibPQ.hsc:(769,1)-(771,41)                 1.4    0.1
escapeByteaConn                  Database.PostgreSQL.LibPQ               src/Database/PostgreSQL/LibPQ.hsc:(1474,1)-(1483,88)               1.4    0.1
escapeStringConn                 Database.PostgreSQL.LibPQ               src/Database/PostgreSQL/LibPQ.hsc:(1455,1)-(1465,29)               1.3    0.0
connPrepare                      Database.Persist.Sql.Types.Internal     Database/Persist/Sql/Types/Internal.hs:94:7-17                     1.3    0.4
toByteString                     Database.PostgreSQL.Simple.Compat       src/Database/PostgreSQL/Simple/Compat.hs:73:1-46                   0.6    1.1
fromCompactRedeemVerificationKey Cardano.Crypto.Signing.Redeem.Compact   src/Cardano/Crypto/Signing/Redeem/Compact.hs:(105,1)-(110,46)      0.1    1.1
```

This pr adds a custom insert function without this check.

Draft because I'm still running tests. This is a single commit on top of https://github.com/input-output-hk/cardano-db-sync/pull/639