### PR TITLE
snaphot restore: only drop objects owned by user instead of whole db.

### DIFF
--- a/nix/nixos/cardano-db-sync-service.nix
+++ b/nix/nixos/cardano-db-sync-service.nix
@@ -147,6 +147,7 @@ in {
 
         ${lib.optionalString (cfg.restoreSnapshot != null) ''
         if [ -f ${cfg.restoreSnapshot} ]; then
+          rm *.lstate
           ${../../scripts/postgresql-setup.sh} --restore-snapshot ${cfg.restoreSnapshot} ./
           rm ${cfg.restoreSnapshot}
         fi

--- a/nix/nixos/cardano-db-sync-service.nix
+++ b/nix/nixos/cardano-db-sync-service.nix
@@ -118,7 +118,9 @@ in {
     in {
       pgpass = builtins.toFile "pgpass" "${cfg.postgres.socketdir}:${toString cfg.postgres.port}:${cfg.postgres.database}:${cfg.postgres.user}:*";
       script = pkgs.writeShellScript "cardano-db-sync" ''
-        ${if (cfg.socketPath == null) then ''if [ -z "$CARDANO_NODE_SOCKET_PATH" ]
+        set -euo pipefail
+
+        ${if (cfg.socketPath == null) then ''if [ -z "''${CARDANO_NODE_SOCKET_PATH:-}" ]
         then
           echo "You must set \$CARDANO_NODE_SOCKET_PATH"
           exit 1
@@ -137,7 +139,7 @@ in {
             SKIP_SNAPSHOT=1
           fi
         done
-        if [ -z $SKIP_SNAPSHOT ]; then
+        if [ -z ''${SKIP_SNAPSHOT:-} ]; then
           SNAPSHOT_SCRIPT=$(cardano-db-tool prepare-snapshot --state-dir ./ | tail -n 1)
           ${../../scripts/postgresql-setup.sh} ''${SNAPSHOT_SCRIPT#*scripts/postgresql-setup.sh}
         fi

--- a/scripts/postgresql-setup.sh
+++ b/scripts/postgresql-setup.sh
@@ -91,11 +91,15 @@ function check_db_exists {
 }
 
 function create_db {
-	createdb -T template0 --owner="$(whoami)" --encoding=UTF8 "${databasename}"
+	if test "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='${databasename}'" )" != '1' ; then
+		createdb -T template0 --owner="$(whoami)" --encoding=UTF8 "${databasename}"
+		fi
 }
 
 function drop_db {
-	dropdb --if-exists "${databasename}"
+	if test "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='${databasename}'" )" = '1' ; then
+		psql "${databasename}" --command="DROP OWNED BY CURRENT_USER;"
+		fi
 }
 
 function list_views {


### PR DESCRIPTION
because user might not have the right to drop (or create) the database (default configuration on nixos).