### PR TITLE
Support networks that fork at 0

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Block.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Block.hs
@@ -54,7 +54,7 @@ import qualified Shelley.Spec.Ledger.Tx as Shelley
 data Block = Block
   { blkEra :: !BlockEra
   , blkHash :: !ByteString
-  , blkPreviousHash :: !ByteString
+  , blkPreviousHash :: !(Maybe ByteString) -- Nothing is used for first block after Genesis.
   , blkCreatorPoolHash :: !ByteString
   , blkSlotLeader :: !ByteString
   , blkSlotNo :: !SlotNo
@@ -156,11 +156,11 @@ blockHash =
 blockNumber :: ShelleyBasedEra era => ShelleyBlock era -> BlockNo
 blockNumber = Shelley.bheaderBlockNo . blockBody
 
-blockPrevHash :: ShelleyBasedEra era => ShelleyBlock era -> ByteString
+blockPrevHash :: ShelleyBasedEra era => ShelleyBlock era -> Maybe ByteString
 blockPrevHash blk =
   case Shelley.bheaderPrev (Shelley.bhbody . Shelley.bheader $ Consensus.shelleyBlockRaw blk) of
-    Shelley.GenesisHash -> "Cardano.DbSync.Era.Shelley.Generic.Block.blockPrevHash"
-    Shelley.BlockHash h -> Crypto.hashToBytes (Shelley.unHashHeader h)
+    Shelley.GenesisHash -> Nothing
+    Shelley.BlockHash h -> Just $ Crypto.hashToBytes (Shelley.unHashHeader h)
 
 blockOpCert :: ShelleyBasedEra era => ShelleyBlock era -> ByteString
 blockOpCert = KES.rawSerialiseVerKeyKES . Shelley.ocertVkHot . Shelley.bheaderOCert . blockBody

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -12,6 +12,12 @@ module Cardano.DbSync.Era.Shelley.Insert
   , postEpochRewards
   , postEpochStake
 
+  -- These are exported for data in Shelley Genesis
+  , insertPoolRegister
+  , insertDelegation
+  , insertStakeAddressRefIfMissing
+
+  -- Util
   , containsUnicodeNul
   , safeDecodeUtf8
   ) where
@@ -29,10 +35,10 @@ import qualified Cardano.Crypto.Hash as Crypto
 import           Cardano.Db (DbLovelace (..), DbWord64 (..), SyncState (..))
 import qualified Cardano.Db as DB
 
-import           Cardano.DbSync.Era
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import           Cardano.DbSync.Era.Shelley.Generic.ParamProposal
 import           Cardano.DbSync.Era.Shelley.Insert.Epoch
+import           Cardano.DbSync.Era.Shelley.Offline
 import           Cardano.DbSync.Era.Shelley.Query
 import           Cardano.DbSync.Era.Util (liftLookupFail, safeDecodeUtf8)
 
@@ -81,7 +87,9 @@ insertShelleyBlock
     -> ReaderT SqlBackend m (Either SyncNodeError ())
 insertShelleyBlock tracer lenv blk lStateSnap details = do
   runExceptT $ do
-    pbid <- liftLookupFail (renderInsertName (Generic.blkEra blk)) $ DB.queryBlockId (Generic.blkPreviousHash blk)
+    pbid <- case Generic.blkPreviousHash blk of
+      Nothing -> liftLookupFail (renderInsertName (Generic.blkEra blk)) DB.queryGenesis -- this is for networks that fork from Byron on epoch 0.
+      Just pHash -> liftLookupFail (renderInsertName (Generic.blkEra blk)) $ DB.queryBlockId pHash
     mPhid <- lift $ queryPoolHashId (Generic.blkCreatorPoolHash blk)
 
     slid <- lift . DB.insertSlotLeader $ Generic.mkSlotLeader (Generic.blkSlotLeader blk) mPhid
@@ -317,7 +325,7 @@ insertPoolCert
     -> ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertPoolCert tracer lStateSnap network epoch blkId txId idx pCert =
   case pCert of
-    Shelley.RegPool pParams -> insertPoolRegister tracer lStateSnap network epoch blkId txId idx pParams
+    Shelley.RegPool pParams -> insertPoolRegister tracer (Right lStateSnap) network epoch blkId txId idx pParams
     Shelley.RetirePool keyHash epochNum -> insertPoolRetire txId epochNum idx keyHash
 
 insertDelegCert
@@ -334,9 +342,9 @@ insertDelegCert tracer network txId idx ridx epochNo slotNo redeemers dCert =
 
 insertPoolRegister
     :: (MonadBaseControl IO m, MonadIO m)
-    => Trace IO Text -> LedgerStateSnapshot -> Ledger.Network -> EpochNo -> DB.BlockId -> DB.TxId -> Word16 -> Shelley.PoolParams StandardCrypto
+    => Trace IO Text -> Either Word64 LedgerStateSnapshot -> Ledger.Network -> EpochNo -> DB.BlockId -> DB.TxId -> Word16 -> Shelley.PoolParams StandardCrypto
     -> ExceptT SyncNodeError (ReaderT SqlBackend m) ()
-insertPoolRegister tracer lStateSnap network (EpochNo epoch) blkId txId idx params = do
+insertPoolRegister tracer mlStateSnap network (EpochNo epoch) blkId txId idx params = do
 
     when (fromIntegral (Ledger.unCoin $ Shelley._poolPledge params) > maxLovelace) $
       liftIO . logWarning tracer $
@@ -379,8 +387,9 @@ insertPoolRegister tracer lStateSnap network (EpochNo epoch) blkId txId idx para
 
   where
     mkEpochActivationDelay :: MonadIO m => DB.PoolHashId -> ExceptT SyncNodeError (ReaderT SqlBackend m) Word64
