### PR TITLE
Introduce smash executable and smash server config

### DIFF
--- a/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
+++ b/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import           Cardano.Prelude
+import           Prelude (read)
 
 import           Cardano.Config.Git.Rev (gitRev)
 
@@ -10,6 +11,9 @@ import           Cardano.DbSync.Metrics (withMetricSetters)
 import           Cardano.DbSync.Plugin.Extended (extendedDbSyncNodePlugin)
 
 import           Cardano.Slotting.Slot (SlotNo (..))
+
+import           Cardano.SMASH.Server.Config (defaultSmashPort)
+
 import           Cardano.Sync.Config
 import           Cardano.Sync.Config.Types
 
@@ -66,6 +70,7 @@ pRunDbSyncNode =
     <*> pMigrationDir
     <*> pRunSmash
     <*> optional pSmashUserFile
+    <*> asum [pSmashPort, pure defaultSmashPort]
     <*> optional pSlotNo
 
 pConfigFile :: Parser ConfigFile
@@ -108,6 +113,15 @@ pSmashUserFile =
     <> Opt.help "Path to the file containing the credentials of smash server admin users"
     <> Opt.completer (Opt.bashCompleter "file")
     <> Opt.metavar "FILEPATH"
+    )
+
+pSmashPort :: Parser Int
+pSmashPort =
+  read <$> Opt.strOption
+    ( Opt.long "smash-port"
+    <> Opt.help "Port for the smash web app server"
+    <> Opt.completer (Opt.bashCompleter "port")
+    <> Opt.metavar "PORT"
     )
 
 pSocketPath :: Parser SocketPath

--- a/cardano-db-sync-extended/cardano-db-sync-extended.cabal
+++ b/cardano-db-sync-extended/cardano-db-sync-extended.cabal
@@ -79,5 +79,6 @@ executable cardano-db-sync-extended
                       , cardano-sync
                       , cardano-prelude
                       , cardano-slotting
+                      , cardano-smash-server
                       , optparse-applicative
                       , text

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -2,11 +2,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import           Cardano.Prelude
+import           Prelude (read)
 
 import           Cardano.Config.Git.Rev (gitRev)
 
 import           Cardano.DbSync (defDbSyncNodePlugin, runDbSyncNode)
 import           Cardano.DbSync.Metrics (withMetricSetters)
+
+import           Cardano.SMASH.Server.Config (defaultSmashPort)
 
 import           Cardano.Sync.Config
 import           Cardano.Sync.Config.Types
@@ -65,6 +68,7 @@ pRunDbSyncNode =
     <*> pMigrationDir
     <*> pRunSmash
     <*> optional pSmashUserFile
+    <*> asum [pSmashPort, pure defaultSmashPort]
     <*> optional pSlotNo
 
 pConfigFile :: Parser ConfigFile
@@ -107,6 +111,15 @@ pSmashUserFile =
     <> Opt.help "Path to the file containing the credentials of smash server admin users"
     <> Opt.completer (Opt.bashCompleter "file")
     <> Opt.metavar "FILEPATH"
+    )
+
+pSmashPort :: Parser Int
+pSmashPort =
+  read <$> Opt.strOption
+    ( Opt.long "smash-port"
+    <> Opt.help "Port for the smash web app server"
+    <> Opt.completer (Opt.bashCompleter "port")
+    <> Opt.metavar "PORT"
     )
 
 pSocketPath :: Parser SocketPath

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -168,5 +168,6 @@ executable cardano-db-sync
                       , cardano-db-sync
                       , cardano-prelude
                       , cardano-slotting
+                      , cardano-smash-server
                       , optparse-applicative
                       , text

