### PR TITLE
nixos service: Add snapshot / restore support

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -19,6 +19,8 @@ in {
       cardano-db-sync;
   inherit (cardanoDbSyncHaskellPackages.cardano-db-sync-extended.components.exes)
       cardano-db-sync-extended;
+  inherit (cardanoDbSyncHaskellPackages.cardano-db-tool.components.exes)
+    cardano-db-tool;
   inherit (cardanoDbSyncHaskellPackages.cardano-node.components.exes)
       cardano-node;
 


### PR DESCRIPTION
restore does not work yet:
```
dropdb: error: database removal failed: ERROR:  must be owner of database cexplorer
```
@erikd could we add an option that instead of using drop/createdb would do a `drop schema cascade`?