### PR TITLE
postgresql-setup.sh: only dump public schema

### DIFF
--- a/nix/nixos/cardano-db-sync-service.nix
+++ b/nix/nixos/cardano-db-sync-service.nix
@@ -192,7 +192,7 @@ in {
         done
         if [ -z ''${SKIP_SNAPSHOT:-} ]; then
           set +e
-          SNAPSHOT_SCRIPT=$(cardano-db-tool prepare-snapshot --state-dir ./ | tail -n 1)
+          SNAPSHOT_SCRIPT=$( (yes phrase ||:) | cardano-db-tool prepare-snapshot --state-dir ./ | tail -n 1)
           res=$?
           set -e
           if [ $res -eq 0 ]; then

--- a/nix/nixos/cardano-db-sync-service.nix
+++ b/nix/nixos/cardano-db-sync-service.nix
@@ -191,8 +191,15 @@ in {
           fi
         done
         if [ -z ''${SKIP_SNAPSHOT:-} ]; then
+          set +e
           SNAPSHOT_SCRIPT=$(cardano-db-tool prepare-snapshot --state-dir ./ | tail -n 1)
-          ${../../scripts/postgresql-setup.sh} ''${SNAPSHOT_SCRIPT#*scripts/postgresql-setup.sh}
+          res=$?
+          set -e
+          if [ $res -eq 0 ]; then
+            ${../../scripts/postgresql-setup.sh} ''${SNAPSHOT_SCRIPT#*scripts/postgresql-setup.sh}
+          else
+            >&2 echo "State does not permit to take snapshot, proceeding with normal startup."
+          fi
         fi
         ''}
 

--- a/scripts/postgresql-setup.sh
+++ b/scripts/postgresql-setup.sh
@@ -127,7 +127,7 @@ function run_migrations {
 }
 
 function dump_schema {
-	pg_dump -s "${PGDATABASE}"
+	pg_dump -s --schema=public "${PGDATABASE}"
 }
 
 function create_snapshot {
@@ -136,7 +136,7 @@ function create_snapshot {
 	ledger_file=$2
 	tmp_dir=$(mktemp --directory -t db-sync-snapshot-XXXXXXXXXX)
 	echo $"Working directory: ${tmp_dir}"
-	pg_dump --no-owner "${PGDATABASE}" > "${tmp_dir}/$1.sql"
+	pg_dump --no-owner --schema=public "${PGDATABASE}" > "${tmp_dir}/$1.sql"
 	cp "$ledger_file" "$tmp_dir/$(basename "${ledger_file}")"
 	tar zcvf "${tgz_file}" --directory "${tmp_dir}" "${dbfile}" "$(basename "${ledger_file}")"
 	rm -rf "${tmp_dir}"

--- a/scripts/postgresql-setup.sh
+++ b/scripts/postgresql-setup.sh
@@ -138,7 +138,8 @@ function create_snapshot {
 	echo $"Working directory: ${tmp_dir}"
 	pg_dump --no-owner --schema=public "${PGDATABASE}" > "${tmp_dir}/$1.sql"
 	cp "$ledger_file" "$tmp_dir/$(basename "${ledger_file}")"
-	tar zcvf "${tgz_file}" --directory "${tmp_dir}" "${dbfile}" "$(basename "${ledger_file}")"
+	tar zcvf "${tgz_file}.tmp" --directory "${tmp_dir}" "${dbfile}" "$(basename "${ledger_file}")"
+	mv "${tgz_file}.tmp" "${tgz_file}"
 	rm -rf "${tmp_dir}"
 	if test "$(gzip --test "${tgz_file}")" ; then
 	  echo "Gzip reports the snapshot file as being corrupt."


### PR DESCRIPTION
since all db-sync object are in public this avoid dumping
objects from other applications using separate schemas.