--- a/cardano-smash-server/app/cardano-smash-server.hs
+++ b/cardano-smash-server/app/cardano-smash-server.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import           Cardano.Prelude
+import           Prelude (read)
+
+import           Options.Applicative (Parser, ParserInfo)
+import qualified Options.Applicative as Opt
+
+import           Cardano.Config.Git.Rev (gitRev)
+
+import           Cardano.SMASH.Server.Config
+import           Cardano.SMASH.Server.Run
+
+import           Data.String (String)
+import qualified Data.Text as Text
+import           Data.Version (showVersion)
+
+import           Paths_cardano_smash_server (version)
+
+import           System.Info (arch, compilerName, compilerVersion, os)
+
+main :: IO ()
+main = do
+  cmd <- Opt.execParser opts
+  case cmd of
+    CmdVersion -> runVersionCommand
+    CmdRun params -> do
+      serverConfig <- paramsToConfig params
+      runSmashServer serverConfig
+
+data SmashServerCommand
+  = CmdRun !SmashServerParams
+  | CmdVersion
+
+opts :: ParserInfo SmashServerCommand
+opts =
+  Opt.info (pCommandLine <**> Opt.helper)
+    ( Opt.fullDesc
+    <> Opt.progDesc "Cardano Smash web server."
+    )
+
+pCommandLine :: Parser SmashServerCommand
+pCommandLine =
+  asum
+    [ pVersionCommand
+    , CmdRun <$> pSmashServerParams
+    ]
+
+pSmashServerParams :: Parser SmashServerParams
+pSmashServerParams =
+  SmashServerParams
+    <$> asum [pSmashPort, pure defaultSmashPort]
+    <*> pSmashConfig
+    <*> optional pSmashUserFile
+
+pSmashUserFile :: Parser FilePath
+pSmashUserFile =
+  Opt.strOption
+    ( Opt.long "admins"
+    <> Opt.help (  "Path to the csv file containing the credentials of smash server admin users."
+                ++ "It should include lines in the form of username,password")
+    <> Opt.completer (Opt.bashCompleter "file")
+    <> Opt.metavar "FILEPATH"
+    )
+
+pSmashConfig :: Parser FilePath
+pSmashConfig =
+  Opt.strOption
+    ( Opt.long "config"
+    <> Opt.help "Path to the smash or db-sync config file. This is used to parse logging config."
+    <> Opt.completer (Opt.bashCompleter "file")
+    <> Opt.metavar "FILEPATH"
+    )
+
+pSmashPort :: Parser Int
+pSmashPort =
+  read <$> Opt.strOption
+    ( Opt.long "smash-port"
+    <> Opt.help "Port for the smash web app server. Default is 3100."
+    <> Opt.completer (Opt.bashCompleter "port")
+    <> Opt.metavar "PORT"
+    )
+
+pVersionCommand :: Parser SmashServerCommand
+pVersionCommand =
+  asum
+    [ Opt.subparser
+        ( mconcat
+          [ command' "version" "Show the program version" (pure CmdVersion) ]
+        )
+    , Opt.flag' CmdVersion
+        (  Opt.long "version"
+        <> Opt.help "Show the program version"
+        <> Opt.hidden
+        )
+    ]
+
+command' :: String -> String -> Parser a -> Opt.Mod Opt.CommandFields a
+command' c descr p =
+  Opt.command c
+    $ Opt.info (p <**> Opt.helper)
+    $ mconcat [ Opt.progDesc descr ]
+
+runVersionCommand :: IO ()
+runVersionCommand = do
+    liftIO . putTextLn $ mconcat
+                [ "cardano-smash-server ", renderVersion version
+                , " - ", Text.pack os, "-", Text.pack arch
+                , " - ", Text.pack compilerName, "-", renderVersion compilerVersion
+                , "\ngit revision ", gitRev
+                ]
+  where
+    renderVersion = Text.pack . showVersion

--- a/cardano-smash-server/cardano-smash-server.cabal
+++ b/cardano-smash-server/cardano-smash-server.cabal
@@ -56,6 +56,7 @@ library
                         -fno-warn-orphans
 
   exposed-modules:      Cardano.SMASH.Server.Api
+                        Cardano.SMASH.Server.Config
                         Cardano.SMASH.Server.FetchPolicies
                         Cardano.SMASH.Server.Impl
                         Cardano.SMASH.Server.PoolDataLayer
@@ -86,6 +87,40 @@ library
                       , transformers-except
                       , wai
                       , warp
+                      , yaml
 
   default-extensions:   NoImplicitPrelude
                         OverloadedStrings
+
+executable cardano-smash-server
+  default-language:     Haskell2010
+  main-is:              cardano-smash-server.hs
+  hs-source-dirs:       app
+
+  ghc-options:          -O2
+                        -Wall
+                        -Werror
+                        -Wcompat
+                        -Wredundant-constraints
+                        -Wincomplete-patterns
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wunused-imports
+                        -Wunused-packages
+                        -Wno-unsafe
+                        -threaded
+                        -with-rtsopts=-N3
+
+  autogen-modules:      Paths_cardano_smash_server
+
+  other-modules:        Paths_cardano_smash_server
+
+  build-depends:        base                            >= 4.14         && < 4.16
+                      , cardano-config
+                      , cardano-smash-server
+                      , cardano-prelude
+                      , optparse-applicative
+                      , text
+
+
+

--- a/cardano-smash-server/src/Cardano/SMASH/Server/Config.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/Config.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.SMASH.Server.Config where
+
+import           Cardano.Prelude
+
+import           Data.Aeson
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import qualified Data.Yaml as Yaml
+
+import qualified Cardano.BM.Configuration.Model as Logging
+import qualified Cardano.BM.Setup as Logging
+import           Cardano.BM.Trace (Trace)
+import           Cardano.Db (textShow)
+
+import           System.IO.Error
+
+data SmashServerParams = SmashServerParams
+  { sspSmashPort :: !Int
+  , sspConfigFile :: !FilePath -- config is only used for the logging parameters.
+  , sspAdminUsers :: !(Maybe FilePath)
+  }
+
+defaultSmashPort :: Int
+defaultSmashPort = 3100
+
+paramsToConfig :: SmashServerParams -> IO SmashServerConfig
+paramsToConfig params = do
+  appUsers <- readAppUsers $ sspAdminUsers params
+  tracer <- configureLogging (sspConfigFile params) "smash-server"
+  pure $ SmashServerConfig
+    { sscSmashPort = sspSmashPort params
+    , sscTrace = tracer
+    , sscAdmins = appUsers
+    }
+
+data SmashServerConfig = SmashServerConfig
+  { sscSmashPort :: Int
+  , sscTrace :: Trace IO Text
+  , sscAdmins :: ApplicationUsers
+  }
+
+-- A data type we use to store user credentials.
+data ApplicationUser = ApplicationUser
+    { username :: !Text
+    , password :: !Text
+    } deriving (Eq, Show, Generic)
+
+instance ToJSON ApplicationUser
+instance FromJSON ApplicationUser
+
+-- A list of users with special rights.
+newtype ApplicationUsers = ApplicationUsers [ApplicationUser]
+    deriving (Eq, Show, Generic)
+
+instance ToJSON ApplicationUsers
+instance FromJSON ApplicationUsers
+
+readAppUsers :: Maybe FilePath -> IO ApplicationUsers
+readAppUsers mPath = case mPath of
+  Nothing -> pure $ ApplicationUsers []
+  Just path -> do
+    userLines <- Text.lines <$> Text.readFile path
+    case mapM parseAppUser userLines of
+      Right users -> pure $ ApplicationUsers users
+      Left err -> throwIO $ userError $ Text.unpack err
+
+parseAppUser :: Text -> Either Text ApplicationUser
+parseAppUser line = case Text.breakOn "," line of
+    (user, commaPswd)
+      | not (Text.null commaPswd)
+      , passwd <- Text.tail commaPswd -- strip the comma
+      -> Right $ ApplicationUser (prepareCred user) (prepareCred passwd)
+    _ -> Left "Credentials need to be supplied in the form: username,password"
+  where
+    prepareCred name = Text.strip name
+
+configureLogging :: FilePath -> Text -> IO (Trace IO Text)
+configureLogging fp loggingName = do
+  bs <- readByteString fp "DbSync" -- only uses the db-sync config
+  case Yaml.decodeEither' bs of
+    Left err -> panic $ "readSyncNodeConfig: Error parsing config: " <> textShow err
+    Right representation -> do
+      -- Logging.Configuration
+      logConfig <- Logging.setupFromRepresentation representation
+      liftIO $ Logging.setupTrace (Right logConfig) loggingName
+
+readByteString :: FilePath -> Text -> IO ByteString
+readByteString fp cfgType =
+  catch (BS.readFile fp) $ \(_ :: IOException) ->
+    panic $ mconcat [ "Cannot find the ", cfgType, " configuration file at : ", Text.pack fp ]

--- a/cardano-smash-server/src/Cardano/SMASH/Server/Types.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/Types.hs
@@ -348,24 +348,6 @@ instance MonadFail (Either Text) where
 
 instance ToParamSchema TimeStringFormat
 
-
--- A data type we use to store user credentials.
-data ApplicationUser = ApplicationUser
-    { username :: !Text
-    , password :: !Text
-    } deriving (Eq, Show, Generic)
-
-instance ToJSON ApplicationUser
-instance FromJSON ApplicationUser
-
--- A list of users we use.
-newtype ApplicationUsers = ApplicationUsers [ApplicationUser]
-    deriving (Eq, Show, Generic)
-
-instance ToJSON ApplicationUsers
-instance FromJSON ApplicationUsers
-
-
 -- | A user we'll grab from the database when we authenticate someone
 newtype User = User { userName :: Text }
   deriving (Eq, Show)

--- a/cardano-sync/src/Cardano/Sync/Config/Types.hs
+++ b/cardano-sync/src/Cardano/Sync/Config/Types.hs
@@ -110,6 +110,7 @@ data SyncNodeParams = SyncNodeParams
   , enpMigrationDir :: !MigrationDir
   , enpRunSmash :: !Bool
   , enpSmashUserFile :: !(Maybe FilePath)
+  , enpSmashPort :: !Int
   , enpMaybeRollback :: !(Maybe SlotNo)
   }
 


### PR DESCRIPTION
smash standalone server.
```
Usage: cardano-smash-server (COMMAND | [--smash-port PORT] --config FILEPATH 
                              [--admins FILEPATH])
  Cardano Smash web server.

Available options:
  --version                Show the program version
  --smash-port PORT        Port for the smash web app server
  --config FILEPATH        Path to the smash or db-sync config file. This is
                           used to parse logging config.
  --admins FILEPATH        Path to the file containing the credentials of smash
                           server admin users
  -h,--help                Show this help text

Available commands:
  version                  Show the program version
```
