### PR TITLE
Rework ticker endpoints

### DIFF
--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -517,7 +517,7 @@ share
   -- For now they are grouped under the specific hash of the pool.
   ReservedPoolTicker
     name                Text
-    poolId              PoolHashId
+    poolHash            ByteString          sqltype=hash28type
     UniqueReservedPoolTicker name
 
   -- A table containing delisted pools.
@@ -915,7 +915,7 @@ schemaDocs =
     ReservedPoolTicker --^ do
       "A table containing a managed list of reserved ticker names."
       ReservedPoolTickerName # "The ticker name."
-      ReservedPoolTickerPoolId # "The PoolHash table index for the pool that has reserved this name."
+      ReservedPoolTickerPoolHash # "The hash of the pool that owns this ticker."
 
     DelistedPool --^ do
       "A table containing pools that have been delisted."

--- a/cardano-db/src/Cardano/Db/Schema/Types.hs
+++ b/cardano-db/src/Cardano/Db/Schema/Types.hs
@@ -7,7 +7,6 @@ module Cardano.Db.Schema.Types
   , PaymentAddrHash (..)
   , PoolMetaHash (..)
   , PoolUrl (..)
-  , TickerName (..)
   ) where
 
 import           Data.ByteString.Char8 (ByteString)
@@ -52,10 +51,3 @@ newtype PoolUrl
   = PoolUrl { unPoolUrl :: Text }
   deriving (Eq, Ord, Generic)
   deriving Show via (Quiet PoolUrl)
-
--- | The ticker name wrapper so we have some additional safety.
-newtype TickerName
-  = TickerName { unTickerName :: Text }
-  deriving (Eq, Ord, Generic)
-  deriving Show via (Quiet TickerName)
-

--- a/cardano-smash-server/src/Cardano/SMASH/Server/Api.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/Api.hs
@@ -99,7 +99,7 @@ type DelistPoolAPI = BasicAuthURL :> "api" :> APIVersion :> "delist" :> ReqBody 
 
 type EnlistPoolAPI = BasicAuthURL :> "api" :> APIVersion :> "enlist" :> ReqBody '[JSON] PoolId :> ApiRes Patch PoolId
 
-type AddTickerAPI = "api" :> APIVersion :> "tickers" :> Capture "name" TickerName :> ReqBody '[JSON] PoolMetadataHash :> ApiRes Post TickerName
+type AddTickerAPI = BasicAuthURL :> "api" :> APIVersion :> "tickers" :> Capture "name" TickerName :> ReqBody '[JSON] PoolId :> ApiRes Post TickerName
 
 -- Enabling the SMASH server to fetch the policies from remote SMASH server. Policies like delisting or unique ticker names.
 type FetchPoliciesAPI = BasicAuthURL :> "api" :> APIVersion :> "policies" :> ReqBody '[JSON] SmashURL :> ApiRes Post PolicyResult

--- a/cardano-smash-server/src/Cardano/SMASH/Server/Types.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/Types.hs
@@ -26,7 +26,7 @@ import           Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
 import           Network.URI (URI, parseURI)
 import           Servant (FromHttpApiData (..), MimeUnrender (..), OctetStream)
 
-import           Cardano.Db hiding (TickerName)
+import           Cardano.Db
 
 import           Cardano.Api (AsType (..), Hash, deserialiseFromBech32, deserialiseFromRawBytesHex,
                    serialiseToRawBytes)
@@ -232,20 +232,20 @@ instance ToSchema SmashURL where
     pure (NamedSchema (Just "SmashURL") mempty)
 
 
-newtype UniqueTicker = UniqueTicker { getUniqueTicker :: (TickerName, PoolMetadataHash) }
+newtype UniqueTicker = UniqueTicker { getUniqueTicker :: (TickerName, PoolId) }
     deriving (Eq, Show, Generic)
 
 instance ToJSON UniqueTicker where
     toJSON (UniqueTicker (tickerName, poolMetadataHash)) =
         object
             [ "tickerName" .= getTickerName tickerName
-            , "poolMetadataHash" .= getPoolMetadataHash poolMetadataHash
+            , "poolId" .= getPoolId poolMetadataHash
             ]
 
 instance FromJSON UniqueTicker where
     parseJSON = withObject "UniqueTicker" $ \o -> do
         tickerName <- o .: "tickerName"
-        poolMetadataHash <- o .: "poolMetadataHash"
+        poolMetadataHash <- o .: "poolId"
 
         pure . UniqueTicker $ (tickerName, poolMetadataHash)
 

--- a/schema/migration-2-0005-20211018.sql
+++ b/schema/migration-2-0005-20211018.sql
@@ -1,0 +1,20 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 5 THEN
+    EXECUTE 'ALTER TABLE "reserved_pool_ticker" ADD COLUMN "pool_hash" hash28type NOT NULL' ;
+    EXECUTE 'ALTER TABLE "reserved_pool_ticker" DROP COLUMN "pool_id"' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
The ticker endpoints were never used and were actually unusable. Previous implementation associated tickers to pool metadata hash. It makes more sense to associate tickers to pools, in the sense that a pool owns a ticker.

The idea is that if a pool uses a ticker that is reserved by another pool, its "metadata" endpoint will start returning 404.