### PR TITLE
db: Robustify creation of indices in migrations

### DIFF
--- a/schema/migration-3-0008-20220118.sql
+++ b/schema/migration-3-0008-20220118.sql
@@ -5,12 +5,12 @@ BEGIN
   SELECT stage_three + 1 INTO next_version FROM schema_version ;
   IF next_version <= 8 THEN
 
-    CREATE INDEX idx_datum_tx_id ON datum (tx_id) ;
-    CREATE INDEX idx_redeemer_datum_id ON redeemer (datum_id) ;
-    CREATE INDEX idx_extra_key_witness_tx_id ON extra_key_witness (tx_id) ;
-    CREATE INDEX idx_cost_model_block_id ON cost_model (block_id) ;
-    CREATE INDEX idx_param_proposal_cost_model_id ON param_proposal (cost_model_id) ;
-    CREATE INDEX idx_epoch_param_cost_model_id ON epoch_param (cost_model_id) ;
+    CREATE INDEX IF NOT EXISTS idx_datum_tx_id ON datum (tx_id) ;
+    CREATE INDEX IF NOT EXISTS idx_redeemer_datum_id ON redeemer (datum_id) ;
+    CREATE INDEX IF NOT EXISTS idx_extra_key_witness_tx_id ON extra_key_witness (tx_id) ;
+    CREATE INDEX IF NOT EXISTS idx_cost_model_block_id ON cost_model (block_id) ;
+    CREATE INDEX IF NOT EXISTS idx_param_proposal_cost_model_id ON param_proposal (cost_model_id) ;
+    CREATE INDEX IF NOT EXISTS idx_epoch_param_cost_model_id ON epoch_param (cost_model_id) ;
 
     UPDATE schema_version SET stage_three = 8 ;
     RAISE NOTICE 'DB has been migrated to stage_three version %', next_version ;


### PR DESCRIPTION
Ensure schema migration in stage 3 to version 8 does not fail when involved indices
are already created.