### PR TITLE
Update docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         max-file: "10"
 
   cardano-node:
-    image: inputoutput/cardano-node:1.35.0
+    image: inputoutput/cardano-node:1.35.2
     environment:
       - NETWORK=${NETWORK:-mainnet}
     volumes:
@@ -52,7 +52,7 @@ services:
         max-file: "10"
 
   cardano-db-sync:
-    image: inputoutput/cardano-db-sync:13.0.0
+    image: inputoutput/cardano-db-sync:13.0.2
     environment:
       - NETWORK=${NETWORK:-mainnet}
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
Match the latest versions on each of `cardano-node` and `cardano-db-sync`.

Curiously the `inputoutput/cardano-node:1.35.0` image is no longer on docker hub?