### PR TITLE
un-hardcode arch + bsd cmd output mod

### DIFF
--- a/cardano-db-tool/src/Cardano/DbTool/PrepareSnapshot.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/PrepareSnapshot.hs
@@ -18,6 +18,7 @@ import           Ouroboros.Network.Block hiding (blockHash)
 
 import           Paths_cardano_db_tool (version)
 
+import           System.Info (arch, os)
 import           System.IO (hFlush, stdout)
 
 newtype PrepareSnapshotArgs = PrepareSnapshotArgs
@@ -93,12 +94,16 @@ runPrepareSnapshotAux firstTry args = do
           majorStr = case mMajor of
                         Nothing -> ""
                         Just majorV -> "schema-" ++ show majorV
+          cmdStr = "Create a snapshot with:\n"
+                ++ case os of
+                      "freebsd" -> "     cardano-db-sync-pgsql-setup"
+                      _         -> "     scripts/postgresql-setup.sh"
+                ++ " --create-snapshot db-sync-snapshot-"
       putStrLn $ concat
-        [ "Create a snapshot with:\n"
-        , "    scripts/postgresql-setup.sh --create-snapshot db-sync-snapshot-"
+        [ cmdStr
         , majorStr
         , "-block-"
         , show bblockNo
-        , "-x86_64 "
+        , "-" ++ arch ++ " "
         , fp
         ]


### PR DESCRIPTION
"prepare-snapshot" command output is always hardcoded to x86_64, un-hardcoded arch.

Due to the generic name of the "postgresql-setup.sh" script, we cannot install this to the OS in our FreeBSD port "as-is" hence we are renaming it to: cardano-db-sync-pgsql-setup in our port. Added a modification that detects "freebsd" and outputs correct  "--create-snapshot" command so that users are not confused. Outputs "normal" command for all other OSes. This logic can later be used on other OSs as well that might require changing the default snapshot creation instructions.

Tested build on FreeBSD 13.1/ARM ( aarch64 )

"prepare-snapshot" command output seems correct:
![image](https://user-images.githubusercontent.com/6512602/180370793-f18ec7b4-2178-4d49-a541-80f5ea2bd488.png)
