### PR TITLE
Fix deleting during rollback

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Default.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Default.hs
@@ -4,7 +4,7 @@
 module Cardano.DbSync.Plugin.Default
   ( defDbSyncNodePlugin
   , insertDefaultBlock
-  , rollbackToSlot
+  , rollbackToPoint
   ) where
 
 
@@ -19,7 +19,7 @@ import           Cardano.DbSync.Era.Cardano.Insert (insertEpochSyncTime)
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import           Cardano.DbSync.Era.Shelley.Insert (insertShelleyBlock, postEpochRewards,
                    postEpochStake)
-import           Cardano.DbSync.Rollback (rollbackToSlot)
+import           Cardano.DbSync.Rollback (rollbackToPoint)
 
 import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..))
 
@@ -51,7 +51,7 @@ defDbSyncNodePlugin backend =
   SyncNodePlugin
     { plugOnStartup = []
     , plugInsertBlock = [insertDefaultBlock backend]
-    , plugRollbackBlock = [rollbackToSlot backend]
+    , plugRollbackBlock = [rollbackToPoint backend]
     }
 
 -- -------------------------------------------------------------------------------------------------

--- a/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
@@ -1,16 +1,20 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 module Cardano.DbSync.Rollback
-  ( rollbackToSlot
+  ( rollbackToPoint
   , unsafeRollback
   ) where
 
 import           Cardano.Prelude
+import qualified Data.ByteString.Short as BSS
 
 import           Cardano.BM.Trace (Trace, logInfo)
 
 import qualified Cardano.Db as DB
+
+import           Cardano.DbSync.Era.Util
 
 import           Cardano.Sync.Error
 import           Cardano.Sync.Types
@@ -19,14 +23,15 @@ import           Cardano.Sync.Util
 import           Database.Persist.Sql (SqlBackend)
 
 import           Ouroboros.Consensus.Block.Abstract (ConvertRawHash (..))
+import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (getOneEraHash)
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Point
 
 -- Rollbacks are done in an Era generic way based on the 'Point' we are
 -- rolling back to.
-rollbackToSlot :: SqlBackend -> Trace IO Text -> CardanoPoint -> IO (Either SyncNodeError ())
-rollbackToSlot backend trce point =
+rollbackToPoint :: SqlBackend -> Trace IO Text -> CardanoPoint -> IO (Either SyncNodeError ())
+rollbackToPoint backend trce point =
     DB.runDbIohkNoLogging backend $ runExceptT action
   where
     action :: MonadIO m => ExceptT SyncNodeError (ReaderT SqlBackend m) ()
@@ -42,9 +47,21 @@ rollbackToSlot backend trce point =
                 ]
           mapM_ (lift . DB.deleteCascadeSlotNo) xs
           liftIO $ logInfo trce "Slots deleted"
+        -- Deleting by slot does not guarantee that all blocks will be deleted,
+        -- because EBBS don't have a slot. In practice most EBBS are still
+        -- deleted because their previous block is deleted and deletes are cascaded.
+        -- However the previous block won't be deleted if it's the point we
+        -- actually roll back to. To catch this case we need to manually delete
+        -- the block right after the block we roll back to.
+        prevId <- liftLookupFail "rollbackToPoint" $ rollbackToId point
+        void $ lift $ DB.deleteCascadeAfter prevId
 
     slotsToDelete Origin = DB.querySlotNos
     slotsToDelete (At sl) = DB.querySlotNosGreaterThan (unSlotNo sl)
+
+    rollbackToId pnt = case getPoint pnt of
+      Origin -> DB.queryGenesis
+      At blk -> DB.queryBlockId (BSS.fromShort $ getOneEraHash $ blockPointHash blk)
 
     msg :: Text
     msg = case getPoint point of

--- a/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
@@ -20,6 +20,7 @@ import           Cardano.Sync.Error
 import           Cardano.Sync.Types
 import           Cardano.Sync.Util
 
+import qualified Data.List as List
 import           Database.Persist.Sql (SqlBackend)
 
 import           Ouroboros.Consensus.Block.Abstract (ConvertRawHash (..))
@@ -38,40 +39,44 @@ rollbackToPoint backend trce point =
     action = do
         liftIO $ logInfo trce msg
         xs <- lift $ slotsToDelete (pointSlot point)
-        if null xs then
-          liftIO $ logInfo trce "No Rollback is necessary"
-        else do
+        unless (null xs) $
+          -- there may be more deleted blocks than slots, because ebbs don't have
+          -- a slot. We can only make an estimation here.
           liftIO . logInfo trce $
               mconcat
