### PR TITLE
Get AdaPots from leger events

### DIFF
--- a/cardano-db-sync/CHANGELOG.md
+++ b/cardano-db-sync/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for cardano-db-sync
 
+## Next
+* table `ada_pots`is populated from ledger events with slightly different values instead of the ledger.
+This is a c level breaking change without a migration.
+
 ## 13.1.0.0
 * Avoids rollbacks on restarts, making them way faster [#1190]
 * Syncing speed is increased

--- a/cardano-db-sync/src/Cardano/DbSync/Default.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Default.hs
@@ -240,6 +240,8 @@ insertLedgerEvents env currentEpochNo@(EpochNo curEpoch) =
           lift $ adjustEpochRewards tracer ntw cache e rwd creds
         LedgerTotalRewards _e rwd -> do
           lift $ validateEpochRewards tracer ntw (subFromCurrentEpoch 2) currentEpochNo rwd
+        LedgerAdaPots _ ->
+          pure () -- These are handled separately by insertBlock
         LedgerMirDist rwd -> do
           unless (Map.null rwd) $ do
             let rewards = Map.toList rwd

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Offline/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Offline/Types.hs
@@ -62,7 +62,7 @@ instance FromJSON PoolOfflineMetadata where
         <*> parseTicker o
         <*> fmap PoolHomepage (o .: "homepage")
 
--- |We presume the validation is not required the other way around?
+-- | We presume the validation is not required the other way around?
 instance ToJSON PoolOfflineMetadata where
   toJSON (PoolOfflineMetadata name' description' ticker' homepage') =
     object

--- a/cardano-db-sync/src/Cardano/DbSync/LedgerEvent.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/LedgerEvent.hs
@@ -23,8 +23,8 @@ import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import qualified Cardano.Ledger.Core as Ledger
 import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Era (Crypto)
-import Cardano.Ledger.Shelley.AdaPots
 import Cardano.Ledger.Shelley.API (InstantaneousRewards (..))
+import Cardano.Ledger.Shelley.AdaPots
 import qualified Cardano.Ledger.Shelley.Rewards as Ledger
 import Cardano.Ledger.Shelley.Rules.Epoch (ShelleyEpochEvent (PoolReapEvent))
 import Cardano.Ledger.Shelley.Rules.Mir (ShelleyMirEvent (..))

--- a/cardano-db-sync/src/Cardano/DbSync/LedgerState.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/LedgerState.hs
@@ -34,8 +34,6 @@ import Cardano.BM.Trace (Trace, logInfo, logWarning)
 import Cardano.Binary (Decoder, DecoderError, Encoding, FromCBOR (..), ToCBOR (..))
 import qualified Cardano.Binary as Serialize
 
--- import           Cardano.Ledger.Shelley.Constraints (UsesValue)
-
 import Cardano.DbSync.Config.Types
 import qualified Cardano.DbSync.Era.Cardano.Util as Cardano
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
@@ -47,9 +45,8 @@ import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import Cardano.Ledger.Alonzo.Scripts
 import qualified Cardano.Ledger.Babbage.PParams as Babbage
 import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Crypto)
-import qualified Cardano.Ledger.Shelley.API.Wallet as Shelley
+import Cardano.Ledger.Shelley.AdaPots (AdaPots)
 import Cardano.Ledger.Shelley.LedgerState (EpochState (..))
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Prelude hiding (atomically)
@@ -310,14 +307,14 @@ applyBlock env blk = do
     !ledgerDB <- readStateUnsafe env
     let oldState = ledgerDbCurrent ledgerDB
     let !result = applyBlk (ExtLedgerCfg (topLevelConfig env)) blk (clsState oldState)
+    let !ledgerEvents = mapMaybe convertAuxLedgerEvent (lrEvents result)
     let !newLedgerState = lrResult result
     !details <- getSlotDetails env (ledgerState newLedgerState) time (cardanoBlockSlotNo blk)
