### PR TITLE
Add quickcheck state machine tests

### DIFF
--- a/cardano-chain-gen/cardano-chain-gen.cabal
+++ b/cardano-chain-gen/cardano-chain-gen.cabal
@@ -155,6 +155,7 @@ test-suite cardano-chain-gen
 
   other-modules:        Test.Cardano.Db.Mock.Config
                         Test.Cardano.Db.Mock.Examples
+                        Test.Cardano.Db.Mock.Property.Property
                         Test.Cardano.Db.Mock.Unit.Alonzo
                         Test.Cardano.Db.Mock.Unit.Babbage
                         Test.Cardano.Db.Mock.UnifiedApi
@@ -209,3 +210,5 @@ test-suite cardano-chain-gen
                       , persistent
                       , persistent-postgresql
                       , postgresql-simple
+                      , QuickCheck
+                      , quickcheck-state-machine

--- a/cardano-chain-gen/src/Cardano/Mock/ChainDB.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/ChainDB.hs
@@ -13,6 +13,8 @@ module Cardano.Mock.ChainDB
   , extendChainDB
   , findFirstPoint
   , rollbackChainDB
+  , findPointByBlockNo
+  , currentBlockNo
   ) where
 
 import           Ouroboros.Consensus.Block
@@ -72,3 +74,11 @@ rollbackChainDB :: HasHeader block => ChainDB block -> Point block -> Maybe (Cha
 rollbackChainDB chainDB p = do
   chain <- rollback (cchain chainDB) p
   Just $ chainDB { cchain = chain}
+
+findPointByBlockNo :: HasHeader block => ChainDB block -> BlockNo -> Maybe (Point block)
+findPointByBlockNo chainDB =
+  findFirstPointByBlockNo (cchain chainDB)
+
+currentBlockNo :: HasHeader block => ChainDB block -> Maybe BlockNo
+currentBlockNo chainDB =
+  currentTipBlockNo (cchain chainDB)

--- a/cardano-chain-gen/src/Cardano/Mock/ChainSync/Server.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/ChainSync/Server.hs
@@ -117,6 +117,9 @@ rollback handle point =
 restartServer :: ServerHandle IO blk -> IO ()
 restartServer sh = do
     stopServer sh
+    -- TODO not sure why, but this delay is necessary. Without it reconnection doesn't happen
+    -- some times.
+    threadDelay 1_000_000
     thread <- forkAgain sh
     atomically $ writeTVar (threadHandle sh) thread
 

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Interpreter.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Interpreter.hs
@@ -23,6 +23,7 @@ module Cardano.Mock.Forging.Interpreter
   , getCurrentInterpreterState
   , getCurrentLedgerState
   , getCurrentEpoch
+  , getNextBlockNo
   , getCurrentSlot
   , forgeWithStakeCreds
   , withBabbageLedgerState
@@ -400,6 +401,10 @@ getCurrentInterpreterState = readMVar . interpState
 
 getCurrentLedgerState :: Interpreter -> IO (ExtLedgerState CardanoBlock)
 getCurrentLedgerState = fmap (currentState . istChain) . getCurrentInterpreterState
+
+getNextBlockNo :: Interpreter -> IO BlockNo
+getNextBlockNo inter =
+    istNextBlockNo <$> getCurrentInterpreterState inter
 
 getCurrentEpoch :: Interpreter -> IO EpochNo
 getCurrentEpoch inter = do

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Interpreter.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Interpreter.hs
@@ -105,7 +105,7 @@ data Interpreter = Interpreter
   , interpTracerForge :: !(Tracer IO (ForgeStateInfo CardanoBlock))
   , interpTopLeverConfig :: !(TopLevelConfig CardanoBlock)
   , interpFingerMode :: !FingerprintMode
-  , interpFingerFile :: !FilePath
+  , interpFingerFile :: !(Maybe FilePath)
   }
 
 data InterpreterState = InterpreterState
@@ -115,7 +115,7 @@ data InterpreterState = InterpreterState
   -- ^ The first slot to try the next block
   , istNextBlockNo :: !BlockNo
   -- ^ the block number of the block to be forged
-  , istFingerprint :: Fingerprint
+  , istFingerprint :: Maybe Fingerprint
   -- ^ newest first list of slots where blocks were succesfully produced.
   } deriving Generic
     deriving NoThunks via OnlyCheckWhnfNamed "InterpreterState" InterpreterState
