### PR TITLE
 Store information about Alonzo scripts (without the script_size column) in the database 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -95,8 +95,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-crypto
-  tag: 07397f0e50da97eaa0575d93bee7ac4b2b2576ec
-  --sha256: 06sdx5ndn2g722jhpicmg96vsrys89fl81k8290b3lr6b1b0w4m3
+  tag: ce8f1934e4b6252084710975bd9bbc0a4648ece4
+  --sha256: 1v2laq04piyj511b2m77hxjh9l1yd6k9kc7g6bjala4w3zdwa4ni
 
 source-repository-package
   type: git
@@ -123,8 +123,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: bc225ae3085ba6f4f4007c50c4877bc4cebcd7de
-  --sha256: 18i3axv3irls5gbcsppkw1aci72zyqw80ffhz25sfpbflbj1m4f5
+  tag: 4d2b68075b7ad5e4be5e810a32daf227a378fdd9
+  --sha256: 1wscjk1wq29q5sj8pm5gxxyp533ygg15jj6phddqg8xyapmbw3bq
   subdir:
     cardano-api
     cardano-config

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
@@ -173,6 +173,8 @@ insertTxOuts blkId (address, value) = do
               , DB.txInvalidHereafter = Nothing
               , DB.txInvalidBefore = Nothing
               , DB.txValidContract = True
+              , DB.txExUnitsNumber = 0
+              , DB.txExUnitsFees = DB.DbLovelace 0
               }
   void . DB.insertTxOut $
             DB.TxOut

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
@@ -195,6 +195,8 @@ insertTx tracer blkId tx blockIndex = do
                 , DB.txInvalidHereafter = Nothing
                 , DB.txInvalidBefore = Nothing
                 , DB.txValidContract = True
+                , DB.txExUnitsNumber = 0
+                , DB.txExUnitsFees = DB.DbLovelace 0
                 }
 
     -- Insert outputs for a transaction before inputs in case the inputs for this transaction

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Block.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Block.hs
@@ -27,6 +27,7 @@ import           Cardano.DbSync.Era.Shelley.Generic.Util
 
 import           Cardano.Ledger.Alonzo ()
 import           Cardano.Ledger.Core (Witnesses)
+import qualified Cardano.Ledger.Core as Ledger
 import           Cardano.Ledger.Crypto (VRF)
 import           Cardano.Ledger.Era (Crypto, SupportsSegWit (..))
 import qualified Cardano.Ledger.Era as Ledger
@@ -127,8 +128,8 @@ fromMaryBlock blk =
     , blkTxs = map fromMaryTx (blockTxs blk)
     }
 
-fromAlonzoBlock :: ShelleyBlock StandardAlonzo -> Block
-fromAlonzoBlock blk =
+fromAlonzoBlock :: Ledger.PParams StandardAlonzo -> ShelleyBlock StandardAlonzo -> Block
+fromAlonzoBlock pp blk =
   Block
     { blkEra = Alonzo
     , blkHash = blockHash blk
@@ -142,7 +143,7 @@ fromAlonzoBlock blk =
     , blkVrfKey = blockVrfKeyView blk
     , blkOpCert = blockOpCert blk
     , blkOpCertCounter = blockOpCertCounter blk
-    , blkTxs = map fromAlonzoTx (alonzoBlockTxs blk)
+    , blkTxs = map (fromAlonzoTx pp) (alonzoBlockTxs blk)
     }
 
 -- -------------------------------------------------------------------------------------------------

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
@@ -186,6 +186,8 @@ insertTxOuts blkId (Shelley.TxIn txInId _, txOut) = do
               , DB.txInvalidHereafter = Nothing
               , DB.txInvalidBefore = Nothing
               , DB.txValidContract = True
+              , DB.txExUnitsNumber = 0
+              , DB.txExUnitsFees = DB.DbLovelace 0
               }
   void . DB.insertTxOut $
             DB.TxOut

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -203,6 +203,8 @@ insertTx tracer network lStateSnap blkId epochNo slotNo blockIndex tx = do
                 , DB.txInvalidBefore = DbWord64 . unSlotNo <$> Generic.txInvalidBefore tx
                 , DB.txInvalidHereafter = DbWord64 . unSlotNo <$> Generic.txInvalidHereafter tx
                 , DB.txValidContract = Generic.txValidContract tx
