### PR TITLE
Fix fork to Shelley at 0

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Block.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Block.hs
@@ -161,7 +161,7 @@ blockNumber = Protocol.bheaderBlockNo . blockBody
 blockPrevHash :: ShelleyBasedEra era => ShelleyBlock era -> Maybe ByteString
 blockPrevHash blk =
   case Protocol.bheaderPrev (Protocol.bhbody . Ledger.bheader $ Consensus.shelleyBlockRaw blk) of
-    Protocol.GenesisHash -> Just "Cardano.DbSync.Era.Shelley.Generic.Block.blockPrevHash"
+    Protocol.GenesisHash -> Nothing
     Protocol.BlockHash (Protocol.HashHeader h) -> Just $ Crypto.hashToBytes h
 
 blockOpCert :: ShelleyBasedEra era => ShelleyBlock era -> ByteString


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-db-sync/issues/953
The current definition of `blockPrevHash` is strange.
I think this fix was somehow lost in cherry-picking or rebasing