### PR TITLE
Store information about Alonzo scripts in the database

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
@@ -173,6 +173,9 @@ insertTxOuts blkId (address, value) = do
               , DB.txInvalidHereafter = Nothing
               , DB.txInvalidBefore = Nothing
               , DB.txValidContract = True
+              , DB.txExUnitNumber = 0
+              , DB.txExUnitFee = DB.DbLovelace 0
+              , DB.txScriptSize = 0
               }
   void . DB.insertTxOut $
             DB.TxOut

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
@@ -195,6 +195,9 @@ insertTx tracer blkId tx blockIndex = do
                 , DB.txInvalidHereafter = Nothing
                 , DB.txInvalidBefore = Nothing
                 , DB.txValidContract = True
+                , DB.txExUnitNumber = 0
+                , DB.txExUnitFee = DB.DbLovelace 0
+                , DB.txScriptSize = 0
                 }
 
     -- Insert outputs for a transaction before inputs in case the inputs for this transaction

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Block.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Block.hs
@@ -27,6 +27,7 @@ import           Cardano.DbSync.Era.Shelley.Generic.Util
 
 import           Cardano.Ledger.Alonzo ()
 import           Cardano.Ledger.Core (Witnesses)
+import qualified Cardano.Ledger.Core as Ledger
 import           Cardano.Ledger.Crypto (VRF)
 import           Cardano.Ledger.Era (Crypto, SupportsSegWit (..))
 import qualified Cardano.Ledger.Era as Ledger
@@ -127,8 +128,8 @@ fromMaryBlock blk =
     , blkTxs = map fromMaryTx (blockTxs blk)
     }
 
-fromAlonzoBlock :: ShelleyBlock StandardAlonzo -> Block
-fromAlonzoBlock blk =
+fromAlonzoBlock :: Ledger.PParams StandardAlonzo -> ShelleyBlock StandardAlonzo -> Block
+fromAlonzoBlock pp blk =
   Block
     { blkEra = Alonzo
     , blkHash = blockHash blk
@@ -142,7 +143,7 @@ fromAlonzoBlock blk =
     , blkVrfKey = blockVrfKeyView blk
     , blkOpCert = blockOpCert blk
     , blkOpCertCounter = blockOpCertCounter blk
-    , blkTxs = map fromAlonzoTx (alonzoBlockTxs blk)
+    , blkTxs = map (fromAlonzoTx pp) (alonzoBlockTxs blk)
     }
 
 -- -------------------------------------------------------------------------------------------------

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Tx.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Tx.hs
@@ -29,7 +29,6 @@ import           Cardano.DbSync.Era.Shelley.Generic.Witness
 
 import qualified Cardano.Ledger.Address as Ledger
 import           Cardano.Ledger.Alonzo (AlonzoEra)
-import qualified Cardano.Ledger.Alonzo.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import           Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Script (..), txscriptfee)
 import           Cardano.Ledger.Alonzo.Tx (ValidatedTx (..))
@@ -274,8 +273,8 @@ fromAlonzoTx pp (blkIndex, tx) =
     txBody = getField @"body" tx
 
     exUnits :: [ExUnits]
-    exUnits = map snd (Map.elems $
-      Ledger.unRedeemers $ getField @"txrdmrs" (getField @"wits" tx))
+    exUnits =
+      map snd . Map.elems . Ledger.unRedeemers $ getField @"txrdmrs" (getField @"wits" tx)
 
     sizes :: [Int]
     sizes = mapMaybe getScriptSize $ toList $ Ledger.txscripts $ getField @"wits" tx

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
@@ -186,6 +186,9 @@ insertTxOuts blkId (Shelley.TxIn txInId _, txOut) = do
               , DB.txInvalidHereafter = Nothing
               , DB.txInvalidBefore = Nothing
               , DB.txValidContract = True
+              , DB.txExUnitNumber = 0
+              , DB.txExUnitFee = DB.DbLovelace 0
+              , DB.txScriptSize = 0
               }
   void . DB.insertTxOut $
             DB.TxOut

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -203,6 +203,9 @@ insertTx tracer network lStateSnap blkId epochNo slotNo blockIndex tx = do
                 , DB.txInvalidBefore = DbWord64 . unSlotNo <$> Generic.txInvalidBefore tx
                 , DB.txInvalidHereafter = DbWord64 . unSlotNo <$> Generic.txInvalidHereafter tx
                 , DB.txValidContract = Generic.txValidContract tx
