### PR TITLE
Minor fix to drop_db function to include cascade

### DIFF
--- a/scripts/postgresql-setup.sh
+++ b/scripts/postgresql-setup.sh
@@ -104,7 +104,7 @@ function create_db {
 
 function drop_db {
 	if test "$( psql "${PGDATABASE}" -tAc "SELECT 1 FROM pg_database WHERE datname='${PGDATABASE}'" )" = '1' ; then
-		psql "${PGDATABASE}" --command="DROP OWNED BY CURRENT_USER;"
+		psql "${PGDATABASE}" --command="DROP OWNED BY CURRENT_USER cascade;"
 	fi
 }
 


### PR DESCRIPTION
Fix this error:  ./postgresql-setup.sh --recreatedb
ERROR:  cannot drop desired object(s) because other objects depend on them
DETAIL:  function f_mints(character varying) depends on type int65type
HINT:  Use DROP ... CASCADE to drop the dependent objects too.