### PR TITLE
Take only 1 ledger snapshot on disk per epoch

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -194,7 +194,7 @@ source-repository-package
     word-array
 
 
--- From the node. No idea WTF.
+-- Something in plutus-core requries this.
 source-repository-package
   type: git
   location: https://github.com/Quid2/flat.git

--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Epoch.hs
@@ -128,7 +128,6 @@ latestCachedEpochVar = unsafePerformIO $ newIORef Nothing -- Gets updated later.
 
 updateEpochNum :: (MonadBaseControl IO m, MonadIO m) => Word64 -> Trace IO Text -> ReaderT SqlBackend m (Either SyncNodeError ())
 updateEpochNum epochNum trce = do
-    DB.transactionCommit
     mid <- queryEpochId epochNum
     res <- maybe insertEpoch updateEpoch mid
     liftIO $ atomicWriteIORef latestCachedEpochVar (Just epochNum)

--- a/cardano-sync/src/Cardano/Sync/Database.hs
+++ b/cardano-sync/src/Cardano/Sync/Database.hs
@@ -104,7 +104,7 @@ runActions trce env plugin actions = do
 
 rollbackLedger :: Trace IO Text -> SyncNodePlugin -> SyncEnv -> CardanoPoint -> IO (Maybe [CardanoPoint])
 rollbackLedger _trce _plugin env point = do
-    mst <- loadLedgerAtPoint (envLedger env) point True
+    mst <- loadLedgerAtPoint (envLedger env) point
     dbBlock <- sdlGetLatestBlock (envDataLayer env)
     case mst of
       Right st -> do


### PR DESCRIPTION
## Current issue
Fixes https://github.com/input-output-hk/cardano-db-sync/issues/657
This pr fixes an issue where rewards, stakes and orphaned_rewards that stay in memory for some time, could get lost in case of a restart. To fix this issue we make sure to never take a ledger snapshot when there are volatile data in memory. 

## Proposed solution
The simplest way to achieve this is to flush the TBQueue and commit the data to db before taking a ledger snapshot. By doing so, in case of a restart, db-sync rollbacks to a point where ledger and db are consistent with each other and there are no missing data. However we don't want to do this flush when there are still too many data in the TBQueue, or this will cause big downtime. The solution we follow in this pr is to take the ledger snapshot right before the epoch boundary, where most epochs and rewards from the previous epoch are probably already inserted. There may be other alternative solutions here.

## Performance optimization and profiling
Another result of this pr is that we take very little ledger snapshots: 1 per epoch instead of 1 per 2000 blocks that we used to. Rollback times are pretty good, so we don't need to take snapshots that often. Also taking snapshots is an expensive operation which according to profiling, adds to total sync time 
For example

syncing between epoch 217-223 (74 ledger snapshots) snapshoting took 13,2% of sync time and 22,4% allocations (this could mean there are memory spikes during snapshoting, but I haven't verified this)
![217-223](https://user-images.githubusercontent.com/11467473/124298150-951f4880-db64-11eb-9bf4-c1d9fb3fd7c1.png)


syncing between epochs 257-259 (27 ledger snapshots) takes 9.8% of sync time and 23,9 of total allocations.
![257-259](https://user-images.githubusercontent.com/11467473/124298166-9a7c9300-db64-11eb-82d1-7fb7879af2e6.png)

These data show that as epochs advance, snapshotting takes less and less time percentage wise, but it still takes a lot of absolute time. For earslier epochs, eg Byron, snapshotting takes up to 25% of time.

## Following the chain
While following the chain, db-sync used to take snapshots for every block. These suffered from the previous issues (rewards/stakes could get lost) and was time consuming (even though there is a average 20s delay between new blocks). With this pr, while following the chain, we still still follow the same policy regarding disk snapshots (1 per epoch), which fixes the issue with restarts. However the node can also do small rollbacks, coming from the consensus and chain selection. In this case, we don't want to rollback too far (previous epoch boundary). To fix this, we keep multiple ledger snapshots in memory. This is the same approach that the LedgerDB of the node follows. I used the same data structure as the LedgerDB, to avoid logic duplication as much as possible.
