### PR TITLE
Use major.minor (schema version) to identify snapshot compatibility

### DIFF
--- a/cardano-db-tool/src/Cardano/DbTool/PrepareSnapshot.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/PrepareSnapshot.hs
@@ -12,7 +12,7 @@ import           Cardano.DbSync.Config.Types hiding (LogFileDir)
 import           Cardano.DbSync.LedgerState
 
 import qualified Data.ByteString.Base16 as Base16
-import           Data.Version (versionBranch)
+import           Data.Version (makeVersion, showVersion, versionBranch)
 
 import           Ouroboros.Network.Block hiding (blockHash)
 
@@ -65,14 +65,12 @@ runPrepareSnapshot args = do
 
     printCreateSnapshot :: Word64 -> FilePath -> IO ()
     printCreateSnapshot bblockNo fp = do
-      let mMajor = listToMaybe $ versionBranch version
-          majorStr = case mMajor of
-                        Nothing -> ""
-                        Just majorV -> "schema-" ++ show majorV
+      let schemaVersion = makeVersion $ take 2 $ versionBranch version
       putStrLn $ concat
         [ "Create a snapshot with:\n"
-        , "    scripts/postgresql-setup.sh --create-snapshot db-sync-snapshot-"
-        , majorStr
+        , "    scripts/postgresql-setup.sh --create-snapshot db-sync-snapshot"
+        , "-schema-"
+        , showVersion schemaVersion
         , "-block-"
         , show bblockNo
         , "-x86_64 "

--- a/nix/nixos/cardano-db-sync-service.nix
+++ b/nix/nixos/cardano-db-sync-service.nix
@@ -7,7 +7,7 @@ let
   configFile = __toFile "db-sync-config.json"
     (__toJSON (cfg.explorerConfig // cfg.logConfig));
   stateDirBase = "/var/lib/";
-  majorVersion = lib.versions.major cfg.package.version;
+  schemaVersion = lib.versions.majorMinor cfg.package.version;
 in {
   options = {
     services.cardano-db-sync = {
@@ -233,7 +233,7 @@ in {
         # Only take snapshot after service exited cleanly.
         if [ "$SERVICE_RESULT" = "success" ]; then
           EXISTING_SNAPSHOTS=()
-          for f in db-sync-snapshot-schema-${majorVersion}*.tgz; do
+          for f in db-sync-snapshot-schema-${schemaVersion}*.tgz; do
             if [ -f $f ]; then
               echo "A snapshot already exist for this version: $f"
               EXISTING_SNAPSHOTS+=( $f )


### PR DESCRIPTION
 just major is not enough anymore since 13.1.

backport of https://github.com/input-output-hk/cardano-db-sync/pull/1354