### PR TITLE
Remove option to run smash from db-sync

### DIFF
--- a/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
+++ b/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import           Cardano.Prelude
-import           Prelude (read)
 
 import           Cardano.Config.Git.Rev (gitRev)
 
@@ -11,8 +10,6 @@ import           Cardano.DbSync.Metrics (withMetricSetters)
 import           Cardano.DbSync.Plugin.Extended (extendedDbSyncNodePlugin)
 
 import           Cardano.Slotting.Slot (SlotNo (..))
-
-import           Cardano.SMASH.Server.Config (defaultSmashPort)
 
 import           Cardano.Sync.Config
 import           Cardano.Sync.Config.Types
@@ -68,9 +65,6 @@ pRunDbSyncNode =
     <*> pSocketPath
     <*> pLedgerStateDir
     <*> pMigrationDir
-    <*> pRunSmash
-    <*> optional pSmashUserFile
-    <*> asum [pSmashPort, pure defaultSmashPort]
     <*> optional pSlotNo
 
 pConfigFile :: Parser ConfigFile
@@ -98,30 +92,6 @@ pMigrationDir =
     <> Opt.help "The directory containing the migrations."
     <> Opt.completer (Opt.bashCompleter "directory")
     <> Opt.metavar "FILEPATH"
-    )
-
-pRunSmash :: Parser Bool
-pRunSmash = Opt.switch
-  ( Opt.long "smash"
-  <> Opt.help "Enable smash web server"
-  )
-
-pSmashUserFile :: Parser FilePath
-pSmashUserFile =
-  Opt.strOption
-    ( Opt.long "admins"
-    <> Opt.help "Path to the file containing the credentials of smash server admin users"
-    <> Opt.completer (Opt.bashCompleter "file")
-    <> Opt.metavar "FILEPATH"
-    )
-
-pSmashPort :: Parser Int
-pSmashPort =
-  read <$> Opt.strOption
-    ( Opt.long "smash-port"
-    <> Opt.help "Port for the smash web app server"
-    <> Opt.completer (Opt.bashCompleter "port")
-    <> Opt.metavar "PORT"
     )
 
 pSocketPath :: Parser SocketPath

--- a/cardano-db-sync-extended/cardano-db-sync-extended.cabal
+++ b/cardano-db-sync-extended/cardano-db-sync-extended.cabal
@@ -79,6 +79,5 @@ executable cardano-db-sync-extended
                       , cardano-sync
                       , cardano-prelude
                       , cardano-slotting
-                      , cardano-smash-server
                       , optparse-applicative
                       , text

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -2,14 +2,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import           Cardano.Prelude
-import           Prelude (read)
 
 import           Cardano.Config.Git.Rev (gitRev)
 
 import           Cardano.DbSync (defDbSyncNodePlugin, runDbSyncNode)
 import           Cardano.DbSync.Metrics (withMetricSetters)
-
-import           Cardano.SMASH.Server.Config (defaultSmashPort)
 
 import           Cardano.Sync.Config
 import           Cardano.Sync.Config.Types
@@ -66,9 +63,6 @@ pRunDbSyncNode =
     <*> pSocketPath
     <*> pLedgerStateDir
     <*> pMigrationDir
-    <*> pRunSmash
-    <*> optional pSmashUserFile
-    <*> asum [pSmashPort, pure defaultSmashPort]
     <*> optional pSlotNo
 
 pConfigFile :: Parser ConfigFile
@@ -96,30 +90,6 @@ pMigrationDir =
     <> Opt.help "The directory containing the migrations."
     <> Opt.completer (Opt.bashCompleter "directory")
     <> Opt.metavar "FILEPATH"
-    )
-
-pRunSmash :: Parser Bool
-pRunSmash = Opt.switch
-  ( Opt.long "smash"
-  <> Opt.help "Enable smash web server"
-  )
-
-pSmashUserFile :: Parser FilePath
-pSmashUserFile =
-  Opt.strOption
-    ( Opt.long "admins"
-    <> Opt.help "Path to the file containing the credentials of smash server admin users"
-    <> Opt.completer (Opt.bashCompleter "file")
-    <> Opt.metavar "FILEPATH"
-    )
-
-pSmashPort :: Parser Int
-pSmashPort =
-  read <$> Opt.strOption
-    ( Opt.long "smash-port"
-    <> Opt.help "Port for the smash web app server"
-    <> Opt.completer (Opt.bashCompleter "port")
-    <> Opt.metavar "PORT"
     )
 
 pSocketPath :: Parser SocketPath

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -98,7 +98,6 @@ library
                       , cardano-crypto-praos
                       , cardano-crypto-wrapper
                       , cardano-db
-                      , cardano-smash-server
                       , cardano-sync
                       , cardano-ledger-alonzo
                       , cardano-ledger-byron
@@ -168,6 +167,5 @@ executable cardano-db-sync
                       , cardano-db-sync
                       , cardano-prelude
                       , cardano-slotting
-                      , cardano-smash-server
                       , optparse-applicative
                       , text

--- a/cardano-sync/src/Cardano/Sync/Config/Types.hs
+++ b/cardano-sync/src/Cardano/Sync/Config/Types.hs
@@ -108,9 +108,6 @@ data SyncNodeParams = SyncNodeParams
   , enpSocketPath :: !SocketPath
   , enpLedgerStateDir :: !LedgerStateDir
   , enpMigrationDir :: !MigrationDir
-  , enpRunSmash :: !Bool
-  , enpSmashUserFile :: !(Maybe FilePath)
-  , enpSmashPort :: !Int
   , enpMaybeRollback :: !(Maybe SlotNo)
   }
 


### PR DESCRIPTION
The option to run smash like this was never part of any release, so removing will not have any consequences for users. If after proper consideration we decide we actually want this, its easy to reinstate.