### PR TITLE
Fix typo in scripts/postgresql-setup.sh

### DIFF
--- a/scripts/postgresql-setup.sh
+++ b/scripts/postgresql-setup.sh
@@ -25,7 +25,7 @@ function check_pgpass_file {
 	fi
 
   if test ! -f "${PGPASSFILE}" ; then
-    echo "Error: PostgeSQL password file ${PGPASSFILE} does not exist."
+    echo "Error: PostgreSQL password file ${PGPASSFILE} does not exist."
     exit 1
     fi
 


### PR DESCRIPTION
There is a typo in an error message in the script. This PR fixes it.