### PR TITLE
Fix outdated help in scripts/postgresql-setup.sh

### DIFF
--- a/scripts/postgresql-setup.sh
+++ b/scripts/postgresql-setup.sh
@@ -115,13 +115,13 @@ function list_views {
 
 function create_migration {
 	echo "To create a migration:"
-	echo "cabal run create-migration --mdir schema/"
+	echo "cabal run cardano-db-tool -- create-migration --mdir schema/"
 	exit 0
 }
 
 function run_migrations {
 	echo "To run migrations:"
-	echo "cabal run cardano-db-tool run-migrations --mdir schema/ --ldir ."
+	echo "cabal run cardano-db-tool -- run-migrations --mdir schema/ --ldir ."
 	echo "You probably do not need to do this."
 	exit 0
 }


### PR DESCRIPTION
Noticed this is wrong while grepping repo for `create-migration` example.