### PR TITLE
Fix werrors in `cardano-db`

### DIFF
--- a/cardano-db/src/Cardano/Db/Run.hs
+++ b/cardano-db/src/Cardano/Db/Run.hs
@@ -48,7 +48,7 @@ import           Database.Esqueleto.Experimental (SqlQuery)
 import           Database.Esqueleto.Internal.Internal (Mode (SELECT), SqlSelect, initialIdentState,
                    toRawSql)
 
-import           Data.Pool (Pool (..))
+import           Data.Pool (Pool)
 import           Database.Persist.Postgresql (ConnectionString, SqlBackend, openSimpleConn,
                    withPostgresqlConn)
 import           Database.Persist.Sql (IsolationLevel (..), runSqlConnWithIsolation,

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -15,6 +15,8 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
 module Cardano.Db.Schema where
 
 import           Cardano.Db.Schema.Orphans ()


### PR DESCRIPTION
* Unimport unused constructors of `Pool` in `Cardano.Db.Run`
* Add `-Wno-name-shadowing` to `Cardano.Db.Schema` to avoid error caused by shadowing of `share` due to TH splice