### PR TITLE
docker/nixos: allow restore of snapshot from env variable

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -145,8 +145,12 @@ let
         else
           DBSYNC=${cardano-db-sync}/bin/cardano-db-sync
         fi
-         exec $DBSYNC \
-           --schema-dir ${../schema} $@
+
+        set -euo pipefail
+        ${scripts.mainnet.db-sync.passthru.service.restoreSnapshotScript}
+
+        exec $DBSYNC \
+          --schema-dir ${../schema} $@
       ${clusterStatements}
       else
         echo "Managed configuration for network "$NETWORK" does not exist"

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -55,6 +55,7 @@ in {
   dockerImage = let
     defaultConfig = rec {
       services.cardano-db-sync = {
+        restoreSnapshot = lib.mkDefault "$RESTORE_SNAPSHOT";
         socketPath = lib.mkDefault ("/node-ipc/node.socket");
         postgres.generatePGPASS = false;
       };

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -26,6 +26,8 @@ let
       #!${pkgs.runtimeShell}
       set -euo pipefail
       ${service.script} $@
-    '';
+    '' // {
+      passthru = { inherit service; };
+    };
   };
 in cardanoLib.forEnvironmentsCustom mkScript environments


### PR DESCRIPTION
for docker by setting eg.:
```
-e RESTORE_SNAPSHOT=https://update-cardano-mainnet.iohk.io/cardano-db-sync/db-sync-snapshot-schema-10-block-6014140-x86_64.tgz
```

Need some more testing for the docker side.