### PR TITLE
Update example query - Get the reward history, epoch number

### DIFF
--- a/doc/interesting-queries.md
+++ b/doc/interesting-queries.md
@@ -257,11 +257,11 @@ epochs 214, 216 and 217.
 ### Get the reward history for a specified stake address
 
 ```sql
-select reward.epoch_no, pool_hash.view as delegated_pool, reward.amount as lovelace
+select reward.earned_epoch, pool_hash.view as delegated_pool, reward.amount as lovelace
     from reward inner join stake_address on reward.addr_id = stake_address.id
     inner join pool_hash on reward.pool_id = pool_hash.id
     where stake_address.view = 'stake1u8gsndukzghdukmqdsd7r7wd6kvamvjv2pzcgag8v6jd69qfqyl5h'
-    order by epoch_no asc ;
+    order by earned_epoch asc ;
  epoch_no |                      delegated_pool                      | lovelace
 ----------+----------------------------------------------------------+----------
       212 | pool1hwlghkwnjsjk8370qt3dvp23d7urwm36f95fmxcz3np2kghknj9 |  2953284


### PR DESCRIPTION
Column reward.epoch_no does not exist, should be replaced by reward.earned_epoch