### PR TITLE
Recover from corrupted ledger file

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -28,7 +28,7 @@ import           Control.Monad.Trans.Maybe (MaybeT (..))
 
 import           Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 
-import           Cardano.BM.Trace (Trace)
+import           Cardano.BM.Trace (Trace, logInfo)
 
 import qualified Cardano.Db as DB
 
@@ -59,9 +59,10 @@ runDbSyncNode metricsSetters mkPlugin params = do
     -- Read the PG connection info
     pgConfig <- DB.readPGPassFileEnv Nothing
 
-    DB.runMigrations pgConfig True dbMigrationDir (Just $ DB.LogFileDir "/tmp")
-
     trce <- configureLogging params "db-sync-node"
+    logInfo trce "Running database migrations"
+
+    DB.runMigrations pgConfig True dbMigrationDir (Just $ DB.LogFileDir "/tmp")
 
     let connectionString = DB.toConnectionString pgConfig
 

--- a/cardano-db-tool/src/Cardano/Db/Tool/Validate/Ledger.hs
+++ b/cardano-db-tool/src/Cardano/Db/Tool/Validate/Ledger.hs
@@ -50,7 +50,7 @@ validate params genCfg slotNo ledgerFiles =
       let ledgerSlot = lsfSlotNo ledgerFile
       if ledgerSlot <= slotNo
         then do
-          Just state <- loadLedgerStateFromFile (mkTopLevelConfig genCfg) False ledgerFile
+          Right state <- loadLedgerStateFromFile (mkTopLevelConfig genCfg) False ledgerFile
           validateBalance ledgerSlot (vpAddressUtxo params) state
         else do
           when logFailure . putStrLn $ redText "Ledger is newer than DB. Trying an older ledger."

--- a/cardano-sync/src/Cardano/Sync.hs
+++ b/cardano-sync/src/Cardano/Sync.hs
@@ -153,7 +153,7 @@ runSyncNode dataLayer metricsSetters trce plugin enp insertValidateGenesisDist r
       liftIO $ runDbStartup trce plugin
       case genCfg of
           GenesisCardano _ bCfg _sCfg _aCfg -> do
-            syncEnv <- ExceptT $ mkSyncEnvFromConfig dataLayer (enpLedgerStateDir enp) genCfg
+            syncEnv <- ExceptT $ mkSyncEnvFromConfig dataLayer trce (enpLedgerStateDir enp) genCfg
             liftIO $ runSyncNodeNodeClient metricsSetters syncEnv iomgr trce plugin
                         runDBThreadFunction (cardanoCodecConfig bCfg) (enpSocketPath enp)
   where

--- a/cardano-sync/src/Cardano/Sync/LedgerState.hs
+++ b/cardano-sync/src/Cardano/Sync/LedgerState.hs
@@ -29,6 +29,8 @@ module Cardano.Sync.LedgerState
 
 import           Prelude (String)
 
+import           Cardano.BM.Trace (Trace, logInfo, logWarning)
+
 import           Cardano.Binary (DecoderError)
 import qualified Cardano.Binary as Serialize
 
@@ -67,6 +69,7 @@ import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Strict.Maybe as Strict
+import qualified Data.Text as Text
 import           Data.Time.Clock (UTCTime)
 
 import           Ouroboros.Consensus.Block (CodecConfig, WithOrigin (..), blockHash, blockIsEBB,
@@ -125,7 +128,8 @@ data IndexCache = IndexCache
   }
 
 data LedgerEnv = LedgerEnv