@@ -131,6 +131,7 @@ data InterpreterState = InterpreterState
 data FingerprintMode
   = SearchSlots !FilePath
   | ValidateSlots
+  | NoFingerprintMode
 
 newtype Fingerprint
   = Fingerprint [Word64]
@@ -142,31 +143,32 @@ deriving instance NoThunks (Forecast a)
 
 deriving instance Generic (Forecast a)
 
-mkFingerprint :: FilePath -> IO (FingerprintMode, Fingerprint)
-mkFingerprint path = do
+mkFingerprint :: Maybe FilePath -> IO (FingerprintMode, Maybe Fingerprint)
+mkFingerprint Nothing = pure (NoFingerprintMode, Nothing)
+mkFingerprint (Just path) = do
   fileExists <- doesPathExist path
   if fileExists
     then do
       mfingerPrint <- eitherDecodeFileStrict path
-      (ValidateSlots,) <$> either (throwIO . FingerprintDecodeError) pure mfingerPrint
+      (ValidateSlots,) <$> either (throwIO . FingerprintDecodeError) (pure . Just) mfingerPrint
     else
-      pure (SearchSlots path, emptyFingerprint)
+      pure (SearchSlots path, Just emptyFingerprint)
 
-isSearchingMode :: FingerprintMode -> Bool
-isSearchingMode fm =
+isNotValidatingMode :: FingerprintMode -> Bool
+isNotValidatingMode fm =
   case fm of
-    SearchSlots {} -> True
-    _ -> False
+    ValidateSlots -> False
+    _ -> True
 
 -- | Given the current slot, return the slot to test and the next 'Fingerprint'
-getFingerTipSlot :: Interpreter -> Fingerprint -> SlotNo -> Either ForgingError SlotNo
-getFingerTipSlot interpreter fingerprint currentSlotNo =
+getFingerTipSlot :: Interpreter -> Maybe Fingerprint -> SlotNo -> Either ForgingError SlotNo
+getFingerTipSlot interpreter mFingerprint currentSlotNo =
   case interpFingerMode interpreter of
-    SearchSlots {} -> Right currentSlotNo
-    ValidateSlots ->
+    ValidateSlots | Just fingerprint <- mFingerprint ->
       case fst <$> unconsFingerprint fingerprint of
         Nothing -> Left $ EmptyFingerprint currentSlotNo (interpFingerFile interpreter)
         Just slotNo -> Right slotNo
+    _ -> Right currentSlotNo
 
 addSlot :: Fingerprint -> SlotNo -> Fingerprint
 addSlot (Fingerprint slots) slot = Fingerprint (unSlotNo slot : slots)
@@ -187,18 +189,18 @@ finalizeFingerprint :: Interpreter -> IO ()
 finalizeFingerprint inter = do
   interState <- getCurrentInterpreterState inter
   case interpFingerMode inter of
-    SearchSlots fp -> encodeFile fp $ reverseFingerprint (istFingerprint interState)
-    ValidateSlots -> pure ()
+    SearchSlots fp | Just fingerprint <- istFingerprint interState -> encodeFile fp $ reverseFingerprint fingerprint
+    _ -> pure ()
 
 initInterpreter
-    :: ProtocolInfo IO CardanoBlock -> Tracer IO (ForgeStateInfo CardanoBlock) -> FilePath
+    :: ProtocolInfo IO CardanoBlock -> Tracer IO (ForgeStateInfo CardanoBlock) -> Maybe FilePath
     -> IO Interpreter
-initInterpreter pinfo traceForge fingerprintFile = do
+initInterpreter pinfo traceForge mFingerprintFile = do
   forging <- pInfoBlockForging pinfo
   let topLeverCfg = pInfoConfig pinfo
   let initSt = pInfoInitLedger pinfo
   let ledgerView = mkForecast topLeverCfg initSt
-  (mode, fingerprint) <- mkFingerprint fingerprintFile
+  (mode, fingerprint) <- mkFingerprint mFingerprintFile
   stvar <- newMVar $
             InterpreterState
               { istChain = initChainDB topLeverCfg initSt
@@ -214,11 +216,11 @@ initInterpreter pinfo traceForge fingerprintFile = do
           , interpTracerForge = traceForge
           , interpTopLeverConfig = topLeverCfg
           , interpFingerMode = mode
-          , interpFingerFile = fingerprintFile
+          , interpFingerFile = mFingerprintFile
           }
 
 withInterpreter
