### PR TITLE
nixos service: use schema from cfg.dbSyncPkgs

### DIFF
--- a/nix/nixos/cardano-db-sync-service.nix
+++ b/nix/nixos/cardano-db-sync-service.nix
@@ -157,7 +157,7 @@ in {
         exec ${exec} \
           --config ${configFile} \
           --socket-path "$CARDANO_NODE_SOCKET_PATH" \
-          --schema-dir ${../../schema} \
+          --schema-dir ${self.schema or (self.src + "/schema")} \
           --state-dir ${cfg.stateDir}
       '';
     };

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -8,6 +8,12 @@ in {
     name = "cardano-db-sync";
   };
 
+  schema = haskell-nix.haskellLib.cleanGit {
+    src = ../.;
+    subDir = "schema";
+    name = "cardano-db-sync-schema";
+  };
+
   cardanoDbSyncProject = callPackage ./haskell.nix {
     inherit compiler;
   };


### PR DESCRIPTION
because otherwise, when using the nixos service definition from master and the binary from tag, the service was using master schema instead of tag schema.