### PR TITLE
Extract script for checkout and building of secp256k1 library.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -29,31 +29,6 @@ jobs:
       run: |
         echo "$HOME/.cabal/bin"                 >> $GITHUB_PATH
 
-    - name: Install pkgconfiglite
-      if: matrix.os == 'windows-latest'
-      run: choco install -y pkgconfiglite
-
-    - name: Install libsodium
-      if: matrix.os == 'windows-latest'
-      run: |
-        curl -Ls \
-          --connect-timeout 5 \
-          --max-time 10 \
-          --retry 5 \
-          --retry-delay 0 \
-          --retry-max-time 40 \
-          https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-mingw.tar.gz -o libsodium-1.0.18-mingw.tar.gz
-        tar zxvf libsodium-1.0.18-mingw.tar.gz
-
-        sed -i "s|/d/a/1/s/|D:/a/cardano-node/cardano-node/|g" libsodium-win64/lib/pkgconfig/libsodium.pc
-
-        export PKG_CONFIG_PATH="$(readlink -f libsodium-win64/lib/pkgconfig)"
-        echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
-
-        export LIBSODIUM_PATH="$(readlink -f libsodium-win64/bin | sed 's|^/d|D:|g' | tr / '\\')"
-        echo "LIBSODIUM_PATH=$LIBSODIUM_PATH"
-        echo "$LIBSODIUM_PATH" >> $GITHUB_PATH
-
     - name: Install Postgres (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
@@ -104,58 +79,13 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get -y install autoconf automake libtool
-        mkdir secp256k1-sources
-        cd secp256k1-sources
-        git clone https://github.com/bitcoin-core/secp256k1.git
-        cd secp256k1
-        git reset --hard $SECP256K1_REF
-        ./autogen.sh
-        ./configure --prefix=/usr --enable-module-schnorrsig --enable-experimental
-        make
-        make check
-        sudo make install
-        cd ../..
+        ./scripts/secp256k1-setup.sh $SECP256K1_REF
 
     - name: Install secp256k1 (MacOS)
       if: matrix.os == 'macos-latest'
       run: |
         brew install autoconf automake libtool
-        mkdir secp256k1-sources
-        cd secp256k1-sources
-        git clone https://github.com/bitcoin-core/secp256k1.git
-        cd secp256k1
-        git reset --hard $SECP256K1_REF
-        ./autogen.sh
-        ./configure --enable-module-schnorrsig --enable-experimental
-        make
-        make check
-        make install
-
-    - name: Install secp256k1 (Windows)
-      if: matrix.os == 'windows-latest'
-      env:
-        RUNNER_TEMP: ${{ runner.temp }}
-      run: |
-        echo "RUNNER_TEMP=$RUNNER_TEMP"
-        cd "$RUNNER_TEMP"
-        RUNNER_TEMP_FWD="$(echo "$RUNNER_TEMP" | sed 's|\\|/|g')"
-        curl -Ls \
-          --connect-timeout 5 \
-          --max-time 10 \
-          --retry 5 \
-          --retry-delay 0 \
-          --retry-max-time 40 \
-          https://hydra.iohk.io/job/Cardano/haskell-nix/windows-secp256k1/latest/download/1 -o secp256k1.zip
-        mkdir secp256k1
-        cd secp256k1
-        unzip ../secp256k1.zip
-        cd ..
-        export PKG_CONFIG_PATH="$PKG_CONFIG_PATH;$(readlink -f secp256k1/lib/pkgconfig | sed 's|^/d|D:|g' | tr / '\\')"
-        echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
-        echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
-        export SECP256K1_PATH="$(readlink -f secp256k1/bin | sed 's|^/d|D:|g' | tr / '\\')"
-        echo "SECP256K1_PATH=$SECP256K1_PATH"
-        echo "$SECP256K1_PATH" >> $GITHUB_PATH
+        ./scripts/secp256k1-setup.sh $SECP256K1_REF
 
     - name: Cabal update
       run: cabal update

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ gen/
 /.vscode
 
 cardano-chain-gen/test/testfiles/temp/
+/secp256k1/

--- a/doc/building-running.md
+++ b/doc/building-running.md
@@ -26,6 +26,7 @@ the db. If you want to to use a single database for more than one chain, you wil
 testnet `PGPASSFILE` is at `config/pgpass-testnet`.
 
 ### Set up and run a local node
+
 Regular users should almost never attempt building and running from the `master` branch. Instead,
 they should build and run the latest release tag. The tags can be listed using the `git tag`
 command. Pre-release tags (eg things like `12.0.0-preX`) should also be avoided in most cases.
@@ -39,6 +40,20 @@ nix-build -A scripts.mainnet.node -o mainnet-node-local
 
 ### Set up and run the db-sync node
 
+- Install secp256k1 library as a prerequisite for building with cabal:
+
+``` shell
+./scripts/secp256k1-setup.sh ac83be33d0956faf6b7f61a60ab524ef7d6a473a
+# Check ./github/workflows/haskell.yml to validate the git sha above.
+
+# On Linux
+sudo make install 
+
+# On OSX
+make install 
+
+```
+
 - with cabal:
 
 ```
@@ -46,6 +61,7 @@ git clone https://github.com/input-output-hk/cardano-db-sync
 cd cardano-db-sync
 PGPASSFILE=config/pgpass-mainnet scripts/postgresql-setup.sh --createdb
 git checkout <latest-official-tag> -b tag-<latest-official-tag>
+
 cabal build cardano-db-sync
 PGPASSFILE=config/pgpass-mainnet cabal run cardano-db-sync -- \
     --config config/mainnet-config.yaml \

--- a/scripts/secp256k1-setup.sh
+++ b/scripts/secp256k1-setup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This script installs a specific version of secp256k1 for both Linux and OSX.
+#
+# To use this script run it from the top level and provide a git sha from secp256k1.
+
+# Unofficial bash strict mode.
+# See: http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -u
+set -o pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo 'Usage: $0 SECP256K1_REF' >&2
+    exit 2
+fi
+
+SECP256K1_REF=$1
+
+UNAME=$(uname -s) INSTAL_CMD=
+case $UNAME in
+    Darwin )      INSTAL_CMD="make install";;
+    Linux )       INSTAL_CMD="sudo make install";;
+esac
+
+PREFIX=
+case $UNAME in
+    Darwin ) PREFIX="";;
+    Linux ) PREFIX="--prefix=/usr";;
+esac
+
+if [ ! -d "secp256k1" ]; then
+    git clone https://github.com/bitcoin-core/secp256k1.git secp256k1
+fi 
+pushd secp256k1
+git reset --hard $SECP256K1_REF
+./autogen.sh
+./configure $PREFIX --enable-module-schnorrsig --enable-experimental
+make
+make check
+$INSTAL_CMD
+popd
+


### PR DESCRIPTION
Add documentation for using script in doc/building-running.md and
reuse the script in GH Actions to validate it works. Script should
work on both Linux and OSX.

Fix for https://github.com/input-output-hk/cardano-db-sync/issues/1113