-    mkEpochActivationDelay poolHashId =
-      if Set.member (Shelley._poolId params) $ getPoolParams (lssOldState lStateSnap)
+    mkEpochActivationDelay poolHashId = case mlStateSnap of
+      Left n -> pure n
+      Right lStateSnap -> if Set.member (Shelley._poolId params) $ getPoolParams (lssOldState lStateSnap)
         then pure 3
         else do
           -- if the pool is not registered at the end of the previous block, check for

--- a/cardano-db/src/Cardano/Db/Delete.hs
+++ b/cardano-db/src/Cardano/Db/Delete.hs
@@ -10,7 +10,7 @@ import           Cardano.Slotting.Slot (SlotNo (..))
 import           Control.Monad.IO.Class (MonadIO)
 import           Control.Monad.Trans.Reader (ReaderT)
 
-import           Database.Persist.Sql (SqlBackend, delete, selectKeysList, (==.))
+import           Database.Persist.Sql (SqlBackend, delete, selectKeysList, (!=.), (==.))
 
 import           Cardano.Db.Schema
 
@@ -29,7 +29,8 @@ deleteCascadeBlock block = do
 -- deleted and 'False' if it did not exist.
 deleteCascadeAfter :: MonadIO m => BlockId -> ReaderT SqlBackend m Bool
 deleteCascadeAfter bid = do
-  keys <- selectKeysList [ BlockPreviousId ==. Just bid ] []
+  -- Genesis artificial blocks are not deleted (Byron or Shelley) since they have null epoch
+  keys <- selectKeysList [ BlockPreviousId ==. Just bid, BlockEpochNo !=. Nothing ] []
   mapM_ delete keys
   pure $ not (null keys)
 

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -414,7 +414,7 @@ share
     minPoolCost         DbLovelace Maybe    sqltype=lovelace
 
     coinsPerUtxoWord    DbLovelace Maybe    sqltype=lovelace
-    costModelsId        CostModelsId Maybe
+    costModelsId        CostModelsId Maybe  OnDeleteCascade
     priceMem            Double Maybe        -- sqltype=rational
     priceStep           Double Maybe        -- sqltype=rational
     maxTxExMem          DbWord64 Maybe      sqltype=word64type
@@ -452,7 +452,7 @@ share
     nonce               ByteString Maybe    sqltype=hash32type
 
     coinsPerUtxoWord    DbLovelace Maybe    sqltype=lovelace
-    costModelsId        CostModelsId Maybe
+    costModelsId        CostModelsId Maybe  OnDeleteCascade
     priceMem            Double Maybe        -- sqltype=rational
     priceStep           Double Maybe        -- sqltype=rational
     maxTxExMem          DbWord64 Maybe      sqltype=word64type

--- a/cardano-sync/src/Cardano/Sync/Era/Shelley/Generic/Rewards.hs
+++ b/cardano-sync/src/Cardano/Sync/Era/Shelley/Generic/Rewards.hs
@@ -109,7 +109,8 @@ genericRewards network era epoch lstate =
     cleanup :: Map StakeCred (Set Reward) -> Rewards
     cleanup rmap =
       Rewards
-        { rwdEpoch = epoch - 1 -- Epoch in which rewards were earned.
+        { rwdEpoch = if epoch < 1 then 0 else epoch - 1 -- Epoch in which rewards were earned.
+                                                        -- The check exists for networks that start at Shelley.
         , rwdRewards = filterByEra era rmap
         }
 

--- a/schema/migration-2-0024-20210910.sql
+++ b/schema/migration-2-0024-20210910.sql
@@ -1,0 +1,23 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 24 THEN
+    EXECUTE 'ALTER TABLE "redeemer" ADD CONSTRAINT "redeemer_datum_id_fkey" FOREIGN KEY("datum_id") REFERENCES "datum"("id") ON DELETE CASCADE  ON UPDATE RESTRICT' ;
+    EXECUTE 'ALTER TABLE "param_proposal" DROP CONSTRAINT "param_proposal_cost_models_id_fkey"' ;
+    EXECUTE 'ALTER TABLE "param_proposal" ADD CONSTRAINT "param_proposal_cost_models_id_fkey" FOREIGN KEY("cost_models_id") REFERENCES "cost_models"("id") ON DELETE CASCADE  ON UPDATE RESTRICT' ;
+    EXECUTE 'ALTER TABLE "epoch_param" DROP CONSTRAINT "epoch_param_cost_models_id_fkey"' ;
+    EXECUTE 'ALTER TABLE "epoch_param" ADD CONSTRAINT "epoch_param_cost_models_id_fkey" FOREIGN KEY("cost_models_id") REFERENCES "cost_models"("id") ON DELETE CASCADE  ON UPDATE RESTRICT' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/cardano-db-sync/issues/507

With this pr db-sync supports node configuration like
`"TestShelleyHardForkAtEpoch": 0`

It also supports initial funds and staking in the Shelley Genesis

When the Shelley Genesis file has some important information, like initial distribution, pools and delegations, an artificial Shelley Genesis Block is inserted and artificial Txs, to attach all the information to it. The genesis blocks have some unique characteristics in the db:
- Byron Genesis Block has null EpochNo and null PreviousId
- Shelley Genesis Block has null EpochNo and non-null PreviousId

 In most cases the Shelley Genesis Block will be the next block of the Byron Genesis block. This means the byron genesis block may have two next blocks.

The Shelley Genesis block is not inserted, if it lacks any important information (funds/staking). So this should not affect mainnet.