### PR TITLE
fix: align docker-compose db-sync-data mount with nix default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - postgres_user
       - postgres_db
     volumes:
-      - db-sync-data:/var/lib/cdbsync
+      - db-sync-data:/var/lib/cexplorer
       - node-ipc:/node-ipc
     restart: on-failure
     logging:


### PR DESCRIPTION
`/var/lib/cexplorer` is the expected mount path for the `--state-dir` config defined in the nix service (see below), but the docker-compose file is mounting to `/var/lib/cdbsync`. The snapshot script is trying to unpack the ledger state to a non-existent directory

https://github.com/input-output-hk/cardano-db-sync/blob/cc6d8d4934c162a64c86b30cf35b520205328139/nix/nixos/cardano-db-sync-service.nix#L125-L128

Fixes #1150