+                , DB.txExUnitNumber = fromIntegral $ length $ Generic.txExUnits tx
+                , DB.txExUnitFee = DB.DbLovelace (fromIntegral . unCoin $ Generic.scriptsFee tx)
+                , DB.txScriptSize = fromIntegral $ sum $ Generic.scriptSizes tx
                 }
 
     -- Insert outputs for a transaction before inputs in case the inputs for this transaction

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -107,13 +107,15 @@ share
     deposit             Int64                                   -- Needs to allow negaitve values.
     size                Word64              sqltype=uinteger
 
+    -- New for Allega
     invalidBefore       DbWord64 Maybe      sqltype=word64type
     invalidHereafter    DbWord64 Maybe      sqltype=word64type
+
+    -- New for Alonzo
+    validContract       Bool                                    -- False if the contract is invalid, True otherwise.
     exUnitNumber        Word64              sqltype=uinteger
     exUnitFee           DbLovelace          sqltype=lovelace
     scriptSize          Word64              sqltype=uinteger
-
-    validContract       Bool                                    -- False if the contract is invalid, True otherwise.
     UniqueTx            hash
 
   StakeAddress          -- Can be an address of a script hash
@@ -530,6 +532,9 @@ schemaDocs =
       TxInvalidBefore # "Transaction in invalid before this slot number."
       TxInvalidHereafter # "Transaction in invalid at or after this slot number."
       TxValidContract # "False if the contract is invalid. True if the contract is valid or there is no contract."
+      TxExUnitNumber # "The cost of running the scripts in a transaction in arbitrary execution units."
+      TxExUnitFee # "The fees associated with Plutus scripts in the transaction."
+      TxScriptSize # "The sum of the script sizes (in bytes) of scripts in the transaction."
 
     StakeAddress --^ do
       "A table of unique stake addresses. Can be an actual address or a script hash."

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -109,6 +109,9 @@ share
 
     invalidBefore       DbWord64 Maybe      sqltype=word64type
     invalidHereafter    DbWord64 Maybe      sqltype=word64type
+    exUnitNumber        Word64              sqltype=uinteger
+    exUnitFee           DbLovelace          sqltype=lovelace
+    scriptSize          Word64              sqltype=uinteger
 
     validContract       Bool                                    -- False if the contract is invalid, True otherwise.
     UniqueTx            hash

--- a/cardano-db/test/Test/IO/Cardano/Db/Rollback.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Rollback.hs
@@ -115,7 +115,7 @@ createAndInsertBlocks blockCount =
         newMTxOutId <- if indx /= 0
                       then pure mTxOutId
                       else do
-                        txId <- insertTx $ Tx (mkTxHash blkId 0) blkId 0 (DbLovelace 0) (DbLovelace 0) 0 12 Nothing Nothing True
+                        txId <- insertTx $ Tx (mkTxHash blkId 0) blkId 0 (DbLovelace 0) (DbLovelace 0) 0 12 Nothing Nothing True 0 (DbLovelace 0) 0
                         void $ insertTxOut (mkTxOut blkId txId)
                         pure $ Just txId
         case (indx, mTxOutId) of

--- a/cardano-db/test/Test/IO/Cardano/Db/TotalSupply.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/TotalSupply.hs
@@ -51,6 +51,9 @@ initialSupplyTest =
                   , txInvalidHereafter = Nothing
                   , txInvalidBefore = Nothing
                   , txValidContract = True
+                  , txExUnitNumber = 0
+                  , txExUnitFee = DbLovelace 0
+                  , txScriptSize = 0
                   }
     _ <- insertTxIn (TxIn tx1Id (head tx0Ids) 0)
     let addr = mkAddressHash bid1 tx1Id

--- a/cardano-db/test/Test/IO/Cardano/Db/Util.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Util.hs
@@ -95,6 +95,9 @@ mkTxs blkId count =
         , txInvalidHereafter = Nothing
         , txInvalidBefore = Nothing
         , txValidContract = True
+        , txExUnitNumber = 0
+        , txExUnitFee = DbLovelace 0
+        , txScriptSize = 0
         }
 
 testSlotLeader :: SlotLeader

--- a/cardano-sync/src/Cardano/Sync/LedgerState.hs
+++ b/cardano-sync/src/Cardano/Sync/LedgerState.hs
@@ -29,6 +29,7 @@ module Cardano.Sync.LedgerState
   , getHeaderHash
   , ledgerTipBlockNo
   , getPoolParams
+  , getAlonzoPParams
   ) where
 
 import           Prelude (String, id)
@@ -43,6 +44,7 @@ import qualified Cardano.Db as DB
 
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import           Cardano.Ledger.Coin (Coin)
+import           Cardano.Ledger.Core (PParams)
 import           Cardano.Ledger.Era
 import           Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import           Cardano.Ledger.Shelley.Constraints (UsesValue)
