### PR TITLE
Miscelllaneous fixes

### DIFF
--- a/cardano-chain-gen/cardano-chain-gen.cabal
+++ b/cardano-chain-gen/cardano-chain-gen.cabal
@@ -3,7 +3,7 @@ cabal-version:          2.4
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-chain-gen
-version:                12.0.1
+version:                12.0.2
 synopsis:               A fake chain generator for testing cardano DB sync.
 description:            A fake chain generator for testing cardano DB sync.
 homepage:               https://github.com/input-output-hk/cardano-db-sync

--- a/cardano-db-sync/CHANGELOG.md
+++ b/cardano-db-sync/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Next
 * Store `requiredSigners` (transaction extra key witnesses).
 
+## 12.0.2
+* Fix PoolOfflineFetchError URL entry (#697).
+
 ## 12.0.1
 * No changes.
 

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -3,7 +3,7 @@ cabal-version:          2.4
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-db-sync
-version:                12.0.1
+version:                12.0.2
 synopsis:               The Cardano DB Sync node
 description:            A Cardano node that follows the Cardano chain and inserts data from the
                         chain into a PostgresQL database.

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ParamProposal.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ParamProposal.hs
@@ -53,7 +53,7 @@ data ParamProposal = ParamProposal
   , pppMinPoolCost :: !(Maybe Coin)
 
   -- New for Alonzo.
-  , pppCoinsPerUtxoWord :: !(Maybe Coin)
+  , pppCoinsPerUtxo :: !(Maybe Coin)
   , pppCostmdls :: !(Maybe (Map Language Alonzo.CostModel))
   , pppPriceMem :: !(Maybe Rational)
   , pppPriceStep :: !(Maybe Rational)
@@ -117,7 +117,7 @@ convertBabbageParamProposal epochNo (key, pmap) =
     , pppProtocolVersion = strictMaybeToMaybe (Babbage._protocolVersion pmap)
     , pppMinUtxoValue = Nothing -- Removed in Alonzo
     , pppMinPoolCost = strictMaybeToMaybe (Babbage._minPoolCost pmap)
-    , pppCoinsPerUtxoWord = strictMaybeToMaybe (Babbage._coinsPerUTxOByte pmap)
+    , pppCoinsPerUtxo = strictMaybeToMaybe (Babbage._coinsPerUTxOByte pmap)
     , pppCostmdls = strictMaybeToMaybe (Alonzo.unCostModels <$> Babbage._costmdls pmap)
     , pppPriceMem = Ledger.unboundRational . Alonzo.prMem <$> strictMaybeToMaybe (Babbage._prices pmap)
     , pppPriceStep = Ledger.unboundRational . Alonzo.prSteps <$> strictMaybeToMaybe (Babbage._prices pmap)
@@ -154,7 +154,7 @@ convertAlonzoParamProposal epochNo (key, pmap) =
     , pppMinPoolCost = strictMaybeToMaybe (Alonzo._minPoolCost pmap)
 
     -- New for Alonzo.
-    , pppCoinsPerUtxoWord = strictMaybeToMaybe (Alonzo._coinsPerUTxOWord pmap)
+    , pppCoinsPerUtxo = strictMaybeToMaybe (Alonzo._coinsPerUTxOWord pmap)
     , pppCostmdls = strictMaybeToMaybe (Alonzo.unCostModels <$> Alonzo._costmdls pmap)
     , pppPriceMem = Ledger.unboundRational . Alonzo.prMem <$> strictMaybeToMaybe (Alonzo._prices pmap)
     , pppPriceStep = Ledger.unboundRational . Alonzo.prSteps <$> strictMaybeToMaybe (Alonzo._prices pmap)
@@ -191,7 +191,7 @@ convertShelleyParamProposal epochNo (key, pmap) =
     , pppMinPoolCost = strictMaybeToMaybe (Shelley._minPoolCost pmap)
 
     -- The following are Alonzo related, hence Nothing.
-    , pppCoinsPerUtxoWord = Nothing
+    , pppCoinsPerUtxo = Nothing
     , pppCostmdls = Nothing
     , pppPriceMem = Nothing
     , pppPriceStep = Nothing

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ProtoParams.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ProtoParams.hs
@@ -49,7 +49,7 @@ data ProtoParams = ProtoParams
   , ppMinPoolCost :: !Coin
 
   -- New for Alonzo.
-  , ppCoinsPerUtxoWord :: !(Maybe Coin)
+  , ppCoinsPerUtxo :: !(Maybe Coin)
   , ppCostmdls :: !(Maybe (Map Language Alonzo.CostModel))
   , ppPriceMem :: !(Maybe Rational)
   , ppPriceStep :: !(Maybe Rational)
@@ -114,7 +114,7 @@ fromBabbageParams params =
     , ppProtocolVersion = Babbage._protocolVersion params
     , ppMinUTxOValue = Babbage._coinsPerUTxOByte params
     , ppMinPoolCost = Babbage._minPoolCost params
-    , ppCoinsPerUtxoWord = Just $ Babbage._coinsPerUTxOByte params
+    , ppCoinsPerUtxo = Just $ Babbage._coinsPerUTxOByte params
     , ppCostmdls = Just $ Alonzo.unCostModels $ Babbage._costmdls params
     , ppPriceMem = Just . Ledger.unboundRational $ Alonzo.prMem (Babbage._prices params)
     , ppPriceStep = Just . Ledger.unboundRational $ Alonzo.prSteps (Babbage._prices params)
@@ -147,7 +147,7 @@ fromAlonzoParams params =
     , ppProtocolVersion = Alonzo._protocolVersion params
     , ppMinUTxOValue = Alonzo._coinsPerUTxOWord params
     , ppMinPoolCost = Alonzo._minPoolCost params
-    , ppCoinsPerUtxoWord = Just $ Alonzo._coinsPerUTxOWord params
+    , ppCoinsPerUtxo = Just $ Alonzo._coinsPerUTxOWord params
     , ppCostmdls = Just $ Alonzo.unCostModels $ Alonzo._costmdls params
     , ppPriceMem = Just . Ledger.unboundRational $ Alonzo.prMem (Alonzo._prices params)
     , ppPriceStep = Just . Ledger.unboundRational $ Alonzo.prSteps (Alonzo._prices params)
@@ -180,7 +180,7 @@ fromShelleyParams params =
     , ppProtocolVersion = Shelley._protocolVersion params
     , ppMinUTxOValue = Shelley._minUTxOValue params
     , ppMinPoolCost = Shelley._minPoolCost params
-    , ppCoinsPerUtxoWord = Nothing
+    , ppCoinsPerUtxo = Nothing
     , ppCostmdls = Nothing
     , ppPriceMem = Nothing
     , ppPriceStep = Nothing

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -731,7 +731,7 @@ insertParamProposal _tracer blkId txId pp = do
 
       -- New for Alonzo
 
-      , DB.paramProposalCoinsPerUtxoWord = Generic.coinToDbLovelace <$> pppCoinsPerUtxoWord pp
+      , DB.paramProposalCoinsPerUtxoSize = Generic.coinToDbLovelace <$> pppCoinsPerUtxo pp
       , DB.paramProposalCostModelId = cmId
       , DB.paramProposalPriceMem = realToFrac <$> pppPriceMem pp
       , DB.paramProposalPriceStep = realToFrac <$> pppPriceStep pp
@@ -869,7 +869,7 @@ insertEpochParam _tracer blkId (EpochNo epoch) params nonce = do
       , DB.epochParamMinUtxoValue = Generic.coinToDbLovelace (Generic.ppMinUTxOValue params)
       , DB.epochParamMinPoolCost = Generic.coinToDbLovelace (Generic.ppMinPoolCost params)
       , DB.epochParamNonce = Generic.nonceToBytes nonce
-      , DB.epochParamCoinsPerUtxoWord = Generic.coinToDbLovelace <$> Generic.ppCoinsPerUtxoWord params
+      , DB.epochParamCoinsPerUtxoSize = Generic.coinToDbLovelace <$> Generic.ppCoinsPerUtxo params
       , DB.epochParamCostModelId = cmId
       , DB.epochParamPriceMem = realToFrac <$> Generic.ppPriceMem params
       , DB.epochParamPriceStep = realToFrac <$> Generic.ppPriceStep params

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs
@@ -12,7 +12,6 @@ module Cardano.DbSync.Era.Shelley.Insert.Epoch
   ( insertRewards
   , insertPoolDepositRefunds
   , insertStakeSlice
-  , insertEpochRewardTotalReceived
   , sumRewardTotal
   ) where
 
@@ -44,17 +43,6 @@ import qualified Data.Strict.Maybe as Strict
 import           Database.Persist.Sql (SqlBackend)
 
 {- HLINT ignore "Use readTVarIO" -}
-
-insertEpochRewardTotalReceived
-    :: (MonadBaseControl IO m, MonadIO m)
-    => EpochNo -> DB.DbLovelace
-    -> ReaderT SqlBackend m ()
-insertEpochRewardTotalReceived epochNo total =
-  void . DB.insertEpochRewardTotalReceived $
-    DB.EpochRewardTotalReceived
-      { DB.epochRewardTotalReceivedEarnedEpoch = unEpochNo epochNo
-      , DB.epochRewardTotalReceivedAmount = total
-      }
 
 insertStakeSlice
     :: (MonadBaseControl IO m, MonadIO m)

--- a/cardano-db-tool/CHANGELOG.md
+++ b/cardano-db-tool/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for cardano-db-tool
 
+## 12.0.2
+* No changes.
+
 ## 12.0.1
 * No changes.
 

--- a/cardano-db-tool/cardano-db-tool.cabal
+++ b/cardano-db-tool/cardano-db-tool.cabal
@@ -3,7 +3,7 @@ cabal-version:          2.2
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-db-tool
-version:                12.0.1
+version:                12.0.2
 synopsis:               Utilities to manage the cardano-db-sync databases.
 description:            Utilities and executable, used to manage and validate the
                         PostgreSQL db and the ledger database of the cardano-db-sync node

--- a/cardano-db/CHANGELOG.md
+++ b/cardano-db/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Next
 * Add `extra_key_witness` table for storing `requiredSigners` (transaction extra key witnesses).
 
+## 12.0.2
+* Fix PoolOfflineFetchError URL entry (#697).
+
 ## 12.0.1
 * No changes.
 

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -3,7 +3,7 @@ cabal-version:          2.2
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-db
-version:                12.0.1
+version:                12.0.2
 synopsis:               A base PostgreSQL component for the cardano-db-sync node.
 description:            Code for the Cardano DB Sync node that is shared between the
                         cardano-db-node and other components.

--- a/cardano-db/src/Cardano/Db/Insert.hs
+++ b/cardano-db/src/Cardano/Db/Insert.hs
@@ -13,7 +13,6 @@ module Cardano.Db.Insert
   , insertDelegation
   , insertEpoch
   , insertEpochParam
-  , insertEpochRewardTotalReceived
   , insertEpochSyncTime
   , insertExtraKeyWitness
   , insertManyEpochStakes
@@ -130,9 +129,6 @@ insertEpoch = insertUnchecked "Epoch"
 
 insertEpochParam :: (MonadBaseControl IO m, MonadIO m) => EpochParam -> ReaderT SqlBackend m EpochParamId
 insertEpochParam = insertUnchecked "EpochParam"
-
-insertEpochRewardTotalReceived :: (MonadBaseControl IO m, MonadIO m) => EpochRewardTotalReceived -> ReaderT SqlBackend m EpochRewardTotalReceivedId
-insertEpochRewardTotalReceived = insertCheckUnique "EpochRewardTotalReceived"
 
 insertEpochSyncTime :: (MonadBaseControl IO m, MonadIO m) => EpochSyncTime -> ReaderT SqlBackend m EpochSyncTimeId
 insertEpochSyncTime = insertReplace "EpochSyncTime"

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -454,7 +454,7 @@ share
     minUtxoValue        DbLovelace Maybe    sqltype=lovelace
     minPoolCost         DbLovelace Maybe    sqltype=lovelace
 
-    coinsPerUtxoWord    DbLovelace Maybe    sqltype=lovelace
+    coinsPerUtxoSize    DbLovelace Maybe    sqltype=lovelace
     costModelId         CostModelId Maybe   OnDeleteCascade
     priceMem            Double Maybe        -- sqltype=rational
     priceStep           Double Maybe        -- sqltype=rational
@@ -492,7 +492,7 @@ share
 
     nonce               ByteString Maybe    sqltype=hash32type
 
-    coinsPerUtxoWord    DbLovelace Maybe    sqltype=lovelace
+    coinsPerUtxoSize    DbLovelace Maybe    sqltype=lovelace
     costModelId         CostModelId Maybe   OnDeleteCascade
     priceMem            Double Maybe        -- sqltype=rational
     priceStep           Double Maybe        -- sqltype=rational
@@ -907,7 +907,7 @@ schemaDocs =
       ParamProposalProtocolMinor # "The protocol minor number."
       ParamProposalMinUtxoValue # "The minimum value of a UTxO entry."
       ParamProposalMinPoolCost # "The minimum pool cost."
-      ParamProposalCoinsPerUtxoWord # "The cost per UTxO word."
+      ParamProposalCoinsPerUtxoSize # "For Alonzo this is the cost per UTxO word. For Babbage and later per UTxO byte. New in v13: Renamed from coins_per_utxo_word."
       ParamProposalCostModelId # "The CostModel table index for the proposal."
       ParamProposalPriceMem # "The per word cost of script memory usage."
       ParamProposalPriceStep # "The cost of script execution step usage."
@@ -942,7 +942,7 @@ schemaDocs =
       EpochParamMinUtxoValue # "The minimum value of a UTxO entry."
       EpochParamMinPoolCost # "The minimum pool cost."
       EpochParamNonce # "The nonce value for this epoch."
-      EpochParamCoinsPerUtxoWord # "The cost per UTxO word."
+      EpochParamCoinsPerUtxoSize # "For Alonzo this is the cost per UTxO word. For Babbage and later per UTxO byte. New in v13: Renamed from coins_per_utxo_word."
       EpochParamCostModelId # "The CostModel table index for the params."
       EpochParamPriceMem # "The per word cost of script memory usage."
       EpochParamPriceStep # "The cost of script execution step usage."

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -539,15 +539,6 @@ share
     deriving Show
 
   --------------------------------------------------------------------------
-  -- Currently this table contains the total rewards for an epoch extracted
-  -- from the ledger state, but *before* orphaned rewards are removed from the
-  -- Reward table.
-  EpochRewardTotalReceived
-    earnedEpoch         Word64              sqltype=word31type
-    amount              DbLovelace          sqltype=lovelace
-    UniqueEpochRewardTotalReceived earnedEpoch
-
-  --------------------------------------------------------------------------
   -- A table containing a managed list of reserved ticker names.
   -- For now they are grouped under the specific hash of the pool.
   ReservedPoolTicker
@@ -986,13 +977,6 @@ schemaDocs =
       PoolOfflineFetchErrorPmrId # "The PoolMetadataRef table index for this offline data."
       PoolOfflineFetchErrorFetchError # "The text of the error."
       PoolOfflineFetchErrorRetryCount # "The number of retries."
-
-    EpochRewardTotalReceived --^ do
-      "This table is used to help validate the accounting of rewards. It contains the total reward \
-        \ amount for each epoch received from the ledger state and includes orphaned rewards that \
-        \ are later removed from the Reward table."
-      EpochRewardTotalReceivedEarnedEpoch # "The epoch in which the reward was earned."
-      EpochRewardTotalReceivedAmount # "The total rewards for the epoch in Lovelace."
 
     ReservedPoolTicker --^ do
       "A table containing a managed list of reserved ticker names."

--- a/cardano-smash-server/CHANGELOG.md
+++ b/cardano-smash-server/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Revision history for cardano-smash-server
 
+## 12.0.2
+* Fix PoolOfflineFetchError URL entry (#697).
+
 ## 12.0.1
 * Fix metadata hash in served JSON.
-
 
 ## 12.0.0
 * Port standalone smash to db-sync.

--- a/cardano-smash-server/cardano-smash-server.cabal
+++ b/cardano-smash-server/cardano-smash-server.cabal
@@ -3,7 +3,7 @@ cabal-version:          2.2
 -- http://haskell.org/cabal/users-guide/
 
 name:                   cardano-smash-server
-version:                12.0.1
+version:                12.0.2
 synopsis:               The Cardano smash server
 description:            Please see the README on GitHub at
                         <https://github.com/input-output-hk/cardano-db-sync/cardano-smash-server/#readme>

--- a/schema/migration-2-0016-20220524.sql
+++ b/schema/migration-2-0016-20220524.sql
@@ -9,6 +9,7 @@ BEGIN
     EXECUTE 'ALTER TABLE "cost_model" ADD COLUMN "hash" hash32type NOT NULL' ;
     EXECUTE 'ALTER TABLE "cost_model" DROP CONSTRAINT "unique_cost_model"' ;
     EXECUTE 'ALTER TABLE "cost_model" ADD CONSTRAINT "unique_cost_model" UNIQUE("hash")' ;
+    EXECUTE 'DROP TABLE epoch_reward_total_received';
     -- Hand written SQL statements can be added here.
     UPDATE schema_version SET stage_two = next_version ;
     RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;

--- a/schema/migration-2-0017-20220526.sql
+++ b/schema/migration-2-0017-20220526.sql
@@ -1,0 +1,22 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 17 THEN
+    EXECUTE 'ALTER TABLE "param_proposal" ADD COLUMN "coins_per_utxo_size" lovelace NULL' ;
+    EXECUTE 'ALTER TABLE "param_proposal" DROP COLUMN "coins_per_utxo_word"' ;
+    EXECUTE 'ALTER TABLE "epoch_param" ADD COLUMN "coins_per_utxo_size" lovelace NULL' ;
+    EXECUTE 'ALTER TABLE "epoch_param" DROP COLUMN "coins_per_utxo_word"' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
Follow up to https://github.com/input-output-hk/cardano-db-sync/pull/1112
- backports changelog for 12.0.2
- Documents Schema better. Adds `New in v13` annotations for things that changed wince release 12.0.0.
- Removes total_reward 
- Improves naming for babbage params.
