### PR TITLE
Store scripts

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -11,9 +11,6 @@ module Cardano.DbSync.Era.Shelley.Insert
   ( insertShelleyBlock
   , postEpochRewards
   , postEpochStake
-
-  , containsUnicodeNul
-  , safeDecodeUtf8
   ) where
 
 import           Cardano.Prelude
@@ -34,7 +31,7 @@ import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import           Cardano.DbSync.Era.Shelley.Generic.ParamProposal
 import           Cardano.DbSync.Era.Shelley.Insert.Epoch
 import           Cardano.DbSync.Era.Shelley.Query
-import           Cardano.DbSync.Era.Util (liftLookupFail, safeDecodeUtf8)
+import           Cardano.DbSync.Era.Util (liftLookupFail, safeDecodeToJson)
 
 import qualified Cardano.Ledger.Address as Ledger
 import           Cardano.Ledger.Alonzo.Language (Language)
@@ -64,7 +61,6 @@ import           Data.Group (invert)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe.Strict (strictMaybeToMaybe)
 import qualified Data.Set as Set
-import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
 import           Database.Persist.Sql (SqlBackend)
@@ -725,21 +721,7 @@ insertDatum
   => Trace IO Text -> DB.TxId -> Generic.TxDatum
   -> ExceptT SyncNodeError (ReaderT SqlBackend m) DB.DatumId
 insertDatum tracer txId txd = do
-    ejson <- liftIO $ safeDecodeUtf8 $ Generic.txDatumValue txd
-    value <- case ejson of
-      Left err -> do
-        liftIO . logWarning tracer $ mconcat
-            [ "insertDatum: Could not decode to UTF8: ", textShow err ]
-        -- We have to inser
-        pure Nothing
-      Right json ->
-        -- See https://github.com/input-output-hk/cardano-db-sync/issues/297
-        if containsUnicodeNul json
-          then do
-            liftIO $ logWarning tracer "insertDatum: dropped due to a Unicode NUL character."
-            pure Nothing
-          else
-            pure $ Just json
+    value <- safeDecodeToJson tracer "insertDatum" $ Generic.txDatumValue txd
 
     lift . DB.insertDatum $ DB.Datum
       { DB.datumHash = Generic.txDatumHash txd
@@ -761,20 +743,8 @@ insertTxMetadata tracer txId metadata =
     insert (key, md) = do
       let jsonbs = LBS.toStrict $ Aeson.encode (metadataValueToJsonNoSchema md)
           singleKeyCBORMetadata = serialiseToCBOR $ makeTransactionMetadata (Map.singleton key md)
-      ejson <- liftIO $ safeDecodeUtf8 jsonbs
-      mjson <- case ejson of
-                 Left err -> do
-                   liftIO . logWarning tracer $ mconcat
-                      [ "insertTxMetadata: Could not decode to UTF8: ", textShow err ]
-                   pure Nothing
-                 Right json ->
-                   -- See https://github.com/input-output-hk/cardano-db-sync/issues/297
-                   if containsUnicodeNul json
-                     then do
-                       liftIO $ logWarning tracer "insertTxMetadata: dropped due to a Unicode NUL character."
-                       pure Nothing
-                     else
-                       pure $ Just json
+      mjson <- safeDecodeToJson tracer "insertTxMetdata" jsonbs
+
       void . lift . DB.insertTxMetadata $
         DB.TxMetadata
           { DB.txMetadataKey = DbWord64 key
@@ -782,9 +752,6 @@ insertTxMetadata tracer txId metadata =
           , DB.txMetadataBytes = singleKeyCBORMetadata
           , DB.txMetadataTxId = txId
           }
-
-containsUnicodeNul :: Text -> Bool
-containsUnicodeNul = Text.isInfixOf "\\u000"
 
 insertCostModels
     :: (MonadBaseControl IO m, MonadIO m)

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -379,6 +379,8 @@ share
     txId                TxId                OnDeleteCascade
     hash                ByteString          sqltype=hash28type
     type                ScriptType          sqltype=scripttype
+    json                Text Maybe          sqltype=jsonb
+    bytes               ByteString Maybe    sqltype=bytea
     serialisedSize      Word64 Maybe        sqltype=uinteger
     UniqueScript        hash
 
@@ -794,6 +796,8 @@ schemaDocs =
       ScriptTxId # "The Tx table index for the transaction where this script first became available."
       ScriptHash # "The Hash of the Script."
       ScriptType # "The type of the script. This is currenttly either 'timelock' or 'plutus'."
+      ScriptJson # "JSON representation of the timelock script, null for other script types"
+      ScriptBytes # "CBOR encoded plutus script data, null for other script types"
       ScriptSerialisedSize # "The size of the CBOR serialised script, if it is a Plutus script."
 
     Datum --^ do

--- a/schema/migration-2-0024-20210909.sql
+++ b/schema/migration-2-0024-20210909.sql
@@ -1,0 +1,21 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 24 THEN
+    EXECUTE 'ALTER TABLE "redeemer" ADD CONSTRAINT "redeemer_datum_id_fkey" FOREIGN KEY("datum_id") REFERENCES "datum"("id") ON DELETE CASCADE  ON UPDATE RESTRICT' ;
+    EXECUTE 'ALTER TABLE "script" ADD COLUMN "json" jsonb NULL' ;
+    EXECUTE 'ALTER TABLE "script" ADD COLUMN "bytes" bytea NULL' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
Store both `timelock` and `plutus` script contents.

We store `timelock`s as `jsonb` and `plutus` scripts as CBOR encoded `bytea`s.

Contains #800