### PR TITLE
Handle PlutusV1 and V2 script types

### DIFF
--- a/cardano-db-sync/CHANGELOG.md
+++ b/cardano-db-sync/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+* Handle `PlutusV1` and `PlutusV2` scripts as seperate script types, removing old `Plutus` type
 * Store CBOR serialized `Datum` and `Redeemer` via `bytes` field
 * Store `requiredSigners` (transaction extra key witnesses).
 

--- a/cardano-db/CHANGELOG.md
+++ b/cardano-db/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Revision history for cardano-db
 
 ## Next
+* Drop `Plutus` `ScriptType` in favor of `PlutusV1` and `PlutusV2`
 * Add `extra_key_witness` table for storing `requiredSigners` (transaction extra key witnesses).
 
 ## 12.0.2

--- a/cardano-db/src/Cardano/Db/Types.hs
+++ b/cardano-db/src/Cardano/Db/Types.hs
@@ -143,7 +143,8 @@ data ScriptPurpose
 data ScriptType
   = MultiSig
   | Timelock
-  | Plutus
+  | PlutusV1
+  | PlutusV2
   deriving (Eq, Generic, Show)
 
 data PoolCertAction
@@ -268,14 +269,16 @@ renderScriptType st =
   case st of
     MultiSig -> "multisig"
     Timelock -> "timelock"
-    Plutus -> "plutus"
+    PlutusV1 -> "plutusV1"
+    PlutusV2 -> "plutusV2"
 
 readScriptType :: String -> ScriptType
 readScriptType str =
   case str of
     "multisig" -> MultiSig
     "timelock" -> Timelock
-    "plutus" -> Plutus
+    "plutusV1" -> PlutusV1
+    "plutusV2" -> PlutusV2
     _other -> error $ "readScriptType: Unknown ScriptType " ++ str
 
 word64ToAda :: Word64 -> Ada

--- a/schema/migration-1-0009-20210727.sql
+++ b/schema/migration-1-0009-20210727.sql
@@ -9,7 +9,7 @@ BEGIN
   SELECT stage_one + 1 INTO next_version FROM "schema_version";
   IF next_version = 9 THEN
 
-    CREATE TYPE scripttype AS ENUM ('multisig', 'timelock', 'plutus');
+    CREATE TYPE scripttype AS ENUM ('multisig', 'timelock', 'plutusV1', 'plutusV2');
 
     UPDATE "schema_version" SET stage_one = next_version;
     RAISE NOTICE 'DB has been migrated to stage_one version %', next_version;


### PR DESCRIPTION
Not sure if it's better to extend the enum (makes it clear that this is a breaking change) or have this as a separate field (where there's a risk of mishandling `V2` as `V1` if the old code doesn't consult the new field). 

Opening a working draft for discussion.

Needs
- [ ] Changelog
- [x] Migration