-    let !newEpoch = mkNewEpoch (clsState oldState) newLedgerState
+    let !newEpoch = mkNewEpoch (clsState oldState) newLedgerState (findAdaPots ledgerEvents)
     let !newEpochBlockNo = applyToEpochBlockNo (isJust $ blockIsEBB blk) (isJust newEpoch) (clsEpochBlockNo oldState)
     let !newState = CardanoLedgerState newLedgerState newEpochBlockNo
     let !ledgerDB' = pushLedgerDB ledgerDB newState
     writeTVar (leStateVar env) (Strict.Just ledgerDB')
-    let !ledgerEvents = mapMaybe convertAuxLedgerEvent (lrEvents result)
     let !appResult =
           ApplyResult
             { apPrices = getPrices newState
@@ -339,8 +336,8 @@ applyBlock env blk = do
         Left err -> panic err
         Right result -> result
 
-    mkNewEpoch :: ExtLedgerState CardanoBlock -> ExtLedgerState CardanoBlock -> Maybe Generic.NewEpoch
-    mkNewEpoch oldState newState =
+    mkNewEpoch :: ExtLedgerState CardanoBlock -> ExtLedgerState CardanoBlock -> Maybe AdaPots -> Maybe Generic.NewEpoch
+    mkNewEpoch oldState newState mPots =
       if ledgerEpochNo env newState /= ledgerEpochNo env oldState + 1
         then Nothing
         else
@@ -348,7 +345,7 @@ applyBlock env blk = do
             Generic.NewEpoch
               { Generic.neEpoch = ledgerEpochNo env newState
               , Generic.neIsEBB = isJust $ blockIsEBB blk
-              , Generic.neAdaPots = maybeToStrict $ getAdaPots newState
+              , Generic.neAdaPots = maybeToStrict mPots
               , Generic.neEpochUpdate = Generic.epochUpdate newState
               }
 
@@ -793,18 +790,6 @@ getRegisteredPoolShelley lState =
             Shelley.nesEs $
               Consensus.shelleyLedgerState lState
 
--- We only compute 'AdaPots' for later eras. This is a time consuming
--- function and we only want to run it on epoch boundaries.
-getAdaPots :: ExtLedgerState CardanoBlock -> Maybe Shelley.AdaPots
-getAdaPots st =
-  case ledgerState st of
-    LedgerStateByron _ -> Nothing
-    LedgerStateShelley sts -> Just $ totalAdaPots sts
-    LedgerStateAllegra sta -> Just $ totalAdaPots sta
-    LedgerStateMary stm -> Just $ totalAdaPots stm
-    LedgerStateAlonzo sta -> Just $ totalAdaPots sta
-    LedgerStateBabbage stb -> Just $ totalAdaPots stb
-
 ledgerEpochNo :: LedgerEnv -> ExtLedgerState CardanoBlock -> EpochNo
 ledgerEpochNo env cls =
   case ledgerTipSlot (ledgerState cls) of
@@ -840,13 +825,6 @@ tickThenReapplyCheckHash cfg block lsb =
           , renderByteArray (SBS.fromShort . Consensus.getOneEraHash $ blockHash block)
           , "."
           ]
-
-totalAdaPots ::
-  forall p era.
-  Core.EraTxOut era =>
-  LedgerState (ShelleyBlock p era) ->
-  Shelley.AdaPots
-totalAdaPots = Shelley.totalAdaPotsES . Shelley.nesEs . Consensus.shelleyLedgerState
 
 getHeaderHash :: HeaderHash CardanoBlock -> ByteString
 getHeaderHash bh = SBS.fromShort (Consensus.getOneEraHash bh)
@@ -891,3 +869,10 @@ getPrices st = case ledgerState $ clsState st of
           Shelley.nesEs $
             Consensus.shelleyLedgerState bls
   _ -> Strict.Nothing
+
+findAdaPots :: [LedgerEvent] -> Maybe AdaPots
+findAdaPots = go
+  where
+    go [] = Nothing
+    go (LedgerAdaPots p: _) = Just p
+    go (_ : rest) = go rest

--- a/cardano-db-sync/src/Cardano/DbSync/LedgerState.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/LedgerState.hs
@@ -874,5 +874,5 @@ findAdaPots :: [LedgerEvent] -> Maybe AdaPots
 findAdaPots = go
   where
     go [] = Nothing
-    go (LedgerAdaPots p: _) = Just p
+    go (LedgerAdaPots p : _) = Just p
     go (_ : rest) = go rest

--- a/cardano-smash-server/src/Cardano/SMASH/Server/Api.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/Api.hs
@@ -73,7 +73,7 @@ newtype BodyError = BodyError String
 instance ToJSON BodyError where
   toJSON (BodyError b) = object ["error" .= b]
 
--- |For api versioning.
+-- | For api versioning.
 type APIVersion = "v1"
 
 -- | Shortcut for common api result types.

--- a/cardano-smash-server/src/Cardano/SMASH/Server/FetchPolicies.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/FetchPolicies.hs
@@ -20,14 +20,14 @@ import Network.HTTP.Simple (
   parseRequestThrow,
  )
 
--- |The possible errors for the http client.
+-- | The possible errors for the http client.
 data HttpClientError
   = HttpClientCannotParseEndpoint !Text
   | HttpClientInvalidClientBody
   | HttpClientCannotParseJSON !Text
   | HttpClientStatusNotOk
 
--- |Render the http client error.
+-- | Render the http client error.
 renderHttpClientError :: HttpClientError -> Text
 renderHttpClientError = \case
   HttpClientCannotParseEndpoint endpoint ->
@@ -47,7 +47,7 @@ renderHttpClientError = \case
   HttpClientStatusNotOk ->
     "Http client returned status not ok. Status should be 200."
 
--- |Fetch the remote SMASH server policies.
+-- | Fetch the remote SMASH server policies.
 httpClientFetchPolicies :: SmashURL -> IO (Either HttpClientError PolicyResult)
 httpClientFetchPolicies smashURL = runExceptT $ do
   -- https://smash.cardano-mainnet.iohk.io
@@ -82,7 +82,7 @@ httpClientFetchPolicies smashURL = runExceptT $ do
 
   pure policyResult
 
--- |A simple HTTP call for remote server.
+-- | A simple HTTP call for remote server.
 httpApiCall :: forall a. (FromJSON a) => Request -> ExceptT HttpClientError IO a
 httpApiCall request = do
   httpResult <- httpJSONEither request
@@ -99,7 +99,7 @@ httpApiCall request = do
     Left reason -> left $ HttpClientCannotParseJSON (toS reason)
     Right value -> right value
 
--- |When any exception occurs, we simply map it to an http client error.
+-- | When any exception occurs, we simply map it to an http client error.
 parseRequestEither :: Text -> ExceptT HttpClientError IO Request
 parseRequestEither requestEndpoint = do
   let parsedRequest = newExceptT (try $ parseRequestThrow (toS requestEndpoint) :: IO (Either SomeException Request))

--- a/cardano-smash-server/src/Cardano/SMASH/Server/Impl.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/Impl.hs
@@ -117,7 +117,7 @@ getPoolOfflineMetadata (ServerEnv trce dataLayer) poolId poolMetaHash =
             logWarning trce msg
             throwIO err404 -- ticker is reserved by another pool.
 
--- |Simple health status, there are ideas for improvement.
+-- | Simple health status, there are ideas for improvement.
 getHealthStatus :: Handler (ApiResult DBFail HealthStatus)
 getHealthStatus =
   pure . ApiResult . Right $
@@ -126,14 +126,14 @@ getHealthStatus =
       , hsVersion = toS $ showVersion version
       }
 
