### PR TITLE
Allow overriding the env variable PGPASSFILE

### DIFF
--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -3,8 +3,7 @@
 
 import           Cardano.Prelude
 
-
-import           Cardano.Db (MigrationDir (..), PGPassSource (PGPassDefaultEnv), gitRev)
+import           Cardano.Db (MigrationDir (..), PGPassSource (PGPassDefaultEnv, PGPassEnv), gitRev)
 
 import           Cardano.DbSync (runDbSyncNode)
 import           Cardano.DbSync.Config
@@ -95,10 +94,13 @@ pMigrationDir =
     <> Opt.metavar "FILEPATH"
     )
 
--- TODO support more options here
 pPGPassSource :: Parser PGPassSource
 pPGPassSource =
-  pure PGPassDefaultEnv
+  Opt.option (PGPassEnv <$> Opt.str)
+  (  Opt.long "pg-pass-env"
+  <> Opt.help "Alternative env variable to use, defaults to PGPASSFILE env variable."
+  <> Opt.value PGPassDefaultEnv
+  <> Opt.metavar "ENV")
 
 pExtended :: Parser Bool
 pExtended =

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -140,6 +140,7 @@ test-suite test-db
                         Test.IO.Cardano.Db.Rollback
                         Test.IO.Cardano.Db.TotalSupply
                         Test.IO.Cardano.Db.Util
+                        Test.IO.Cardano.Db.PGConfig
 
   ghc-options:          -Wall
                         -Werror

--- a/cardano-db/test/Test/IO/Cardano/Db/Migration.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Migration.hs
@@ -120,7 +120,7 @@ migrationTest :: IO ()
 migrationTest = do
   let schemaDir = MigrationDir "../schema"
   pgConfig <- orDie renderPGPassError $ newExceptT readPGPassDefault
-  _ <-runMigrations pgConfig True schemaDir (Just $ LogFileDir "/tmp")
+  _ <- runMigrations pgConfig True schemaDir (Just $ LogFileDir "/tmp")
   expected <- readSchemaVersion schemaDir
   actual <- getDbSchemaVersion
   unless (expected == actual) $

--- a/cardano-db/test/Test/IO/Cardano/Db/PGConfig.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/PGConfig.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Test.IO.Cardano.Db.PGConfig
+  ( tests
+  ) where
+
+import           Cardano.Db (PGConfig (..), PGPassSource (..), readPGPass, renderPGPassError)
+import           Control.Monad (unless)
+import           Control.Monad.Trans.Except.Exit (orDie)
+import           Control.Monad.Trans.Except.Extra (newExceptT)
+
+import           System.Directory (getCurrentDirectory)
+import           System.Environment
+import           System.FilePath ((</>))
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit (testCase)
+
+tests :: TestTree
+tests =
+  testGroup "PGConfig"
+    [ testCase "Reading PGPass file" pgFileReadTest
+    ]
+
+-- Custom Eq instance that ignores the user field.
+instance Eq PGConfig where
+  (==) a b =
+    pgcHost a == pgcHost b &&
+    pgcPort a == pgcPort b &&
+    pgcDbname a == pgcDbname b &&
+    pgcPassword a == pgcPassword b
+
+pgFileReadTest :: IO ()
+pgFileReadTest = do
+  let expected = PGConfig "/var/run/postgresql" "5432" "testnet" "" "*"
+
+  currentDir <- getCurrentDirectory
+  setEnv "OTHER_PG_PASS_ENV_VARIABLE" (currentDir </> "../config/pgpass-testnet")
+
+  let pg = PGPassEnv "OTHER_PG_PASS_ENV_VARIABLE"
+
+  result <- orDie renderPGPassError $ newExceptT $ readPGPass pg
+  unless (result == expected) $
+    error $ mconcat
+            [ "PGConfig mismatch. Expected "
+            , show expected
+            , " but got "
+            , show result
+            , "."
+            ]
+
+

--- a/cardano-db/test/test-db.hs
+++ b/cardano-db/test/test-db.hs
@@ -10,6 +10,7 @@ import           Test.Tasty (defaultMain, testGroup)
 
 import qualified Test.IO.Cardano.Db.Insert
 import qualified Test.IO.Cardano.Db.Migration
+import qualified Test.IO.Cardano.Db.PGConfig
 import qualified Test.IO.Cardano.Db.Rollback
 import qualified Test.IO.Cardano.Db.TotalSupply
 
@@ -31,5 +32,6 @@ main = do
       , Test.IO.Cardano.Db.Insert.tests
       , Test.IO.Cardano.Db.TotalSupply.tests
       , Test.IO.Cardano.Db.Rollback.tests
+      , Test.IO.Cardano.Db.PGConfig.tests
       ]
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -137,6 +137,7 @@ let
         packages.cardano-db-sync.package.extraSrcFiles = [ "../schema/*.sql" ];
         packages.cardano-chain-gen.package.extraSrcFiles =
           [ "../schema/*.sql" ];
+        packages.cardano-db.package.extraSrcFiles = ["../config/pgpass-testnet"];
       }
       ({ pkgs, ... }: {
         packages = lib.genAttrs [ "cardano-config" "cardano-db" ] (_: {


### PR DESCRIPTION
The --pg-pass-env option allows overriding the env variable to another
value, if absent defaults back to PGPASSFILE inline with previous
behaviour.