### PR TITLE
Loosen unique constraint on `extra_key_witness`

### DIFF
--- a/cardano-db/src/Cardano/Db/Insert.hs
+++ b/cardano-db/src/Cardano/Db/Insert.hs
@@ -133,8 +133,8 @@ insertEpochParam = insertCheckUnique "EpochParam"
 insertEpochSyncTime :: (MonadBaseControl IO m, MonadIO m) => EpochSyncTime -> ReaderT SqlBackend m EpochSyncTimeId
 insertEpochSyncTime = insertReplace "EpochSyncTime"
 
-insertExtraKeyWitness :: (MonadBaseControl IO m, MonadIO m) => ExtraKeyWitness -> ReaderT SqlBackend m ExtraKeyWitnessId
-insertExtraKeyWitness = insertCheckUnique "ExtraKeyWitness"
+insertExtraKeyWitness :: (MonadIO m) => ExtraKeyWitness -> ReaderT SqlBackend m ExtraKeyWitnessId
+insertExtraKeyWitness = insert
 
 insertManyEpochStakes :: (MonadBaseControl IO m, MonadIO m) => [EpochStake] -> ReaderT SqlBackend m ()
 insertManyEpochStakes = insertManyUncheckedUnique "Many EpochStake"

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -441,7 +441,6 @@ share
   ExtraKeyWitness
     hash                ByteString          sqltype=hash28type
     txId                TxId
-    UniqueWitness       hash
 
   -- -----------------------------------------------------------------------------------------------
   -- Update parameter proposals.

--- a/schema/migration-2-0004-20221019.sql
+++ b/schema/migration-2-0004-20221019.sql
@@ -1,0 +1,19 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 4 THEN
+    EXECUTE 'ALTER TABLE "extra_key_witness" DROP CONSTRAINT "unique_witness"' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
The previous unique constraint made `extra_key_witness` only hold key witnesses for the first time a key was used as a "required signer" ("extra key witness"). Subsequent uses of keys as required signers would fail to insert due to the constraint. This loosens the constraint so the combination of the `hash` and `tx_id` columns must be unique. Since this new constraint is unlikely to trigger, I changed the insertion of key witnesses to use `insertUnchecked`. Now any transaction which has "required signers" will have those included in the `extra_key_witness` table.