### PR TITLE
Fix index-state syntax

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,8 +9,11 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
+-- repeating the index-state for hackage to work around hackage.nix parsing limitation
 index-state: 2022-11-11T00:00:00Z
-index-state: cardano-haskell-packages 2022-11-12T20:00:00Z
+index-state:
+  , hackage.haskell.org 2022-11-11T00:00:00Z
+  , cardano-haskell-packages 2022-11-12T20:00:00Z
 
 packages:
   cardano-db


### PR DESCRIPTION
The second index-state stanza completely ovverides the first, resetting hackage index state to HEAD. See haskell/cabal#8568

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