-                [ "Deleting ", textShow (length xs), " slots: ", renderSlotList xs
+                [ "Deleting ", textShow (length xs), " blocks up to slot "
+                , textShow (unSlotNo $ List.head xs)
                 ]
-          mapM_ (lift . DB.deleteCascadeSlotNo) xs
-          liftIO $ logInfo trce "Slots deleted"
-        -- Deleting by slot does not guarantee that all blocks will be deleted,
-        -- because EBBS don't have a slot. In practice most EBBS are still
-        -- deleted because their previous block is deleted and deletes are cascaded.
-        -- However the previous block won't be deleted if it's the point we
-        -- actually roll back to. To catch this case we need to manually delete
-        -- the block right after the block we roll back to.
-        prevId <- liftLookupFail "rollbackToPoint" $ rollbackToId point
-        void $ lift $ DB.deleteCascadeAfter prevId
+        -- We delete the block right after the point we rollback to. This delete
+        -- should cascade to the rest of the chain.
+        prevId <- liftLookupFail "Rollback.rollbackToPoint" $ queryBlockId point
+        deleted <- lift $ DB.deleteCascadeAfter prevId
+        liftIO . logInfo trce $
+                    if deleted
+                      then "Blocks deleted"
+                      else "No blocks need to be deleted"
 
-    slotsToDelete Origin = DB.querySlotNos
-    slotsToDelete (At sl) = DB.querySlotNosGreaterThan (unSlotNo sl)
+    slotsToDelete :: MonadIO m => WithOrigin SlotNo -> ReaderT SqlBackend m [SlotNo]
+    slotsToDelete wosl =
+      case wosl of
+        Origin -> DB.querySlotNos
+        At sl -> DB.querySlotNosGreaterThan (unSlotNo sl)
 
-    rollbackToId pnt = case getPoint pnt of
-      Origin -> DB.queryGenesis
-      At blk -> DB.queryBlockId (BSS.fromShort $ getOneEraHash $ blockPointHash blk)
+    queryBlockId :: MonadIO m => Point CardanoBlock -> ReaderT SqlBackend m (Either DB.LookupFail DB.BlockId)
+    queryBlockId pnt =
+      case getPoint pnt of
+        Origin -> DB.queryGenesis
+        At blk -> DB.queryBlockId (BSS.fromShort . getOneEraHash $ blockPointHash blk)
 
     msg :: Text
-    msg = case getPoint point of
-            Origin -> "Rolling back to genesis"
-            At blk -> mconcat
-                  [ "Rolling back to "
-                  , textShow (unSlotNo $ blockPointSlot blk)
-                  , ", hash "
-                  , renderByteArray $ toRawHash (Proxy @CardanoBlock) $ blockPointHash blk
-                  ]
+    msg =
+      case getPoint point of
+        Origin -> "Rolling back to genesis"
+        At blk ->
+          mconcat
+            [ "Rolling back to ", textShow (unSlotNo $ blockPointSlot blk), ", hash "
+            , renderByteArray $ toRawHash (Proxy @CardanoBlock) (blockPointHash blk)
+            ]
 
 -- For testing and debugging.
 unsafeRollback :: Trace IO Text -> SlotNo -> IO (Either SyncNodeError ())

--- a/cardano-db/src/Cardano/Db/Delete.hs
+++ b/cardano-db/src/Cardano/Db/Delete.hs
@@ -1,5 +1,6 @@
 module Cardano.Db.Delete
   ( deleteCascadeBlock
+  , deleteCascadeAfter
   , deleteCascadeBlockNo
   , deleteCascadeSlotNo
   ) where
@@ -21,6 +22,14 @@ import           Ouroboros.Network.Block (BlockNo (..))
 deleteCascadeBlock :: MonadIO m => Block -> ReaderT SqlBackend m Bool
 deleteCascadeBlock block = do
   keys <- selectKeysList [ BlockHash ==. blockHash block ] []
+  mapM_ delete keys
+  pure $ not (null keys)
+
+-- | Delete a block after the specified 'BlockId'. Returns 'True' if it did exist and has been
+-- deleted and 'False' if it did not exist.
+deleteCascadeAfter :: MonadIO m => BlockId -> ReaderT SqlBackend m Bool
+deleteCascadeAfter bid = do
+  keys <- selectKeysList [ BlockPreviousId ==. Just bid ] []
   mapM_ delete keys
   pure $ not (null keys)
 

--- a/cardano-db/src/Cardano/Db/Error.hs
+++ b/cardano-db/src/Cardano/Db/Error.hs
@@ -24,6 +24,7 @@ data LookupFail
   | DbLookupSlotNo !Word64
   | DbMetaEmpty
   | DbMetaMultipleRows
+  | DBMultipleGenesis
   deriving (Eq, Show)
 
 renderLookupFail :: LookupFail -> Text
@@ -41,6 +42,8 @@ renderLookupFail lf =
         Text.concat [ "slot number ", textShow s ]
     DbMetaEmpty -> "Meta table is empty"
     DbMetaMultipleRows -> "Multiple rows in Meta table which should only contain one"
+    DBMultipleGenesis ->
+        "Multiple Genesis blocks found. These are blocks without an EpochNo"
 
 base16encode :: ByteString -> Text
 base16encode = Text.decodeUtf8 . Base16.encode


### PR DESCRIPTION
Currently during rollbacks we delete blocks by their slot. This causes issues with EBBS because they don't have a slot. In practice most EBBS are still deleted because their previous block is deleted and deletes are cascaded. However the previous block is not deleted, if it's the point we actually roll back to. To catch this case we need to manually delete the block right after the block we roll back to. A special instance of this case is where we roll back to genesis.

I think this hasn't been an issue so far, because insert block was lenient and idempotent, so inserting an existing block didn't raise an error.