### PR TITLE
postgres port declaration not needed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - postgres_db
     volumes:
       - postgres:/var/lib/postgresql/data
-    ports:
-      - 5432:5432
     restart: on-failure
     logging:
       driver: "json-file"


### PR DESCRIPTION
in docker compose declaring the port:
    ports:
      - 5432:5432
 will make the postgres instance reachable publicly  which might lead to security attacks against it.

Removing it will keep the port available for db-sync and other containers running on the same host without compromising the security of it.