### PR TITLE
Add TxOut dataHash

### DIFF
--- a/cardano-db-sync-extended/CHANGELOG.md
+++ b/cardano-db-sync-extended/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for cardano-db-sync-extended
 
+## Next
+* Add tx_out.data_hash field (Alonzo transaction output data hashes)
+
 ## 10.0.1
 * Fix docker issue (#686).
 

--- a/cardano-db-sync/CHANGELOG.md
+++ b/cardano-db-sync/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for cardano-db-sync
 
+## Next
+* Add tx_out.data_hash field (Alonzo transaction output data hashes)
+
 ## 10.0.1
 * Fix docker issue (#686).
 

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
@@ -185,6 +185,7 @@ insertTxOuts blkId (address, value) = do
               , DB.txOutPaymentCred = Nothing
               , DB.txOutStakeAddressId = Nothing
               , DB.txOutValue = DB.DbLovelace (Byron.unsafeGetLovelace value)
+              , DB.txOutDataHash = Nothing
               }
 
 -- -----------------------------------------------------------------------------

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
@@ -224,6 +224,7 @@ insertTxOut _tracer txId index txout =
               , DB.txOutPaymentCred = Nothing -- Byron does not have a payment credential.
               , DB.txOutStakeAddressId = Nothing -- Byron does not have a stake address.
               , DB.txOutValue = DbLovelace (Byron.unsafeGetLovelace $ Byron.txOutValue txout)
+              , DB.txOutDataHash = Nothing
               }
 
 

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
@@ -198,6 +198,7 @@ insertTxOuts blkId (Shelley.TxIn txInId _, txOut) = do
               , DB.txOutPaymentCred = Generic.maybePaymentCred (txOutAddress txOut)
               , DB.txOutStakeAddressId = Nothing -- No stake addresses in Shelley Genesis
               , DB.txOutValue = Generic.coinToDbLovelace (txOutCoin txOut)
+              , DB.txOutDataHash = Nothing -- No data hash in Shelley Genesis
               }
   where
     txOutAddress :: Shelley.TxOut StandardShelley -> Ledger.Addr StandardCrypto

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -243,7 +243,7 @@ insertTxOut
     :: (MonadBaseControl IO m, MonadIO m)
     => Trace IO Text -> DB.TxId -> Generic.TxOut
     -> ExceptT e (ReaderT SqlBackend m) ()
-insertTxOut tracer txId (Generic.TxOut index addr value maMap) = do
+insertTxOut tracer txId (Generic.TxOut index addr value maMap dataHash) = do
     mSaId <- lift $ insertStakeAddressRefIfMissing txId addr
     txOutId <- lift . DB.insertTxOut $
                 DB.TxOut
@@ -255,6 +255,7 @@ insertTxOut tracer txId (Generic.TxOut index addr value maMap) = do
                   , DB.txOutPaymentCred = Generic.maybePaymentCred addr
                   , DB.txOutStakeAddressId = mSaId
                   , DB.txOutValue = Generic.coinToDbLovelace value
+                  , DB.txOutDataHash = dataHash
                   }
     insertMaTxOut tracer txOutId maMap
   where

--- a/cardano-db/CHANGELOG.md
+++ b/cardano-db/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for cardano-db
 
+## Next
+* Add tx_out.data_hash field (Alonzo transaction output data hashes)
+
 ## 10.0.1
 * Fix docker issue (#686).
 

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -133,6 +133,7 @@ share
     paymentCred         ByteString Maybe    sqltype=hash28type
     stakeAddressId      StakeAddressId Maybe OnDeleteCascade
     value               DbLovelace          sqltype=lovelace
+    dataHash            ByteString Maybe    sqltype=hash32type
     UniqueTxout         txId index          -- The (tx_id, index) pair must be unique.
 
   TxIn
@@ -572,6 +573,7 @@ schemaDocs =
       TxOutPaymentCred # "The payment credential part of the Shelley address. (NULL for Byron addresses). For a script-locked address, this is the script hash."
       TxOutStakeAddressId # "The StakeAddress table index for the stake address part of the Shelley address. (NULL for Byron addresses)."
       TxOutValue # "The output value (in Lovelace) of the transaction output."
+      TxOutDataHash # "The hash of the transaction output datum. (NULL in other than Alonzo eras)."
 
     TxIn --^ do
       "A table for transaction inputs."

--- a/cardano-db/test/Test/IO/Cardano/Db/TotalSupply.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/TotalSupply.hs
@@ -55,6 +55,6 @@ initialSupplyTest =
                   }
     _ <- insertTxIn (TxIn tx1Id (head tx0Ids) 0 Nothing)
     let addr = mkAddressHash bid1 tx1Id
-    _ <- insertTxOut $ TxOut tx1Id 0 (Text.pack addr) (BS.pack addr) False Nothing Nothing (DbLovelace 500000000)
+    _ <- insertTxOut $ TxOut tx1Id 0 (Text.pack addr) (BS.pack addr) False Nothing Nothing (DbLovelace 500000000) Nothing
     supply1 <- queryTotalSupply
     assertBool ("Total supply should be < " ++ show supply0) (supply1 < supply0)

--- a/cardano-db/test/Test/IO/Cardano/Db/Util.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Util.hs
@@ -105,4 +105,4 @@ testSlotLeader =
 mkTxOut :: BlockId -> TxId -> TxOut
 mkTxOut blkId txId =
   let addr = mkAddressHash blkId txId in
-  TxOut txId 0 (Text.pack addr) (BS.pack addr) False Nothing Nothing (DbLovelace 1000000000)
+  TxOut txId 0 (Text.pack addr) (BS.pack addr) False Nothing Nothing (DbLovelace 1000000000) Nothing

--- a/schema/migration-2-0018-20210807.sql
+++ b/schema/migration-2-0018-20210807.sql
@@ -1,0 +1,19 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 18 THEN
+    EXECUTE 'ALTER TABLE "tx_out" ADD COLUMN "data_hash" hash32type NULL' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
Track TxOut data hashes. Testing on Purple looks promising:

```
csyncdb=> SELECT (id,address, index, address_has_script, data_hash) FROM tx_out WHERE data_hash is not null;
                                                                       row                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------
 (118,addr_test1wz9q37z3kgh9c4x7ppa7xplw4va4epvg4r82svvcvlrcdcqzuzfp7,0,t,"\\x915e807fa63409181d1533195753e3170587b1edc089be670ab483da8f9bcd48")
 (134,addr_test1wz9q37z3kgh9c4x7ppa7xplw4va4epvg4r82svvcvlrcdcqzuzfp7,2,t,"\\x915e807fa63409181d1533195753e3170587b1edc089be670ab483da8f9bcd48")
 (147,addr_test1wrjdxkv9acxf7hftv6qpc7pz6r7sr9raqkupxh9uhsk0j8gfvhphg,0,t,"\\x915e807fa63409181d1533195753e3170587b1edc089be670ab483da8f9bcd48")
```

```
$ cardano-cli query utxo --testnet-magic 8 --address addr_test1wz9q37z3kgh9c4x7ppa7xplw4va4epvg4r82svvcvlrcdcqzuzfp7
                           TxHash                                 TxIx        Amount
--------------------------------------------------------------------------------------
251dd1b5b5bd4e5be7b241f5db82bd2d18c8bafc00bd319d0a7d180a1a9ebac0     2        8900000 lovelace + TxOutDatumHash ScriptDataInAlonzoEra "915e807fa63409181d1533195753e3170587b1edc089be670ab483da8f9bcd48"
```

