### PR TITLE
Fix logging reward map

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Validate.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Validate.hs
@@ -105,6 +105,7 @@ queryRewardMap (EpochNo epochNo) = do
         `on` (\(rwd :& saddr) ->
                 rwd ^. Db.RewardAddrId ==. saddr ^. Db.StakeAddressId)
       where_ (rwd ^. Db.RewardSpendableEpoch ==. val epochNo)
+      where_ (not_ $ rwd ^. Db.RewardType ==. val Db.RwdDepositRefund)
       orderBy [desc (saddr ^. Db.StakeAddressHashRaw)]
       pure (saddr ^. Db.StakeAddressHashRaw, rwd ^. Db.RewardType, rwd ^. Db.RewardAmount)
 


### PR DESCRIPTION
The query `queryEpochRewardTotal` ignores the deposit refunds. However while printing the diff it is not ignored. So if there is some undelared mismath with events, the deposit refunds are also printed even if they don't cause the issue.