### PR TITLE
Fix stake address rollback

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Cache.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache.hs
@@ -217,9 +217,9 @@ rollbackStakeAddr ci blkNo nBlocks = do
     then liftIO $ atomically $ writeTVar (cStakeCreds ci) Map.empty
     else do
       initMp <- liftIO $ readTVarIO (cStakeCreds ci)
-      stakeAddrIds <- DB.queryStakeAddressIdsAfter blkNo
-      let stakeAddrIdsSet = Set.fromList stakeAddrIds
-      let !mp = Map.filter (`Set.member` stakeAddrIdsSet) initMp
+      stakeAddrIdsToDelete <- DB.queryStakeAddressIdsAfter blkNo
+      let stakeAddrIdsSetToDelete = Set.fromList stakeAddrIdsToDelete
+      let !mp = Map.filter (`Set.notMember` stakeAddrIdsSetToDelete) initMp
       liftIO $ atomically $ writeTVar (cStakeCreds ci) mp
 
 queryRewardAccountWithCache

--- a/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
@@ -60,6 +60,7 @@ rollbackToPoint env point = do
         -- 'length xs' here gives an approximation of the blocks deleted. An approximation
         -- is good enough, since it is only used to decide on the best policy and is not
         -- important for correctness.
+        -- We need to first cleanup the cache and then delete the blocks from db.
         lift $ rollbackCache cache blkNo (fromIntegral $ length xs)
         deleted <- lift $ DB.deleteAfterBlockNo blkNo
         liftIO . logInfo trce $

--- a/cardano-db/src/Cardano/Db/Query.hs
+++ b/cardano-db/src/Cardano/Db/Query.hs
@@ -1078,13 +1078,8 @@ queryStakeAddressScript = do
 queryStakeAddressIdsAfter :: MonadIO m => Word64 -> ReaderT SqlBackend m [StakeAddressId]
 queryStakeAddressIdsAfter blockNo = do
     res <- select $ do
-      (_tx :& blk :& st_addr) <-
-        from $ table @Tx
-        `innerJoin` table @Block
-        `on` (\(tx :& blk) -> tx ^. TxBlockNo ==. blk ^. BlockBlockNo)
-        `innerJoin` table @StakeAddress
-        `on` (\(tx :& _blk :& st_addr) -> tx ^. TxBlockNo  ==. st_addr ^. StakeAddressBlockNo)
-      where_ (blk ^. BlockBlockNo >. val (fromIntegral blockNo))
+      st_addr <- from $ table @StakeAddress
+      where_ (st_addr ^. StakeAddressBlockNo >. val (fromIntegral blockNo))
       pure (st_addr ^. StakeAddressId)
     pure $ unValue <$> res
 


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/cardano-db-sync/issues/1222

While the release version https://github.com/input-output-hk/cardano-db-sync/pull/1247 is definitely needed, it's not clear if the master version is necessary. This is because in master the whole logic of rollbacks has changed. So leaving it as draft for now.
