### PR TITLE
Inline git sha Template Haskell into cardano-db-sync project.

### DIFF
--- a/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
+++ b/cardano-db-sync-extended/app/cardano-db-sync-extended.hs
@@ -3,7 +3,7 @@
 
 import           Cardano.Prelude
 
-import           Cardano.Config.Git.Rev (gitRev)
+import           Cardano.Db (gitRev)
 
 import           Cardano.DbSync (runDbSyncNode)
 import           Cardano.DbSync.Metrics (withMetricSetters)

--- a/cardano-db-sync-extended/cardano-db-sync-extended.cabal
+++ b/cardano-db-sync-extended/cardano-db-sync-extended.cabal
@@ -73,7 +73,7 @@ executable cardano-db-sync-extended
                         MigrationValidations
 
   build-depends:        base                            >= 4.14         && < 4.16
-                      , cardano-config
+                      , cardano-db
                       , cardano-db-sync
                       , cardano-db-sync-extended
                       , cardano-sync

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -3,8 +3,8 @@
 
 import           Cardano.Prelude
 
-import           Cardano.Config.Git.Rev (gitRev)
 
+import           Cardano.Db (gitRev)
 import           Cardano.DbSync (defDbSyncNodePlugin, runDbSyncNode)
 import           Cardano.DbSync.Metrics (withMetricSetters)
 

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -43,18 +43,13 @@ library
                         -Wunused-packages
 
   exposed-modules:      Cardano.DbSync
-
                         Cardano.DbSync.Era
-
                         Cardano.DbSync.Era.Byron.Genesis
                         Cardano.DbSync.Era.Byron.Insert
                         Cardano.DbSync.Era.Byron.Util
-
                         Cardano.DbSync.Era.Cardano.Insert
                         Cardano.DbSync.Era.Cardano.Util
-
                         Cardano.DbSync.Era.Shelley.Adjust
-                        Cardano.DbSync.Era.Shelley.Genesis
                         Cardano.DbSync.Era.Shelley.Generic
                         Cardano.DbSync.Era.Shelley.Generic.Block
                         Cardano.DbSync.Era.Shelley.Generic.Metadata
@@ -62,6 +57,7 @@ library
                         Cardano.DbSync.Era.Shelley.Generic.Tx
                         Cardano.DbSync.Era.Shelley.Generic.Util
                         Cardano.DbSync.Era.Shelley.Generic.Witness
+                        Cardano.DbSync.Era.Shelley.Genesis
                         Cardano.DbSync.Era.Shelley.Insert
                         Cardano.DbSync.Era.Shelley.Insert.Epoch
                         Cardano.DbSync.Era.Shelley.Offline
@@ -162,8 +158,8 @@ executable cardano-db-sync
                         MigrationValidations
 
   build-depends:        base                            >= 4.14         && < 4.16
-                      , cardano-config
                       , cardano-sync
+                      , cardano-db
                       , cardano-db-sync
                       , cardano-prelude
                       , cardano-slotting

--- a/cardano-db-tool/cardano-db-tool.cabal
+++ b/cardano-db-tool/cardano-db-tool.cabal
@@ -101,6 +101,8 @@ executable cardano-db-tool
                         -threaded
                         -with-rtsopts=-N2
 
+  other-modules:        Paths_cardano_db_tool
+
   build-depends:        base                            >= 4.14         && < 4.16
                       , cardano-db
                       , cardano-db-tool

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -47,12 +47,14 @@ library
                         Cardano.Db.Schema.Orphans
                         Cardano.Db.Text
                         Cardano.Db.Types
+                        Cardano.Db.Version
 
   build-depends:        aeson
                       , base                            >= 4.14         && < 4.16
                       , bech32
                       , base16-bytestring
                       , bytestring
+                      , cardano-config
                       , cardano-crypto-class
                       , cardano-ledger-core
                       , cardano-ledger-shelley
@@ -68,6 +70,7 @@ library
                       , extra
                       , fast-logger
                       , filepath
+                      , file-embed
                       , iohk-monitoring
                       , lifted-base
                       , memory

--- a/cardano-db/src/Cardano/Db.hs
+++ b/cardano-db/src/Cardano/Db.hs
@@ -7,6 +7,8 @@ module Cardano.Db
   , Tx (..)
   , TxIn (..)
   , TxOut (..)
+
+  , gitRev
   ) where
 
 import           Cardano.Db.Delete as X
@@ -21,3 +23,4 @@ import           Cardano.Db.Schema as X
 import           Cardano.Db.Schema.Types as X
 import           Cardano.Db.Text as X
 import           Cardano.Db.Types as X
+import           Cardano.Db.Version (gitRev)

--- a/cardano-db/src/Cardano/Db/Version.hs
+++ b/cardano-db/src/Cardano/Db/Version.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Cardano.Db.Version
+  ( gitRev
+  ) where
+
+import           Cardano.Config.Git.RevFromGit (gitRevFromGit)
+import           Data.FileEmbed (dummySpaceWith)
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+
+-- | Provide the git revision at compilation time (if possible)
+--
+-- Used to provide a git revision in cli programs
+gitRev :: Text
+gitRev
+    | gitRevEmbed /= zeroRev = gitRevEmbed
+    | Text.null fromGit = zeroRev
+    | otherwise = fromGit
+  where
+    -- Git revision embedded after compilation using
+    -- Data.FileEmbed.injectWith. If nothing has been injected,
+    -- this will be filled with 0 characters.
+    gitRevEmbed :: Text
+    gitRevEmbed = Text.decodeUtf8 $(dummySpaceWith "gitrev" 40)
+
+    -- Git revision found during compilation by running git. If
+    -- git could not be run, then this will be empty.
+#if defined(arm_HOST_ARCH)
+    -- cross compiling to arm fails; due to a linker bug
+    fromGit = ""
+#else
+    fromGit = Text.strip (Text.pack $(gitRevFromGit))
+#endif
+
+zeroRev :: Text
+zeroRev = "0000000000000000000000000000000000000000"
+


### PR DESCRIPTION
Previously with cabal builds the wrong git sha was being reported by
the cli tools cardano-db-sync and cardano-db-sync-extended. This
change fixes this and also adds git sha output into cardano-db-tool.
Binaries produced by nix should not be affected as they get their git
sha's injected in a post-build stage.