@@ -79,7 +81,8 @@ import           Data.Time.Clock (UTCTime)
 import           Ouroboros.Consensus.Block (CodecConfig, Point (..), WithOrigin (..), blockHash,
                    blockIsEBB, blockPoint, blockPrevHash, pointSlot)
 import           Ouroboros.Consensus.Block.Abstract (ConvertRawHash (..))
-import           Ouroboros.Consensus.Cardano.Block (LedgerState (..), StandardCrypto)
+import           Ouroboros.Consensus.Cardano.Block (LedgerState (..), StandardAlonzo,
+                   StandardCrypto)
 import           Ouroboros.Consensus.Cardano.CanHardFork ()
 import           Ouroboros.Consensus.Config (TopLevelConfig (..), configCodec, configLedger)
 import qualified Ouroboros.Consensus.HardFork.Combinator as Consensus
@@ -100,7 +103,7 @@ import qualified Ouroboros.Network.AnchoredSeq as AS
 import           Ouroboros.Network.Block (HeaderHash, Point (..))
 import qualified Ouroboros.Network.Point as Point
 
-import           Shelley.Spec.Ledger.LedgerState (AccountState, EpochState, UTxOState)
+import           Shelley.Spec.Ledger.LedgerState (AccountState, EpochState (..), UTxOState)
 import qualified Shelley.Spec.Ledger.LedgerState as Shelley
 import qualified Shelley.Spec.Ledger.Rewards as Shelley
 import qualified Shelley.Spec.Ledger.UTxO as Shelley
@@ -776,6 +779,14 @@ totalAdaPots lState =
 getHeaderHash :: HeaderHash CardanoBlock -> ByteString
 getHeaderHash bh = BSS.fromShort (Consensus.getOneEraHash bh)
 
+-- | This will fail if the state is not a 'LedgerStateAlonzo'
+getAlonzoPParams :: CardanoLedgerState -> PParams StandardAlonzo
+getAlonzoPParams cls =
+  case ledgerState $ clsState cls of
+    LedgerStateAlonzo als -> esPp $ Shelley.nesEs $ Consensus.shelleyLedgerState als
+    _ -> panic "Expected LedgerStateAlonzo after an Alonzo Block"
+
 -- | This should be exposed by 'consensus'.
 ledgerTipBlockNo :: ExtLedgerState blk -> WithOrigin BlockNo
 ledgerTipBlockNo = fmap Consensus.annTipBlockNo . Consensus.headerStateTip . Consensus.headerState
+

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -1,6 +1,6 @@
 # Schema Documentation for cardano-db-sync
 
-Schema version: 10.0.0 (from branch **erikd/schema-docs** which may not accurately reflect the version number)
+Schema version: 10.0.0 (from branch **kderme/scripts-data** which may not accurately reflect the version number)
 
 ### `schema_version`
 
@@ -84,6 +84,9 @@ A table for transactions within a block on the chain.
 | `invalid_before` | word64type | Transaction in invalid before this slot number. |
 | `invalid_hereafter` | word64type | Transaction in invalid at or after this slot number. |
 | `valid_contract` | boolean | False if the contract is invalid. True if the contract is valid or there is no contract. |
+| `ex_unit_number` | uinteger | The cost of running the scripts in a transaction in arbitrary execution units. |
+| `ex_unit_fee` | lovelace | The fees associated with Plutus scripts in the transaction. |
+| `script_size` | uinteger | The sum of the script sizes (in bytes) of scripts in the transaction. |
 
 ### `stake_address`
 
@@ -325,7 +328,7 @@ A table for metadata attached to a transaction.
 
 ### `reward`
 
-A table for rewards earned by staking. One of the fields is the epoch number in which the reward was earned, but rewards can only be spent two epochs after they are earned.
+A table for rewards earned by staking. The rewards earned in epoch `N` are added in this table when they are calculated during epoch `N + 1` but are not spendable until after the start of epoch `N + 2`.
 
 * Primary Id: `id`
 

--- a/schema/migration-2-0012-20210723.sql
+++ b/schema/migration-2-0012-20210723.sql
@@ -1,0 +1,21 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 12 THEN
+    EXECUTE 'ALTER TABLE "tx" ADD COLUMN "ex_unit_number" uinteger NOT NULL' ;
+    EXECUTE 'ALTER TABLE "tx" ADD COLUMN "ex_unit_fee" lovelace NOT NULL' ;
+    EXECUTE 'ALTER TABLE "tx" ADD COLUMN "script_size" uinteger NOT NULL' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
This fixes https://jira.iohk.io/browse/CAD-3050 and https://jira.iohk.io/browse/CAD-3161
It creates migrations for data related to Alonzo scripts

For each transansaction this adds:
- Number of ExUnits
- How much these ExUnits contribute to the minimum amount of fees of the transaction
- sum of sizes of serialised plutus scripts in the tx
