### PR TITLE
Dockerised instance now exposes PostgresDb port to localhost

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -13,9 +13,13 @@ cd cardano-db-sync
 ``` console
 docker-compose up -d && docker-compose logs -f
 ```
-### :tada
+### tada:tada:
 
 The PostgreSQL database is exposed on localhost port `5432`
+
+### To connect to PostgreSQL database:
+
+`$ psql -h 0.0.0.0 -p 5432 -U postgres -d cexplorer` (then enter secret password)
 
 ### To connect to another network:
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - postgres_password
       - postgres_user
       - postgres_db
+    ports:
+      - ${POSTGRES_PORT:-5432}:5432
     volumes:
       - postgres:/var/lib/postgresql/data
     restart: on-failure


### PR DESCRIPTION
Dockerised instance now exposes PostgresDb port to localhost and updated Docker doc to reflect