### PR TITLE
WAIT_FOR_NODE_SYNC Docker env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
         packages = project.exes // scripts // {
           # Built by `nix build .`
           default = project.exes.cardano-db-sync;
-          inherit (pkgs) dockerImage cardano-node cardano-smash-server-no-basic-auth;
+          inherit (pkgs) dockerImage cardano-node cardano-cli cardano-smash-server-no-basic-auth;
         } # Add checks to be able to build them individually:
         // (prefixNamesWith "checks/" checks);
 
@@ -168,7 +168,7 @@
             inherit ((import flake-compat {
           pkgs = final;
           inherit (final.cardanoDbSyncProject.hsPkgs.cardano-node) src;
-        }).defaultNix.packages.${final.system}) cardano-node;
+        }).defaultNix.packages.${final.system}) cardano-node cardano-cli;
             inherit (final.cardanoDbSyncProject.exes) cardano-db-sync cardano-smash-server cardano-db-tool;
           };
         nixosModules = {

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -39,14 +39,14 @@
 { cardanoLib, dockerTools
 
 # The main contents of the image.
-, cardano-db-sync, scripts
+, cardano-cli, cardano-db-sync, scripts
 
 # Get the current commit
 , gitrev
 
 # Other things to include in the image.
-, bashInteractive, cacert, coreutils, curl, findutils, glibcLocales, gnutar
-, gzip, iana-etc, iproute, iputils, socat, utillinux, writeScript
+, bashInteractive, cacert, coreutils, curl, findutils, getconf, glibcLocales
+, gnutar, gzip, jq, iana-etc, iproute, iputils, socat, utillinux, writeScript
 , writeScriptBin, runCommand, runtimeShell, lib, libidn, libpqxx, postgresql
 
 , dbSyncRepoName ? "inputoutput/cardano-db-sync" }:
@@ -69,9 +69,11 @@ let
       curl # CLI tool for transferring files via URLs
       env-shim # Make /usr/bin/env available
       findutils # GNU find
+      getconf # get num cpus
       gnutar # GNU tar
       glibcLocales # Locale information for the GNU C Library
       gzip # Gnuzip
+      jq # JSON processor
       iana-etc # IANA protocol and port number assignments
       iproute # Utilities for controlling TCP/IP networking
       iputils # Useful utilities for Linux networking
@@ -80,6 +82,7 @@ let
       postgresql # A powerful, open source object-relational database system
       socat # Utility for bidirectional data transfer
       utillinux # System utilities for Linux
+      cardano-cli
     ];
     runAsRoot = ''
       #!${runtimeShell}


### PR DESCRIPTION
Added `WAIT_FOR_NODE_SYNC` env var to sleep until syncProgress is >= 99%

This minimizes the risk of `db-sync` being "taller" than `node` which leads to (an expensive) SQL DROP operation and reprocessing