-    :: ProtocolInfo IO CardanoBlock -> Tracer IO (ForgeStateInfo CardanoBlock) -> FilePath
+    :: ProtocolInfo IO CardanoBlock -> Tracer IO (ForgeStateInfo CardanoBlock) -> Maybe FilePath
     -> (Interpreter -> IO a)
     -> IO a
 withInterpreter p t f action = do
@@ -228,21 +230,23 @@ withInterpreter p t f action = do
   pure a
 
 addOrValidateSlot
-    :: Interpreter -> Fingerprint -> CardanoBlock
-    -> Either ForgingError Fingerprint
-addOrValidateSlot interp fingerprint blk =
+    :: Interpreter -> Maybe Fingerprint -> CardanoBlock
+    -> Either ForgingError (Maybe Fingerprint)
+addOrValidateSlot interp mFingerprint blk =
   case interpFingerMode interp of
-    SearchSlots _ -> Right $ addSlot fingerprint (blockSlot blk)
-    ValidateSlots ->
+    SearchSlots _ | Just fingerprint <- mFingerprint ->
+      Right $ Just $ addSlot fingerprint (blockSlot blk)
+    ValidateSlots | Just fingerprint <- mFingerprint ->
       case unconsFingerprint fingerprint of
         Nothing -> Left $ EmptyFingerprint (blockSlot blk) (interpFingerFile interp)
         Just (slotNo, fingerPrint') ->
           if slotNo == blockSlot blk
-            then Right fingerPrint'
+            then Right (Just fingerPrint')
             else
               -- The validation here is unecessary, since we have used the slot to
               -- forge the block. But we do it nontheless as a sanity check.
               Left $ NotExpectedSlotNo (blockSlot blk) slotNo (lengthSlots fingerPrint')
+    _ -> Right Nothing
 
 forgeWithStakeCreds :: Interpreter -> IO CardanoBlock
 forgeWithStakeCreds inter = do
@@ -291,15 +295,15 @@ forgeNextLeaders interpreter txes possibleLeaders = do
     cfg = interpTopLeverConfig interpreter
 
     tryOrValidateSlot
-        :: InterpreterState -> [BlockForging IO CardanoBlock] -> IO (CardanoBlock, Fingerprint)
+        :: InterpreterState -> [BlockForging IO CardanoBlock] -> IO (CardanoBlock, Maybe Fingerprint)
     tryOrValidateSlot interState blockForgings = do
       currentSlot <- throwLeftIO $
                         getFingerTipSlot interpreter (istFingerprint interState) (istSlot interState)
-      trySlots interState blockForgings 0 currentSlot (isSearchingMode $ interpFingerMode interpreter)
+      trySlots interState blockForgings 0 currentSlot (isNotValidatingMode $ interpFingerMode interpreter)
 
     trySlots
         :: InterpreterState -> [BlockForging IO CardanoBlock] -> Int -> SlotNo -> Bool
-        -> IO (CardanoBlock, Fingerprint)
+        -> IO (CardanoBlock, Maybe  Fingerprint)
     trySlots interState blockForgings numberOfTries currentSlot searching = do
       when (numberOfTries > 140) (throwIO $ WentTooFar currentSlot)
       mproof <- tryAllForging interpreter interState currentSlot blockForgings
@@ -307,7 +311,7 @@ forgeNextLeaders interpreter txes possibleLeaders = do
         Nothing ->
           if searching
             then trySlots interState blockForgings (numberOfTries + 1) (currentSlot + 1) searching
-            else throwIO $ FailedToValidateSlot currentSlot (lengthSlots $ istFingerprint interState) (interpFingerFile interpreter)
+            else throwIO $ FailedToValidateSlot currentSlot (lengthSlots <$> istFingerprint interState) (interpFingerFile interpreter)
         Just (proof, blockForging) -> do
           -- Tick the ledger state for the 'SlotNo' we're producing a block for
           let tickedLedgerSt :: Ticked (LedgerState CardanoBlock)

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Babbage.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Babbage.hs
@@ -31,6 +31,7 @@ module Cardano.Mock.Forging.Tx.Babbage
   , mkMAssetsScriptTx
   , mkDCertTx
   , mkSimpleDCertTx
+  , mkDummyRegisterTx
   , mkDCertPoolTx
   , mkScriptDCertTx
   , mkDepositTxPools
@@ -72,13 +73,14 @@ import           Cardano.Ledger.BaseTypes
 import           Cardano.Ledger.Coin
 import qualified Cardano.Ledger.Core as Core
 import           Cardano.Ledger.Credential
+import           Cardano.Ledger.Crypto (ADDRHASH)
 import           Cardano.Ledger.Hashes
 import           Cardano.Ledger.Keys
 import           Cardano.Ledger.Mary.Value
 import           Cardano.Ledger.Serialization
 import           Cardano.Ledger.Shelley.Metadata
-import           Cardano.Ledger.Shelley.TxBody (DCert (..), PoolCert (..), PoolMetadata (..),
-                   PoolParams (..), StakePoolRelay (..), Wdrl (..))
+import           Cardano.Ledger.Shelley.TxBody (DCert (..), DelegCert (..), PoolCert (..),
+                   PoolMetadata (..), PoolParams (..), StakePoolRelay (..), Wdrl (..))
 import           Cardano.Ledger.ShelleyMA.Timelocks
 import           Cardano.Ledger.TxIn (TxId, TxIn (..), txid)
 
@@ -342,6 +344,11 @@ mkSimpleDCertTx consDert st = do
       pure $ mkDCert cred
     mkDCertTx dcerts (Wdrl mempty) Nothing
 
+mkDummyRegisterTx :: Int -> Int -> Either ForgingError (ValidatedTx StandardBabbage)
+mkDummyRegisterTx n m =
+  mkDCertTx (DCertDeleg . RegKey . KeyHashObj . KeyHash . mkDummyHash (Proxy @(ADDRHASH StandardCrypto)) . fromIntegral <$> [n, m])
+            (Wdrl mempty) Nothing
+
 mkDCertPoolTx :: [([StakeIndex], PoolIndex,
                   [StakeCredential StandardCrypto] -> KeyHash 'StakePool StandardCrypto -> DCert StandardCrypto)]
               -> BabbageLedgerState
@@ -440,11 +447,11 @@ mkWitnesses rdmrs datas =
     redeemers = fmap (, (plutusDataList, ExUnits 100 100))
                     (fst <$> rdmrs)
 
-addMetadata :: Word64 -> ValidatedTx StandardBabbage
+addMetadata :: Word64 -> Word64 -> ValidatedTx StandardBabbage
             -> ValidatedTx StandardBabbage
-addMetadata n tx = tx { auxiliaryData = Strict.SJust $ AuxiliaryData mp mempty}
+addMetadata n m tx = tx { auxiliaryData = Strict.SJust $ AuxiliaryData mp mempty}
   where
-    mp = Map.singleton n $ List []
+    mp = Map.fromList [(n, List []), (m , List [])]
 
 mkUTxOBabbage :: ValidatedTx StandardBabbage -> [(TxIn StandardCrypto, TxOut StandardBabbage)]
 mkUTxOBabbage tx =

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Babbage.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Babbage.hs
@@ -440,9 +440,9 @@ mkWitnesses rdmrs datas =
     redeemers = fmap (, (plutusDataList, ExUnits 100 100))
                     (fst <$> rdmrs)
 
-addMetadata :: ValidatedTx StandardBabbage -> Word64
+addMetadata :: Word64 -> ValidatedTx StandardBabbage
             -> ValidatedTx StandardBabbage
-addMetadata tx n = tx { auxiliaryData = Strict.SJust $ AuxiliaryData mp mempty}
+addMetadata n tx = tx { auxiliaryData = Strict.SJust $ AuxiliaryData mp mempty}
   where
     mp = Map.singleton n $ List []
 

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Generic.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Generic.hs
@@ -15,6 +15,7 @@ module Cardano.Mock.Forging.Tx.Generic
   , createPaymentCredentials
   , mkDummyScriptHash
   , unregisteredGenesisKeys
+  , mkDummyHash
   ) where
 
 import           Cardano.Prelude hiding (length, (.))

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Types.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Types.hs
@@ -63,8 +63,8 @@ data ForgingError
   | ExpectedAlonzoState
   | ExpectedShelleyState
   | UnexpectedEra
-  | EmptyFingerprint !SlotNo !FilePath
-  | FailedToValidateSlot !SlotNo !Int !FilePath
+  | EmptyFingerprint !SlotNo !(Maybe FilePath)
+  | FailedToValidateSlot !SlotNo !(Maybe Int) !(Maybe FilePath)
   | NotExpectedSlotNo !SlotNo !SlotNo !Int
   | FingerprintDecodeError !String
   | RollbackFailed

--- a/cardano-chain-gen/test/Main.hs
+++ b/cardano-chain-gen/test/Main.hs
@@ -14,7 +14,9 @@ import           MigrationValidations (KnownMigration (..), knownMigrations)
 import           Cardano.Mock.ChainSync.Server
 
 import           Test.Tasty
+import           Test.Tasty.QuickCheck (testProperty)
 
+import qualified Test.Cardano.Db.Mock.Property.Property as Property
 import qualified Test.Cardano.Db.Mock.Unit.Alonzo as Alonzo
 import qualified Test.Cardano.Db.Mock.Unit.Babbage as Babbage
 
@@ -34,7 +36,8 @@ tests iom = do
       testGroup
         "cardano-chain-gen"
           [
-            Babbage.unitTests iom knownMigrationsPlain
+            testProperty "QSM" $ Property.prop_empty_blocks iom knownMigrationsPlain
+          , Babbage.unitTests iom knownMigrationsPlain
           , Alonzo.unitTests iom knownMigrationsPlain
           ]
   where

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Property/Property.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Property/Property.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Db.Mock.Property.Property
+    ( prop_empty_blocks
+    ) where
+
+import           Control.Monad.Class.MonadSTM.Strict (MonadSTM (atomically))
+import           Data.Foldable
+import           Data.Maybe (fromJust)
+import           Data.Text (Text)
+import           Data.TreeDiff (defaultExprViaShow)
+import           GHC.Generics (Generic, Generic1)
+
+import           Cardano.Mock.Chain
+import           Cardano.Mock.ChainSync.Server
+import           Cardano.Mock.Forging.Interpreter
+import           Cardano.Mock.Forging.Tx.Babbage
+import           Cardano.Mock.Forging.Types
+
+import           Test.Cardano.Db.Mock.Config
+import           Test.Cardano.Db.Mock.UnifiedApi
+import           Test.Cardano.Db.Mock.Validate
+
+import           Ouroboros.Network.Block hiding (RollBack)
+
+import           Test.QuickCheck (Gen, Property, frequency, (===))
+import           Test.QuickCheck.Monadic (monadicIO, run)
+
+import           Test.StateMachine
+import           Test.StateMachine.Sequential (runCommands')
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+
+data Command r
+    = RollForward Int
+    | RollBack (Maybe BlockNo)
+    | StopDBSync
+    | StartDBSync
+    | AssertBlockNo (Maybe BlockNo)
+    deriving stock (Eq, Generic1)
+    deriving anyclass (Rank2.Functor, Rank2.Foldable, Rank2.Traversable, CommandNames)
+
+deriving stock instance Show (Command Symbolic)
+deriving stock instance Show (Command Concrete)
+
+data Model r = Model
+    { serverTip :: Maybe BlockNo
+    , dbSyncTip :: Maybe BlockNo
+    , dbSynsIsOn :: Bool
+    }
+    deriving stock (Generic, Show)
+
+instance ToExpr (Model Symbolic)
+instance ToExpr (Model Concrete)
+
+initModel :: Model r
+initModel = Model Nothing Nothing False
+
+instance ToExpr BlockNo where
+    toExpr = defaultExprViaShow
+
+-- Model $ initChainDB (pInfoConfig pinfo) (pInfoInitLedger pinfo)
+
+data Response r =
+    NewBlockAdded (Reference (Opaque CardanoBlock) r)
+  | Error String
+  | Unit ()
+  deriving stock (Generic1)
+  deriving anyclass (Rank2.Foldable)
+
+deriving stock instance Show (Response Symbolic)
+deriving stock instance Read (Response Symbolic)
+deriving stock instance Show (Response Concrete)
+
+transition :: Model r -> Command r -> Response r -> Model r
+transition m cmd resp = case (cmd, resp) of
+    (_, Error msg) -> error msg
+    (RollForward _, _) | dbSynsIsOn m ->
+        Model (nextTip $ serverTip m) (nextTip $ dbSyncTip m) (dbSynsIsOn m)
+    (RollForward _, _) ->
+        Model (nextTip $ serverTip m) (dbSyncTip m) (dbSynsIsOn m)
+    (RollBack blkNo, _) | dbSynsIsOn m ->
+        Model blkNo blkNo (dbSynsIsOn m)
+    (RollBack blkNo, _) ->
+        Model blkNo (dbSyncTip m) (dbSynsIsOn m)
+    (StopDBSync, _) | dbSynsIsOn m ->
+        Model (serverTip m) (dbSyncTip m)  False
+    (StopDBSync, _) ->
+        error "Tried to stop stopped DBSync"
+    (StartDBSync, _) | dbSynsIsOn m ->
+        error "Tried to start started DBSync"
+    (StartDBSync, _) ->
+        Model (serverTip m) (dbSyncTip m) True
+    (AssertBlockNo _, _) ->
+        m
+  where
+    nextTip Nothing = Just $ BlockNo 1
+    nextTip (Just b) = Just $ b + 1
+
+precondition :: Model Symbolic -> Command Symbolic -> Logic
+precondition m cmd = case cmd of
+  RollForward _ -> Top
+  RollBack n -> n .< serverTip m -- can it be equal?
+  StopDBSync  -> Boolean $ dbSynsIsOn m
+  StartDBSync -> Boolean $ not $ dbSynsIsOn m
+  AssertBlockNo n -> Boolean $ dbSyncTip m == n
+
+postcondition :: Model Concrete -> Command Concrete -> Response Concrete -> Logic
+postcondition _ _ resp = case resp of
+  Error msg -> Annotate msg Bot
+  _ -> Top
+
+semantics :: Interpreter -> ServerHandle IO CardanoBlock -> DBSyncEnv -> Command Concrete -> IO (Response Concrete)
+semantics interpreter mockServer dbSync cmd = case cmd of
+    RollForward n -> NewBlockAdded . reference . Opaque <$> createBlock n interpreter mockServer
+    RollBack Nothing -> Unit <$> rollbackTo interpreter mockServer GenesisPoint
+    RollBack (Just blkNo) -> do
+        chain <- atomically $ readChain mockServer
+        case findFirstPointByBlockNo chain blkNo of
+            Nothing -> pure $ Error $ "Failed to find point for " <> show blkNo
+            Just pnt -> Unit <$> rollbackTo interpreter mockServer pnt
+    StopDBSync -> Unit <$> stopDBSync dbSync
+    StartDBSync -> Unit <$> startDBSync dbSync
+    AssertBlockNo Nothing -> Unit <$> assertBlocksCount dbSync 2
+    AssertBlockNo (Just n) -> Unit <$> assertBlockNoBackoff dbSync (fromIntegral $ unBlockNo n)
+
+mock :: Model Symbolic -> Command Symbolic -> GenSym (Response Symbolic)
+mock m cmd = case cmd of
+    RollForward _ -> NewBlockAdded <$> genSym
+    RollBack Nothing -> pure $ Unit ()
+    RollBack mBlkNo | mBlkNo < serverTip m -> pure $ Unit ()
+    RollBack (Just blkNo) -> pure $ Error $ "Failed to find point for " <> show blkNo
+    StopDBSync -> pure $ Unit ()
+    StartDBSync -> pure $ Unit ()
+    AssertBlockNo _ -> pure $ Unit ()
+
+createBlock :: Int -> Interpreter -> ServerHandle IO CardanoBlock -> IO CardanoBlock
+createBlock n interpreter mockServer = case n of
+    0 -> forgeNextFindLeaderAndSubmit interpreter mockServer []
+    _ -> withBabbageFindLeaderAndSubmit interpreter mockServer $ \_ -> Right [addMetadata (fromIntegral n) emptyTx]
+
+generator :: Model Symbolic -> Maybe (Gen (Command Symbolic))
+generator m            = Just $ frequency
+  [ (if isOn then 90 else 0, genRollForward m)
+  , (if not canRollback then 0 else if isOn then 10 else 0, genRollBack m)
+  , (if isOn then 10 else  0, genStopDBSync m)
+  , (if isOn then  0 else 60, genStartDBSync m)
+  , (if isOn then 30 else 0, genAssertBlockNo m)
+  ]
+  where
+    isOn = dbSynsIsOn m
+    canRollback = case serverTip m of
+      Nothing -> False
+      Just 0 -> False
+      Just _ -> True
+
+genRollForward :: Model Symbolic -> Gen (Command Symbolic)
+genRollForward _ = RollForward <$> frequency [(60, pure 0), (30, pure 1), (10, pure 2)]
+
+genRollBack :: Model Symbolic -> Gen (Command Symbolic)
+genRollBack m = RollBack <$> frequency [(10, pure Nothing), (90, Just <$> rollbackPrev)]
+  where
+    srvTip = fromJust (error "Server on Genesis") (serverTip m)
+    rollbackPrev = frequency $ zip [1..(fromIntegral (unBlockNo srvTip) - 1)] (pure <$> [1.. (srvTip - 1)])
+
+genStopDBSync :: Model Symbolic -> Gen (Command Symbolic)
+genStopDBSync _ = pure StopDBSync
+
+genStartDBSync :: Model Symbolic -> Gen (Command Symbolic)
+genStartDBSync _ = pure StartDBSync
+
+genAssertBlockNo :: Model Symbolic -> Gen (Command Symbolic)
+genAssertBlockNo m = pure $ AssertBlockNo $ dbSyncTip m
+
+shrinker :: Model Symbolic -> Command Symbolic -> [Command Symbolic]
+shrinker _ (RollForward n) = [ RollForward n' | n' <- [0,1,2], n' < n ]
+shrinker m (RollBack mBlockNo) =
+    [ RollBack (Just blkNo')
+    | serverBlockNo <- toList (serverTip m)
+    , blkNo' <- [toNext mBlockNo..serverBlockNo]
+    , blkNo' < serverBlockNo ]
+  where
+    toNext Nothing = BlockNo 1
+    toNext (Just n) = n + 1
+shrinker _ _ = []
+
+sm :: Interpreter -> ServerHandle IO CardanoBlock -> DBSyncEnv -> StateMachine Model Command IO Response
+sm interpreter mockServer dbSync = StateMachine initModel transition precondition postcondition
+         Nothing generator shrinker (semantics interpreter mockServer dbSync) mock noCleanup
+
+prop_empty_blocks :: IOManager -> [(Text, Text)] -> Property
+prop_empty_blocks iom knownMigrations = forAllCommands smSymbolic Nothing $ \cmds -> monadicIO $ do
+    (hist, _model, res) <- run $ runAction $ \interpreter mockServer dbSync -> do
+       runCommands' (sm interpreter mockServer dbSync) cmds
+    prettyCommands smSymbolic hist (checkCommandNames cmds (res === Ok))
+  where
+    smSymbolic = sm (error "inter") (error "mockServer") (error "dbSync")
+    runAction action = withFullConfig' False "config" "qsm" action iom knownMigrations
+

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Validate.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Validate.hs
@@ -156,8 +156,8 @@ checkStillRuns env = do
     Just (Left err) -> throwIO err
 
 migrationNotDoneYet :: Text -> Bool
-migrationNotDoneYet txt =
-  Text.isPrefixOf "relation" txt && Text.isSuffixOf "does not exist" txt
+migrationNotDoneYet =
+  Text.isPrefixOf "relation"
 
 assertCurrentEpoch :: DBSyncEnv -> Word64 -> IO ()
 assertCurrentEpoch env expected =


### PR DESCRIPTION
This is a follow up pr to test https://github.com/input-output-hk/cardano-db-sync/pull/1266

These tests generate a list of symbolic commands like these
``` haskell
data Command r
    = RollForward Int
    | RollBack (Maybe BlockNo)
    | StopDBSync
    | StartDBSync
    | AssertBlockNo (Maybe BlockNo)
```

The commands are translated into real commands. For example `RollForward Int` will forge a new block that fits on the current chain. These real commands are executed against db-sync using the mock chain-sync server. The symbolic commands are exxecuted against a vesy simplistic Model of db-sync which looks like this:

``` haskell
data Model r = Model
    { serverTip :: Maybe BlockNo
    , dbSyncTip :: Maybe BlockNo
    , dbSynsIsOn :: Bool
    }
    deriving stock (Generic, Show)
```

Finally a number of postconditions are checked.