### PR TITLE
Fix ledger snapshots frequency

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/LedgerState.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/LedgerState.hs
@@ -491,10 +491,10 @@ cleanupLedgerStateFiles env slotNo = do
     let (epochBoundary, valid, invalid) = foldr groupFiles ([], [], []) files
     -- Remove invalid (ie SlotNo >= current) ledger state files (occurs on rollback).
     deleteAndLogFiles env "invalid" invalid
-    -- Remove all but 2 most recent state files.
-    deleteAndLogStateFile env "valid" (List.drop 2 valid)
-    -- Remove all but 5 most recent epoch boundary state files.
-    deleteAndLogStateFile env "epoch boundary" (List.drop 5 epochBoundary)
+    -- Remove all but 6 most recent state files.
+    deleteAndLogStateFile env "valid" (List.drop 6 valid)
+    -- Remove all but 6 most recent epoch boundary state files.
+    deleteAndLogStateFile env "epoch boundary" (List.drop 6 epochBoundary)
   where
     groupFiles :: LedgerStateFile
                -> ([LedgerStateFile], [LedgerStateFile], [FilePath])

--- a/cardano-db-sync/src/Cardano/DbSync/Sync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Sync.hs
@@ -131,7 +131,7 @@ runSyncNode metricsSetters trce backend iomgr aop snEveryFollowing snEveryLaggin
       case genCfg of
           GenesisCardano {} -> do
             syncEnv <- ExceptT $ mkSyncEnvFromConfig trce backend
-              (SyncOptions (enpExtended enp) aop snEveryLagging snEveryFollowing)
+              (SyncOptions (enpExtended enp) aop snEveryFollowing snEveryLagging)
               (enpLedgerStateDir enp) genCfg
             liftIO $ epochStartup syncEnv
             liftIO $ runSyncNodeClient metricsSetters syncEnv iomgr trce (enpSocketPath enp)


### PR DESCRIPTION
This bug was causing very frequent snapshots while syncing and big rollbacks to the start of the epoch boundaries.