--- |Get all reserved tickers.
+-- | Get all reserved tickers.
 getReservedTickers :: ServerEnv -> Handler (ApiResult DBFail [UniqueTicker])
 getReservedTickers (ServerEnv _trce dataLayer) =
   convertIOToHandler $ do
     reservedTickers <- dlGetReservedTickers dataLayer
     pure . ApiResult . Right . map UniqueTicker $ reservedTickers
 
--- |Get all delisted pools
+-- | Get all delisted pools
 getDelistedPools :: ServerEnv -> Handler (ApiResult DBFail [PoolId])
 getDelistedPools (ServerEnv _trce dataLayer) =
   convertIOToHandler $ do
@@ -148,7 +148,7 @@ delistPool :: ServerEnv -> User -> PoolId -> Handler (ApiResult DBFail PoolId)
 delistPool env _user = delistPool' env
 #endif
 
--- |General delist pool.
+-- | General delist pool.
 delistPool' :: ServerEnv -> PoolId -> Handler (ApiResult DBFail PoolId)
 delistPool' (ServerEnv trce dataLayer) poolId =
   convertIOToHandler $ do
@@ -165,7 +165,7 @@ enlistPool :: ServerEnv -> User -> PoolId -> Handler (ApiResult DBFail PoolId)
 enlistPool env _user = enlistPool' env
 #endif
 
--- |General enlist pool function.
+-- | General enlist pool function.
 enlistPool' :: ServerEnv -> PoolId -> Handler (ApiResult DBFail PoolId)
 enlistPool' (ServerEnv trce dataLayer) poolId =
   convertIOToHandler $ do


### PR DESCRIPTION
# Description
Instead of using the ledger. This changes semantically the values of the DB, so it's a c level breaking change. A migration is impossible to cover these changes. Fixes #1258.


# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [x] Self-reviewed the diff

# Migrations

- [x] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

Resyncing and running the migrations provided will **NOT** result in the same database semantically
A migration requires replaying the whole ledger rules so we will skip it as unnnecesary.
