### PR TITLE
Bump to cardano-node 1.34.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -143,13 +143,16 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 814df2c146f5d56f8c35a681fe75e85b905aed5d
-  --sha256: 1hr00wqzmcyc3x0kp2hyw78rfmimf6z4zd4vv85b9zv3nqbjgrik
+  tag: 1.34.1
+  --sha256: 1hh53whcj5y9kw4qpkiza7rmkniz18r493vv4dzl1a8r5fy3b2bv
   subdir:
     cardano-api
     cardano-cli
     cardano-node
-    plutus-example
+    cardano-git-rev
+    trace-dispatcher
+    trace-forward
+    trace-resources
 
 source-repository-package
   type: git
@@ -183,6 +186,12 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/ekg-forward
+  tag: 297cd9db5074339a2fb2e5ae7d0780debb670c63
+  --sha256: 1zcwry3y5rmd9lgxy89wsb3k4kpffqji35dc7ghzbz603y1gy24g
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/Win32-network
   tag: 3825d3abf75f83f406c1f7161883c438dac7277d
   --sha256: 19wahfv726fa3mqajpqdqhnl9ica3xmf68i254q45iyjcpj1psqx
@@ -190,8 +199,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: d2d219a86cda42787325bb8c20539a75c2667132
-  --sha256: 18xk7r0h2pxrbx76d6flsxifh0a9rz1cj1rjqs1pbs5kdmy8b7kx
+  tag: 4fac197b6f0d2ff60dc3486c593b68dc00969fbf
+  --sha256: 1b43vbdsr9m3ry1kgag2p2ixpv54gw7a4vvmndxl6knqg8qbsb8b
   subdir:
     cardano-client
     io-sim
@@ -227,6 +236,13 @@ source-repository-package
     stubs/plutus-ghc-stub
     word-array
 
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/plutus-apps
+  tag: fdb0eec477fc0f99f5edfdbc11c041dbd35ca6bb
+  --sha256: 1n6wam6k6lp7c20mxslh08shrzv3xwvmgnmajzry78wkml5241kq
+  subdir:
+    plutus-example
 
 -- Something in plutus-core requries this.
 source-repository-package

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Alonzo/ScriptsExamples.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Alonzo/ScriptsExamples.hs
@@ -16,9 +16,9 @@ import           Cardano.Ledger.Era
 import           Cardano.Ledger.Hashes
 import           Cardano.Ledger.Mary.Value
 
-import           Cardano.PlutusExample.AlwaysFails (alwaysFailsScriptShortBs)
-import           Cardano.PlutusExample.AlwaysSucceeds (alwaysSucceedsScriptShortBs)
-import           Cardano.PlutusExample.MintingScript
+import           PlutusExample.AlwaysFails (alwaysFailsScriptShortBs)
+import           PlutusExample.AlwaysSucceeds (alwaysSucceedsScriptShortBs)
+import           PlutusExample.MintingScript
 
 import qualified PlutusCore.Data as Plutus
 

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Util.hs
@@ -139,7 +139,7 @@ renderAddress
     => Api.IsShelleyBasedEra era
     => ledgerera ~ StandardShelley
     => Ledger.Addr StandardCrypto -> Text
-renderAddress addr = Api.serialiseAddress (Api.fromShelleyAddr addr :: Api.AddressInEra era)
+renderAddress addr = Api.serialiseAddress (Api.fromShelleyAddrIsSbe addr :: Api.AddressInEra era)
 
 renderCostModel :: CostModel -> Text
 renderCostModel (CostModel x) = textShow x

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -78,6 +78,10 @@ let
         # split data output for ekg to reduce closure size
         packages.ekg.components.library.enableSeparateDataOutput = true;
         enableLibraryProfiling = profiling;
+
+        # plugin failures
+        packages.plutus-ledger.doHaddock = false;
+        packages.plutus-example.doHaddock = false;
       }
       {
         packages = lib.genAttrs projectPackages (name: {


### PR DESCRIPTION
* Adds dummy `localTxMonitor`
* `fromShelleyAddr` -> `fromShelleyAddrIsSbe`
* `plutus-example` was moved to `plutus-apps`

I have a follow-up PR updating to more recent `node + deps` which is a bit more involved so creating this one first.