-  { leProtocolInfo :: !(Consensus.ProtocolInfo IO CardanoBlock)
+  { leTrace :: Trace IO Text
+  , leProtocolInfo :: !(Consensus.ProtocolInfo IO CardanoBlock)
   , leDir :: !LedgerStateDir
   , leNetwork :: !Ledger.Network
   , leStateVar :: !(StrictTVar IO (Maybe CardanoLedgerState))
@@ -176,9 +180,9 @@ data LedgerStateSnapshot = LedgerStateSnapshot
   }
 
 mkLedgerEnv
-    :: Consensus.ProtocolInfo IO CardanoBlock -> LedgerStateDir -> Ledger.Network
+    :: Trace IO Text -> Consensus.ProtocolInfo IO CardanoBlock -> LedgerStateDir -> Ledger.Network
     -> IO LedgerEnv
-mkLedgerEnv protocolInfo dir network = do
+mkLedgerEnv trce protocolInfo dir network = do
     svar <- newTVarIO Nothing
     evar <- newTVarIO initLedgerEventState
     ivar <- newTVarIO $ IndexCache mempty mempty
@@ -189,7 +193,8 @@ mkLedgerEnv protocolInfo dir network = do
     orq <- newTBQueueIO 100
     est <- newTVarIO Nothing
     pure LedgerEnv
-      { leProtocolInfo = protocolInfo
+      { leTrace = trce
+      , leProtocolInfo = protocolInfo
       , leDir = dir
       , leNetwork = network
       , leStateVar = svar
@@ -458,23 +463,44 @@ findStateFromPoint env point delFiles = do
     -- TODO: We can make this a monadic action (reread config from disk) to save some memory.
   case getPoint point of
     Origin -> do
-      when delFiles $
-        mapM_ (safeRemoveFile . lsfFilePath) files
+      deleteNewerFiles files
       pure . Right $ initCardanoLedgerState (leProtocolInfo env)
     At blk -> do
       let (newerFiles, found, olderFiles) =
             findLedgerStateFile files (Point.blockPointSlot blk, mkRawHash $ Point.blockPointHash blk)
-      when delFiles $
-        mapM_ (safeRemoveFile . lsfFilePath) newerFiles
+      deleteNewerFiles newerFiles
       case found of
         Just lsf -> do
           mState <- loadLedgerStateFromFile (topLevelConfig env) False lsf
           case mState of
-            Nothing -> do
-              when delFiles $ safeRemoveFile $ lsfFilePath lsf
+            Left err -> do
+              deleteLedgerFile err lsf
+              logNewerFiles olderFiles
               pure $ Left olderFiles
-            Just st -> pure $ Right st
-        Nothing -> pure $ Left olderFiles
+            Right st -> pure $ Right st
+        Nothing -> do
+          logNewerFiles olderFiles
+          pure $ Left olderFiles
+  where
+    deleteNewerFiles :: [LedgerStateFile] -> IO ()
+    deleteNewerFiles lsfs = when (delFiles && not (null lsfs)) $ do
+      logInfo (leTrace env) $ mconcat ["Removing newer files ", textShow (map lsfFilePath lsfs)]
+      mapM_ (safeRemoveFile . lsfFilePath) lsfs
+
+    deleteLedgerFile :: Text -> LedgerStateFile -> IO ()
+    deleteLedgerFile err lsf = when delFiles $ do
+      logWarning (leTrace env) $ mconcat
+        [ "Failed to parse ledger state file ", Text.pack (lsfFilePath  lsf)
+        , " with error '", err, "'. Deleting it."
+        ]
+      safeRemoveFile $ lsfFilePath lsf
+
+    logNewerFiles :: [LedgerStateFile] -> IO ()
+    logNewerFiles lsfs =
+      logWarning (leTrace env) $
+        case lsfs of
+          [] -> "Rollback failed. No more ledger state files."
+          (x:_) -> mconcat [ "Rolling back further to slot ", textShow (unSlotNo $ lsfSlotNo x) ]
 
 -- Splits the files based on the comparison with the given point. It will return
 -- a list of newer files, a file at the given point if found and a list of older
@@ -507,24 +533,22 @@ comparePointToFile lsf (blSlotNo, blHash) =
         else GT
     x -> x
 
-loadLedgerStateFromFile :: TopLevelConfig CardanoBlock -> Bool -> LedgerStateFile -> IO (Maybe CardanoLedgerState)
+loadLedgerStateFromFile :: TopLevelConfig CardanoBlock -> Bool -> LedgerStateFile -> IO (Either Text CardanoLedgerState)
 loadLedgerStateFromFile config delete lsf = do
     mst <- safeReadFile (lsfFilePath lsf)
     case mst of
-      Nothing -> when delete (safeRemoveFile $ lsfFilePath lsf) >> pure Nothing
-      Just st -> pure . Just $ CardanoLedgerState { clsState = st }
+      Left err -> when delete (safeRemoveFile $ lsfFilePath lsf) >> pure (Left err)
+      Right st -> pure . Right $ CardanoLedgerState { clsState = st }
   where
-    safeReadFile :: FilePath -> IO (Maybe (ExtLedgerState CardanoBlock))
+    safeReadFile :: FilePath -> IO (Either Text (ExtLedgerState CardanoBlock))
     safeReadFile fp = do
       mbs <- Exception.try $ BS.readFile fp
       case mbs of
-        Left (_ :: IOException) -> pure Nothing
+        Left (err :: IOException) -> pure $ Left (Text.pack $ displayException err)
         Right bs ->
           case decode bs of
-            Left _err -> do
-              safeRemoveFile fp
-              pure Nothing
-            Right ls -> pure $ Just ls
+            Left err -> pure $ Left $ textShow err
+            Right ls -> pure $ Right ls
 
     codecConfig :: CodecConfig CardanoBlock
     codecConfig = configCodec config


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-db-sync/issues/651 
This is 2 commits on top of https://github.com/input-output-hk/cardano-db-sync/pull/650
An example of recovery
Assume we have these 8 ledger state files
```
ls ledger-state/mainnet-1
11999-04d2f9e587.lstate  15999-b714914757.lstate  19999-683be7324c.lstate  24013-1a8ef01c1a.lstate
13999-291a1b59fc.lstate  17999-e711abf703.lstate  22013-aad3ea4b6f.lstate  26013-e1c8c5e144.lstate
```
db at slot `24529` and assume `24013-1a8ef01c1a.lstate` is corrupted. This is the execution:
```

[db-sync-node:Info:52] [2021-06-18 00:10:53.40 UTC] Starting chainSyncClient
[db-sync-node:Info:52] [2021-06-18 00:10:53.42 UTC] Cardano.Db tip is at slot 24529, block 24516
[db-sync-node:Info:57] [2021-06-18 00:10:53.42 UTC] Running DB thread
[db-sync-node:Info:57] [2021-06-18 00:10:53.42 UTC] Rolling back to 24013, hash 1a8ef01c1a92288b269638552c051a64d0a9b741abd37d78d7762070f9333810
[db-sync-node:Info:57] [2021-06-18 00:10:53.42 UTC] Deleting 516 slots: [24529..24014]
[db-sync-node.Subscription:Notice:47] [2021-06-18 00:10:53.43 UTC] Identity Required subscriptions started
[db-sync-node:Info:57] [2021-06-18 00:10:53.65 UTC] Slots deleted
[db-sync-node:Info:57] [2021-06-18 00:10:53.65 UTC] Removing newer files [LedgerStateFile {lsfSlotNo = SlotNo 26013, lsfHash = "e1c8c5e144", lsNewEpoch = Nothing, lsfFilePath = "ledger-state/mainnet-1/26013-e1c8c5e144.lstate"}]
[db-sync-node:Warning:57] [2021-06-18 00:10:53.67 UTC] Failed to parse ledger state file LedgerStateFile {lsfSlotNo = SlotNo 24013, lsfHash = "1a8ef01c1a", lsNewEpoch = Nothing, lsfFilePath = "ledger-state/mainnet-1/24013-1a8ef01c1a.lstate"} with error DecoderErrorDeserialiseFailure "Ledger state file" (DeserialiseFailure 1425846 "end of input"). Deleting it.
[db-sync-node:Warning:57] [2021-06-18 00:10:53.67 UTC] Rolling back further to [LedgerStateFile {lsfSlotNo = SlotNo 22013, lsfHash = "aad3ea4b6f", lsNewEpoch = Nothing, lsfFilePath = "ledger-state/mainnet-1/22013-aad3ea4b6f.lstate"},LedgerStateFile {lsfSlotNo = SlotNo 19999, lsfHash = "683be7324c", lsNewEpoch = Nothing, lsfFilePath = "ledger-state/mainnet-1/19999-683be7324c.lstate"},LedgerStateFile {lsfSlotNo = SlotNo 17999, lsfHash = "e711abf703", lsNewEpoch = Nothing, lsfFilePath = "ledger-state/mainnet-1/17999-e711abf703.lstate"},LedgerStateFile {lsfSlotNo = SlotNo 15999, lsfHash = "b714914757", lsNewEpoch = Nothing, lsfFilePath = "ledger-state/mainnet-1/15999-b714914757.lstate"},LedgerStateFile {lsfSlotNo = SlotNo 13999, lsfHash = "291a1b59fc", lsNewEpoch = Nothing, lsfFilePath = "ledger-state/mainnet-1/13999-291a1b59fc.lstate"},LedgerStateFile {lsfSlotNo = SlotNo 11999, lsfHash = "04d2f9e587", lsNewEpoch = Nothing, lsfFilePath = "ledger-state/mainnet-1/11999-04d2f9e587.lstate"}]
[db-sync-node:Info:57] [2021-06-18 00:10:53.68 UTC] Rolling back to 22013, hash aad3ea4b6f582418364b4396e52d13742a20251c0c24bd00b87a166c89721da5
[db-sync-node:Info:57] [2021-06-18 00:10:53.68 UTC] Deleting 2000 slots: [24013..22014]
[db-sync-node:Info:57] [2021-06-18 00:10:54.44 UTC] Slots deleted
[db-sync-node:Info:60] [2021-06-18 00:10:54.47 UTC] getHistoryInterpreter: acquired
[db-sync-node:Info:57] [2021-06-18 00:10:54.47 UTC] thisIsAnUglyHack: Main thead
[db-sync-node:Info:57] [2021-06-18 00:10:54.48 UTC] Starting epoch 1
```
After the first `RollbackToMsg 24013` from the node, dbsync removes newer files `26013-e1c8c5e144.lstate` and tries to parse `24013-1a8ef01c1a.lstate` but it's corrupted so it's deleted. As a response, since `loadLedgerStateFromFile` failed, db-sync asks the node to rollback even further to one of the 6 remaining checkpoints. Node responds with `RollbackToMsg 22013` which db-sync successfully parses.