### PR TITLE
Fix Babbage snapshots

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -129,8 +129,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: ce3057e0863304ccb3f79d78c77136219dc786c6
-  --sha256: 19ijcy1sl1iqa7diy5nsydnjsn3281kp75i2i42qv0fpn58238s9
+  tag: 3be8a19083fc13d9261b1640e27dd389b51bb08e
+  --sha256: 0dvm9l43mp1i34bcywmznd0660hhcfxwgawypk9q1hjkml1i41z3
   subdir:
     eras/alonzo/impl
     -- eras/alonzo/test-suite


### PR DESCRIPTION
This fixes the snapshot deserialisation bug in Babbage https://github.com/input-output-hk/cardano-db-sync/issues/1181

Tag `13.0.1` has this fix 