### PR TITLE
Removed `./` from `customConfig` input `url`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1111,11 +1111,11 @@
       "locked": {
         "lastModified": 1,
         "narHash": "sha256-Zd5w1I1Dwt783Q4WuBuCpedcwG1DrIgQGqabyF87prM=",
-        "path": "./custom-config",
+        "path": "custom-config",
         "type": "path"
       },
       "original": {
-        "path": "./custom-config",
+        "path": "custom-config",
         "type": "path"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       url = "github:input-output-hk/flake-compat/fixes";
       flake = false;
     };
-    customConfig = { url = "path:./custom-config"; };
+    customConfig = { url = "path:custom-config"; };
   };
 
   outputs = { self, iohkNix, cardano-world, haskellNix, nixpkgs, utils, customConfig, ... }:


### PR DESCRIPTION
Having a flake input of type `path` starting with `./` was causing errors like this:

```
error: cannot fetch input 'path:./custom-config?lastModified=1&narHash=sha256-Zd5w1I1Dwt783Q4WuBuCpedcwG1DrIgQGqabyF87prM=' because it uses a relative path
```

I was simply trying to build the docker image using this repo as a flake (so without `nix-build` as indicated in the docs) with `nix build .#dockerImage` when I got this error.

Can't tell if this appeared only with more recent Nix versions (I'm on `2.12.0`), by the way this seems to fix it.