### PR TITLE
offline: correct metadata url for retries.

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Offline/Query.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Offline/Query.hs
@@ -83,7 +83,7 @@ queryPoolFetchRetry _now = do
                 pure
                     ( pofe ^. PoolOfflineFetchErrorFetchTime
                     , pofe ^. PoolOfflineFetchErrorPmrId
-                    , ph ^. PoolHashView
+                    , pmr ^. PoolMetadataRefUrl
                     , pmr ^. PoolMetadataRefHash
                     , ph ^. PoolHashId
                     , pofe ^. PoolOfflineFetchErrorRetryCount


### PR DESCRIPTION
 before the pool hash was used in place of actual url, as show by
 reported errors, eg.:
````
  URL parse error from for
  pool1zy4arks3chpruyt32p0mhwqu3qpdgyx7nejrw06nqu3uzfuv3aw resulted in :
  InvalidUrlException "pool1zy4arks3chpruyt32p0mhwqu3qpdgyx7nejrw06nqu3uzfuv3aw"
````
 Should complete the fix for #697.
 
 Backport for 12.x: https://github.com/input-output-hk/cardano-db-sync/pull/1049