### PR TITLE
Batch insert Tx data

### DIFF
--- a/cardano-db/src/Cardano/Db/Insert.hs
+++ b/cardano-db/src/Cardano/Db/Insert.hs
@@ -16,8 +16,10 @@ module Cardano.Db.Insert
   , insertEpochSyncTime
   , insertManyEpochStakes
   , insertManyRewards
+  , insertManyTxIn
   , insertMaTxMint
   , insertMaTxOut
+  , insertManyMaTxOut
   , insertMeta
   , insertMultiAsset
   , insertMultiAssetUnchecked
@@ -133,11 +135,17 @@ insertManyEpochStakes = insertManyUncheckedUnique "Many EpochStake"
 insertManyRewards :: (MonadBaseControl IO m, MonadIO m) => [Reward] -> ReaderT SqlBackend m ()
 insertManyRewards = insertManyUncheckedUnique "Many Rewards"
 
+insertManyTxIn :: (MonadBaseControl IO m, MonadIO m) => [TxIn] -> ReaderT SqlBackend m ()
+insertManyTxIn = insertManyUncheckedUnique "Many TxIn"
+
 insertMaTxMint :: (MonadBaseControl IO m, MonadIO m) => MaTxMint -> ReaderT SqlBackend m MaTxMintId
 insertMaTxMint = insertCheckUnique "insertMaTxMint"
 
 insertMaTxOut :: (MonadBaseControl IO m, MonadIO m) => MaTxOut -> ReaderT SqlBackend m MaTxOutId
 insertMaTxOut = insertCheckUnique "insertMaTxOut"
+
+insertManyMaTxOut :: (MonadBaseControl IO m, MonadIO m) => [MaTxOut] -> ReaderT SqlBackend m ()
+insertManyMaTxOut = insertManyUncheckedUnique "Many MaTxOut"
 
 insertMeta :: (MonadBaseControl IO m, MonadIO m) => Meta -> ReaderT SqlBackend m MetaId
 insertMeta = insertCheckUnique "Meta"


### PR DESCRIPTION
Single commit on top of https://github.com/input-output-hk/cardano-db-sync/pull/904

Optimization which gathers TxIn and MaTxOut in batches. In epoch 297 there are average 36 TxIns per block and 157 MaTxOut, so grouping them together instead of doing multiple inserts makes sence. Doing the same for other tables doesn't contribute much, since they are rare (very little per block). We should be careful to avoid dependencies between these elements within the same block. TxIn and MaTxOut live at the bottom of the tree of dependencies (no other table reference them) so it's safe to use them. The same does not apply to TxOut.