### PR TITLE
Avoid address serialisation roundtrip

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -243,14 +243,14 @@ insertTxOut
     :: (MonadBaseControl IO m, MonadIO m)
     => Trace IO Text -> DB.TxId -> Generic.TxOut
     -> ExceptT e (ReaderT SqlBackend m) ()
-insertTxOut tracer txId (Generic.TxOut index addr value maMap dataHash) = do
+insertTxOut tracer txId (Generic.TxOut index addr addrRaw value maMap dataHash) = do
     mSaId <- lift $ insertStakeAddressRefIfMissing txId addr
     txOutId <- lift . DB.insertTxOut $
                 DB.TxOut
                   { DB.txOutTxId = txId
                   , DB.txOutIndex = index
                   , DB.txOutAddress = Generic.renderAddress addr
-                  , DB.txOutAddressRaw = Ledger.serialiseAddr addr
+                  , DB.txOutAddressRaw = addrRaw
                   , DB.txOutAddressHasScript = hasScript
                   , DB.txOutPaymentCred = Generic.maybePaymentCred addr
                   , DB.txOutStakeAddressId = mSaId


### PR DESCRIPTION
The TxOut patterns for addresses that we use, do a silent deserialisation. Later we serialise addresses again to insert them in the db. We can avoid this round trip by keeping the initial serialised address

This can be optimised even further. `Generic.renderAddress` does another serialization before transforming to the bech32/base58 format. We could use the serialised address to avoid this. However the cardano-api doesn't make this too easy.