### PR TITLE
fix index creation for reserved_pool_ticker

### DIFF
--- a/schema/migration-3-0007-20211022.sql
+++ b/schema/migration-3-0007-20211022.sql
@@ -16,7 +16,7 @@ BEGIN
     CREATE INDEX idx_pool_offline_data_pmr_id ON pool_offline_data (pmr_id);
     CREATE INDEX idx_withdrawal_redeemer_id ON withdrawal (redeemer_id);
     CREATE INDEX idx_stake_deregistration_redeemer_id ON stake_deregistration (redeemer_id);
-    CREATE INDEX idx_reserved_pool_ticker_pool_hash ON reserved_pool_ticker (pool_hash);
+    CREATE INDEX idx_reserved_pool_ticker_pool_id ON reserved_pool_ticker (pool_id);
     CREATE INDEX idx_collateral_tx_in_tx_out_id ON collateral_tx_in (tx_out_id);
     CREATE INDEX idx_script_tx_id ON script (tx_id);
 


### PR DESCRIPTION
This PR solves https://github.com/input-output-hk/cardano-db-sync/issues/914 where a migration is failing due to the missing column `pool_hash` in table `reserved_pool_ticker`.

We probably want to index `pool_id` instead and improve the lookup performance on this column. This is what this PR is proposing.