+                , DB.txExUnitsNumber = fromIntegral $ length $ Generic.txExUnits tx
+                , DB.txExUnitsFees = DB.DbLovelace (fromIntegral . unCoin $ Generic.txExUnitsFees tx)
                 }
 
     -- Insert outputs for a transaction before inputs in case the inputs for this transaction

--- a/cardano-db-sync/src/Cardano/DbSync/Plugin/Default.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Plugin/Default.hs
@@ -84,8 +84,10 @@ insertDefaultBlock backend tracer env blockDetails = do
           newExceptT $ insertShelleyBlock tracer lenv (Generic.fromAllegraBlock blk) lStateSnap details
         BlockMary blk ->
           newExceptT $ insertShelleyBlock tracer lenv (Generic.fromMaryBlock blk) lStateSnap details
-        BlockAlonzo blk ->
-          newExceptT $ insertShelleyBlock tracer lenv (Generic.fromAlonzoBlock blk) lStateSnap details
+        BlockAlonzo blk -> do
+          let pp = getAlonzoPParams $ lssState lStateSnap
+          newExceptT $ insertShelleyBlock tracer lenv (Generic.fromAlonzoBlock pp blk)
+            lStateSnap details
 
     mkSnapshotMaybe
         :: (MonadBaseControl IO m, MonadIO m)

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -109,6 +109,8 @@ share
 
     invalidBefore       DbWord64 Maybe      sqltype=word64type
     invalidHereafter    DbWord64 Maybe      sqltype=word64type
+    exUnitsNumber       Word64              sqltype=uinteger
+    exUnitsFees         DbLovelace          sqltype=lovelace
 
     validContract       Bool                                    -- False if the contract is invalid, True otherwise.
     UniqueTx            hash

--- a/cardano-db/test/Test/IO/Cardano/Db/Rollback.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Rollback.hs
@@ -115,7 +115,7 @@ createAndInsertBlocks blockCount =
         newMTxOutId <- if indx /= 0
                       then pure mTxOutId
                       else do
-                        txId <- insertTx $ Tx (mkTxHash blkId 0) blkId 0 (DbLovelace 0) (DbLovelace 0) 0 12 Nothing Nothing True
+                        txId <- insertTx $ Tx (mkTxHash blkId 0) blkId 0 (DbLovelace 0) (DbLovelace 0) 0 12 Nothing Nothing 0 (DbLovelace 0) True
                         void $ insertTxOut (mkTxOut blkId txId)
                         pure $ Just txId
         case (indx, mTxOutId) of

--- a/cardano-db/test/Test/IO/Cardano/Db/TotalSupply.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/TotalSupply.hs
@@ -51,6 +51,8 @@ initialSupplyTest =
                   , txInvalidHereafter = Nothing
                   , txInvalidBefore = Nothing
                   , txValidContract = True
+                  , txExUnitsNumber = 0
+                  , txExUnitsFees = DbLovelace 0
                   }
     _ <- insertTxIn (TxIn tx1Id (head tx0Ids) 0)
     let addr = mkAddressHash bid1 tx1Id

--- a/cardano-db/test/Test/IO/Cardano/Db/Util.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Util.hs
@@ -95,6 +95,8 @@ mkTxs blkId count =
         , txInvalidHereafter = Nothing
         , txInvalidBefore = Nothing
         , txValidContract = True
+        , txExUnitsNumber = 0
+        , txExUnitsFees = DbLovelace 0
         }
 
 testSlotLeader :: SlotLeader

--- a/schema/migration-2-0012-20210722.sql
+++ b/schema/migration-2-0012-20210722.sql
@@ -1,0 +1,20 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 12 THEN
+    EXECUTE 'ALTER TABLE "tx" ADD COLUMN "ex_units_number" uinteger NOT NULL' ;
+    EXECUTE 'ALTER TABLE "tx" ADD COLUMN "ex_units_fees" lovelace NOT NULL' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
This is a subset of https://github.com/input-output-hk/cardano-db-sync/pull/694 and fixes https://jira.iohk.io/browse/CAD-3050

The split happens because of https://github.com/input-output-hk/cardano-db-sync/pull/694#issuecomment-882870959