### PR TITLE
Stop supporting configs which don't initiate Shelley properly

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era.hs
@@ -22,10 +22,10 @@ import           Cardano.DbSync.Era.Shelley.Offline as X
 import           Database.Persist.Sql (SqlBackend)
 
 insertValidateGenesisDist
-    :: SqlBackend -> Trace IO Text -> NetworkName -> GenesisConfig
+    :: SqlBackend -> Trace IO Text -> NetworkName -> GenesisConfig -> Bool
     -> ExceptT SyncNodeError IO ()
-insertValidateGenesisDist backend trce nname genCfg =
+insertValidateGenesisDist backend trce nname genCfg shelleyInitiation =
   case genCfg of
     GenesisCardano _ bCfg sCfg _aCfg -> do
       Byron.insertValidateGenesisDist backend trce (unNetworkName nname) bCfg
-      Shelley.insertValidateGenesisDist backend trce (unNetworkName nname) (scConfig sCfg)
+      Shelley.insertValidateGenesisDist backend trce (unNetworkName nname) (scConfig sCfg) shelleyInitiation

--- a/cardano-sync/src/Cardano/Sync/Error.hs
+++ b/cardano-sync/src/Cardano/Sync/Error.hs
@@ -35,6 +35,7 @@ data SyncNodeError
   = NEError !Text
   | NEInvariant !Text !SyncInvariant
   | NEBlockMismatch !Word64 !ByteString !ByteString
+  | NEIgnoreShelleyInitiation
   | NEByronConfig !FilePath !Byron.ConfigurationError
   | NEShelleyConfig !FilePath !Text
   | NEAlonzoConfig !FilePath !Text
@@ -73,6 +74,11 @@ renderSyncNodeError ne =
       mconcat
         [ "Block mismatch for block number ", textShow blkNo, ", db has "
         , bsBase16Encode hashDb, " but chain provided ", bsBase16Encode hashBlk
+        ]
+    NEIgnoreShelleyInitiation ->
+      mconcat
+        [ "Node configs that don't fork to Shelley directly and initiate"
+        , " funds or stakes in Shelley Genesis are not supported."
         ]
     NEByronConfig fp ce ->
       mconcat


### PR DESCRIPTION
TestShelleyHardForkAtEpoch has to be 0 when shelley genesis initiate funds or stakes

It fails for an unsupported config, but logs are a bit messed up for some reason:
```
[db-sync-node:Info:42] [2021-10-19 20:25:00.49 UTC] Initial genesis distribution present and correct
[db-sync-node:Info:42] [2021-10-19 20:25:00.49 UTC] Total genesis supply of Ada: 30000015000.000000
Node configs that don't fork to Shelley directly and in[db-sync-node:Error:42] [2021-10-19 20:25:00.49 UTC] Node configs that don't fork to Shelley directly and initiate funds or stakes in Shelley Genesis are not supported.
itiate funds or stakes in Shelley Genesis are not supported.
```