### PR TITLE
Add cabal build instruction to docs

### DIFF
--- a/doc/building-running.md
+++ b/doc/building-running.md
@@ -34,6 +34,30 @@ nix-build -A scripts.mainnet.node -o mainnet-node-local
 ```
 
 ### Set up and run the db-sync node
+
+- with cabal:
+
+```
+git clone https://github.com/input-output-hk/cardano-db-sync
+cd cardano-db-sync
+cabal build cardano-db-sync
+PGPASSFILE=config/pgpass-mainnet cabal run cardano-db-sync -- \
+    --config config/mainnet-config.yaml \
+    --socket-path ../cardano-node/state-node-mainnet/node.socket \
+    --state-dir ledger-state/mainnet \
+    --schema-dir schema/
+```
+
+to find `cardano-db-sync` executable location use:
+
+```
+find . -name cardano-db-sync -executable -type f
+./dist-newstyle/build/x86_64-linux/ghc-8.10.4/cardano-db-sync-12.0.0/build/cardano-db-sync/cardano-db-sync
+```
+
+
+- with nix:
+
 ```
 git clone https://github.com/input-output-hk/cardano-db-sync
 cd cardano-db-sync


### PR DESCRIPTION
Can we add `cabal` section to docs to avoid questions like these:

https://github.com/input-output-hk/cardano-db-sync/issues/339#issuecomment-995713950
https://github.com/input-output-hk/cardano-db-sync/issues/342#issuecomment-906796253

 in the future ?



