### PR TITLE
Introduce tx_out.consumed_by_tx_in_id

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
@@ -197,6 +197,7 @@ insertTxOuts blkId (address, value) = do
       , DB.txOutDataHash = Nothing
       , DB.txOutInlineDatumId = Nothing
       , DB.txOutReferenceScriptId = Nothing
+      , DB.txOutConsumedByTxInId = Nothing
       }
 
 -- -----------------------------------------------------------------------------

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
@@ -248,6 +248,7 @@ insertTxOut _tracer txId index txout =
       , DB.txOutDataHash = Nothing
       , DB.txOutInlineDatumId = Nothing
       , DB.txOutReferenceScriptId = Nothing
+      , DB.txOutConsumedByTxInId = Nothing
       }
 
 insertTxIn ::

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
@@ -247,6 +247,7 @@ insertTxOuts trce blkId (ShelleyTx.TxIn txInId _, txOut) = do
       , DB.txOutDataHash = Nothing -- No output datum in Shelley Genesis
       , DB.txOutInlineDatumId = Nothing
       , DB.txOutReferenceScriptId = Nothing
+      , DB.txOutConsumedByTxInId = Nothing
       }
   where
     addr = txOut ^. Core.addrTxOutL

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -326,6 +326,7 @@ prepareTxOut tracer cache iopts (txId, txHash) (Generic.TxOut index addr addrRaw
           , DB.txOutDataHash = Generic.dataHashToBytes <$> Generic.getTxOutDatumHash dt
           , DB.txOutInlineDatumId = mDatumId
           , DB.txOutReferenceScriptId = mScriptId
+          , DB.txOutConsumedByTxInId = Nothing
           }
   let !eutxo = ExtendedTxOut txHash txOut
   !maTxOuts <- whenFalseMempty (ioMultiAssets iopts) $ prepareMaTxOuts tracer cache maMap

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -226,7 +226,7 @@ insertTx tracer cache iopts network isMember blkId epochNo slotNo blockIndex tx 
   let !outSum = fromIntegral $ unCoin $ Generic.txOutSum tx
       !withdrawalSum = fromIntegral $ unCoin $ Generic.txWithdrawalSum tx
   !resolvedInputs <- mapM (resolveTxInputs (fst <$> groupedTxOut grouped)) (Generic.txInputs tx)
-  let !inSum = sum $ map (unDbLovelace . thrd3) resolvedInputs
+  let !inSum = sum $ map (unDbLovelace . forth4) resolvedInputs
   let diffSum = if inSum >= outSum then inSum - outSum else 0
   let !fees = maybe diffSum (fromIntegral . unCoin) (Generic.txFees tx)
   let !txHash = Generic.txHash tx
@@ -379,15 +379,20 @@ insertCollateralTxOut tracer cache iopts (txId, _txHash) (Generic.TxOut index ad
 prepareTxIn ::
   DB.TxId ->
   Map Word64 DB.RedeemerId ->
-  (Generic.TxIn, DB.TxId, DbLovelace) ->
-  DB.TxIn
-prepareTxIn txInId redeemers (txIn, txOutId, _lovelace) =
-  DB.TxIn
-    { DB.txInTxInId = txInId
-    , DB.txInTxOutId = txOutId
-    , DB.txInTxOutIndex = fromIntegral $ Generic.txInIndex txIn
-    , DB.txInRedeemerId = mlookup (Generic.txInRedeemerIndex txIn) redeemers
+  (Generic.TxIn, DB.TxId, Either Generic.TxIn DB.TxOutId, DbLovelace) ->
+  ExtendedTxIn
+prepareTxIn txInId redeemers (txIn, txOutId, mTxOutId, _lovelace) =
+  ExtendedTxIn
+    { etiTxIn = txInDB
+    , etiTxOutId = mTxOutId
     }
+  where
+  txInDB = DB.TxIn
+           { DB.txInTxInId = txInId
+           , DB.txInTxOutId = txOutId
+           , DB.txInTxOutIndex = fromIntegral $ Generic.txInIndex txIn
+           , DB.txInRedeemerId = mlookup (Generic.txInRedeemerIndex txIn) redeemers
+           }
 
 insertCollateralTxIn ::
   (MonadBaseControl IO m, MonadIO m) =>

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Grouped.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Grouped.hs
@@ -5,6 +5,7 @@
 module Cardano.DbSync.Era.Shelley.Insert.Grouped (
   BlockGroupedData (..),
   MissingMaTxOut (..),
+  ExtendedTxIn (..),
   ExtendedTxOut (..),
   insertBlockGroupedData,
   insertReverseIndex,
@@ -12,7 +13,7 @@ module Cardano.DbSync.Era.Shelley.Insert.Grouped (
   resolveScriptHash,
 ) where
 
-import Cardano.BM.Trace (Trace)
+import Cardano.BM.Trace (Trace, logWarning)
 import Cardano.Db (DbLovelace (..), minIdsToText, textShow)
 import qualified Cardano.Db as DB
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
@@ -23,6 +24,7 @@ import Cardano.Prelude
 import Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Data.List as List
 import Database.Persist.Sql (SqlBackend)
+import qualified Data.Text as Text
 
 -- | Group data within the same block, to insert them together in batches
 --
@@ -36,7 +38,7 @@ import Database.Persist.Sql (SqlBackend)
 -- other table references it in the future it has to be added here and delay its
 -- insertion.
 data BlockGroupedData = BlockGroupedData
-  { groupedTxIn :: ![DB.TxIn]
+  { groupedTxIn :: ![ExtendedTxIn]
   , groupedTxOut :: ![(ExtendedTxOut, [MissingMaTxOut])]
   , groupedTxMetadata :: ![DB.TxMetadata]
   , groupedTxMint :: ![DB.MaTxMint]
@@ -56,6 +58,11 @@ data ExtendedTxOut = ExtendedTxOut
   , etoTxOut :: !DB.TxOut
   }
 
+data ExtendedTxIn = ExtendedTxIn
+  { etiTxIn :: !DB.TxIn
+  , etiTxOutId :: !(Either Generic.TxIn DB.TxOutId)
+  } deriving Show
+
 instance Monoid BlockGroupedData where
   mempty = BlockGroupedData [] [] [] []
 
@@ -72,14 +79,17 @@ insertBlockGroupedData ::
   Trace IO Text ->
   BlockGroupedData ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) DB.MinIds
-insertBlockGroupedData _tracer grouped = do
+insertBlockGroupedData tracer grouped = do
   txOutIds <- lift . DB.insertManyTxOut $ etoTxOut . fst <$> groupedTxOut grouped
   let maTxOuts = concatMap mkmaTxOuts $ zip txOutIds (snd <$> groupedTxOut grouped)
   maTxOutIds <- lift $ DB.insertManyMaTxOut maTxOuts
-  txInId <- lift . DB.insertManyTxIn $ groupedTxIn grouped
+  txInIds <- lift . DB.insertManyTxIn $ etiTxIn <$> groupedTxIn grouped
+  etis <- resolveRemainingInputs (groupedTxIn grouped) $ zip txOutIds (fst <$> groupedTxOut grouped)
+  updateTuples <- lift $ mapM (prepareUpdates tracer) (zip txInIds etis)
+  lift $ DB.updateListTxOutConsumedByTxInId $ catMaybes updateTuples
   void . lift . DB.insertManyTxMetadata $ groupedTxMetadata grouped
   void . lift . DB.insertManyTxMint $ groupedTxMint grouped
-  pure $ DB.MinIds (minimumMaybe txInId) (minimumMaybe txOutIds) (minimumMaybe maTxOutIds)
+  pure $ DB.MinIds (minimumMaybe txInIds) (minimumMaybe txOutIds) (minimumMaybe maTxOutIds)
   where
     mkmaTxOuts :: (DB.TxOutId, [MissingMaTxOut]) -> [DB.MaTxOut]
     mkmaTxOuts (txOutId, mmtos) = mkmaTxOut txOutId <$> mmtos
@@ -91,6 +101,17 @@ insertBlockGroupedData _tracer grouped = do
         , DB.maTxOutQuantity = mmtoQuantity missingMaTx
         , DB.maTxOutTxOutId = txOutId
         }
+
+prepareUpdates ::
+  (MonadBaseControl IO m, MonadIO m) =>
+  Trace IO Text ->
+  (DB.TxInId, ExtendedTxIn) ->
+  m (Maybe (DB.TxOutId, DB.TxInId))
+prepareUpdates trce (txInId, eti) = case etiTxOutId eti of
+  Right txOutId -> pure $ Just (txOutId, txInId)
+  Left _ -> do
+    liftIO $ logWarning trce $ "Failed to find output for " <> Text.pack (show eti)
+    pure Nothing
 
 insertReverseIndex ::
   (MonadBaseControl IO m, MonadIO m) =>
@@ -106,23 +127,41 @@ insertReverseIndex blockId minIds =
 
 -- | If we can't resolve from the db, we fall back to the provided outputs
 -- This happens the input consumes an output introduced in the same block.
+-- In this case we also cannot find yet the 'TxOutId', so we return 'Nothing' for now
 resolveTxInputs ::
   MonadIO m =>
   [ExtendedTxOut] ->
   Generic.TxIn ->
-  ExceptT SyncNodeError (ReaderT SqlBackend m) (Generic.TxIn, DB.TxId, DbLovelace)
+  ExceptT SyncNodeError (ReaderT SqlBackend m) (Generic.TxIn, DB.TxId, Either Generic.TxIn DB.TxOutId, DbLovelace)
 resolveTxInputs groupedOutputs txIn =
-  fmap convert $ liftLookupFail ("resolveTxInputs " <> textShow txIn <> " ") $ do
+  liftLookupFail ("resolveTxInputs " <> textShow txIn <> " ") $ do
     qres <- queryResolveInput txIn
     case qres of
-      Right ret -> pure $ Right ret
+      Right ret -> pure $ Right $ convertFound ret
       Left err ->
         case resolveInMemory txIn groupedOutputs of
           Nothing -> pure $ Left err
-          Just eutxo -> pure $ Right (DB.txOutTxId (etoTxOut eutxo), DB.txOutValue (etoTxOut eutxo))
+          Just eutxo -> pure $ Right $ convertnotFound (DB.txOutTxId (etoTxOut eutxo), DB.txOutValue (etoTxOut eutxo))
   where
-    convert :: (DB.TxId, DbLovelace) -> (Generic.TxIn, DB.TxId, DbLovelace)
-    convert (txId, lovelace) = (txIn, txId, lovelace)
+    convertFound :: (DB.TxId, DB.TxOutId, DbLovelace) -> (Generic.TxIn, DB.TxId, Either Generic.TxIn DB.TxOutId, DbLovelace)
+    convertFound (txId, txOutId, lovelace) = (txIn, txId, Right txOutId, lovelace)
+
+    convertnotFound :: (DB.TxId, DbLovelace) -> (Generic.TxIn, DB.TxId, Either Generic.TxIn DB.TxOutId, DbLovelace)
+    convertnotFound (txId, lovelace) = (txIn, txId, Left txIn, lovelace)
+
+resolveRemainingInputs ::
+  MonadIO m =>
+  [ExtendedTxIn] ->
+  [(DB.TxOutId, ExtendedTxOut)] ->
+  ExceptT SyncNodeError (ReaderT SqlBackend m) [ExtendedTxIn]
+resolveRemainingInputs etis mp =
+  mapM f etis
+  where
+    f eti = case etiTxOutId eti of
+      Right _ -> pure eti
+      Left txIn | Just txOutId <- fst <$> find (matches txIn . snd) mp ->
+        pure eti {etiTxOutId = Right txOutId}
+      _ -> pure eti
 
 resolveScriptHash ::
   (MonadBaseControl IO m, MonadIO m) =>
@@ -141,12 +180,12 @@ resolveScriptHash groupedOutputs txIn =
 
 resolveInMemory :: Generic.TxIn -> [ExtendedTxOut] -> Maybe ExtendedTxOut
 resolveInMemory txIn =
-  List.find matches
-  where
-    matches :: ExtendedTxOut -> Bool
-    matches eutxo =
-      Generic.txInHash txIn == etoTxHash eutxo
-        && Generic.txInIndex txIn == DB.txOutIndex (etoTxOut eutxo)
+  List.find (matches txIn)
+
+matches :: Generic.TxIn -> ExtendedTxOut -> Bool
+matches txIn eutxo =
+  Generic.txInHash txIn == etoTxHash eutxo
+    && Generic.txInIndex txIn == DB.txOutIndex (etoTxOut eutxo)
 
 minimumMaybe :: (Ord a, Foldable f) => f a -> Maybe a
 minimumMaybe xs

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Query.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Query.hs
@@ -61,7 +61,7 @@ queryStakeAddress addr = do
     pure (saddr ^. StakeAddressId)
   pure $ maybeToEither (DbLookupMessage $ "StakeAddress " <> renderByteArray addr) unValue (listToMaybe res)
 
-queryResolveInput :: MonadIO m => Generic.TxIn -> ReaderT SqlBackend m (Either LookupFail (TxId, DbLovelace))
+queryResolveInput :: MonadIO m => Generic.TxIn -> ReaderT SqlBackend m (Either LookupFail (TxId, TxOutId, DbLovelace))
 queryResolveInput txIn =
   queryTxOutValue (Generic.txInHash txIn, fromIntegral (Generic.txInIndex txIn))
 

--- a/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
@@ -44,7 +44,8 @@ rollbackFromBlockNo syncEnv blkNo = do
         , textShow blkNo
         ]
     lift $ do
-      DB.deleteBlocksBlockId trce blockId
+      (minIds, txInDeleted) <- DB.deleteBlocksBlockId trce blockId
+      DB.setNullTxOut trce minIds txInDeleted
       DB.deleteEpochRows epochNo
     liftIO . logInfo trce $ "Blocks deleted"
   where

--- a/cardano-db-sync/src/Cardano/DbSync/Util.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Util.hs
@@ -26,6 +26,7 @@ module Cardano.DbSync.Util (
   textPrettyShow,
   textShow,
   thrd3,
+  forth4,
   traverseMEither,
   whenStrictJust,
   whenMaybe,
@@ -208,8 +209,11 @@ whenMaybe :: Monad m => Maybe a -> (a -> m b) -> m (Maybe b)
 whenMaybe (Just a) f = Just <$> f a
 whenMaybe Nothing _f = pure Nothing
 
-thrd3 :: (a, b, c) -> c
-thrd3 (_, _, c) = c
+thrd3 :: (a, b, c, d) -> c
+thrd3 (_, _, c, _) = c
+
+forth4 :: (a, b, c, d) -> d
+forth4 (_, _, _, d) = d
 
 mlookup :: Ord k => Maybe k -> Map k a -> Maybe a
 mlookup mKey mp = (`Map.lookup` mp) =<< mKey

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -40,6 +40,7 @@ library
                         Cardano.Db.PGConfig
                         Cardano.Db.Migration
                         Cardano.Db.Migration.Haskell
+                        Cardano.Db.Migration.TxOut
                         Cardano.Db.Migration.Version
                         Cardano.Db.MinId
                         Cardano.Db.Old.V13_0.Schema

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -52,6 +52,7 @@ library
                         Cardano.Db.Schema.Orphans
                         Cardano.Db.Text
                         Cardano.Db.Types
+                        Cardano.Db.Update
                         Cardano.Db.Version
 
   build-depends:        aeson

--- a/cardano-db/src/Cardano/Db.hs
+++ b/cardano-db/src/Cardano/Db.hs
@@ -22,4 +22,5 @@ import Cardano.Db.Schema as X
 import Cardano.Db.Schema.Types as X
 import Cardano.Db.Text as X
 import Cardano.Db.Types as X
+import Cardano.Db.Update as X
 import Cardano.Db.Version (gitRev)

--- a/cardano-db/src/Cardano/Db.hs
+++ b/cardano-db/src/Cardano/Db.hs
@@ -13,6 +13,7 @@ import Cardano.Db.Delete as X
 import Cardano.Db.Error as X
 import Cardano.Db.Insert as X
 import Cardano.Db.Migration as X
+import Cardano.Db.Migration.TxOut as X
 import Cardano.Db.Migration.Version as X
 import Cardano.Db.MinId as X
 import Cardano.Db.PGConfig as X

--- a/cardano-db/src/Cardano/Db/Delete.hs
+++ b/cardano-db/src/Cardano/Db/Delete.hs
@@ -22,6 +22,7 @@ import Cardano.Db.MinId
 import Cardano.Db.Query hiding (isJust)
 import Cardano.Db.Schema
 import Cardano.Slotting.Slot (SlotNo (..))
+import Control.Monad (void)
 import Control.Monad.Extra (whenJust)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Reader (ReaderT)
@@ -31,7 +32,8 @@ import Data.Text (Text)
 import Data.Word (Word64)
 import Database.Esqueleto.Experimental (PersistEntity, PersistField, persistIdField)
 import Database.Persist.Class.PersistQuery (deleteWhere)
-import Database.Persist.Sql (PersistEntityBackend, SqlBackend, delete, selectKeysList, (==.), (>=.))
+import Database.Persist.Sql (PersistEntityBackend, SqlBackend, delete, deleteWhereCount,
+         selectKeysList, (==.), (>=.))
 
 deleteBlocksSlotNoNoTrace :: MonadIO m => SlotNo -> ReaderT SqlBackend m Bool
 deleteBlocksSlotNoNoTrace = deleteBlocksSlotNo nullTracer
@@ -44,20 +46,21 @@ deleteBlocksSlotNo trce (SlotNo slotNo) = do
   case mBlockId of
     Nothing -> pure False
     Just blockId -> do
-      deleteBlocksBlockId trce blockId
+      void $ deleteBlocksBlockId trce blockId
       pure True
 
 deleteBlocksBlockIdNotrace :: MonadIO m => BlockId -> ReaderT SqlBackend m ()
-deleteBlocksBlockIdNotrace = deleteBlocksBlockId nullTracer
+deleteBlocksBlockIdNotrace = void . deleteBlocksBlockId nullTracer
 
 -- | Delete starting from a 'BlockId'.
-deleteBlocksBlockId :: MonadIO m => Trace IO Text -> BlockId -> ReaderT SqlBackend m ()
+deleteBlocksBlockId :: MonadIO m => Trace IO Text -> BlockId -> ReaderT SqlBackend m (MinIds, Word64)
 deleteBlocksBlockId trce blockId = do
   mMinIds <- fmap (textToMinId =<<) <$> queryReverseIndexBlockId blockId
   (cminIds, completed) <- findMinIdsRec mMinIds mempty
   mTxId <- queryMinRefId TxBlockId blockId
   minIds <- if completed then pure cminIds else completeMinId mTxId cminIds
-  deleteTablesAfterBlockId blockId mTxId minIds
+  txInDeleted <- deleteTablesAfterBlockId blockId mTxId minIds
+  pure (minIds, txInDeleted)
   where
     findMinIdsRec :: MonadIO m => [Maybe MinIds] -> MinIds -> ReaderT SqlBackend m (MinIds, Bool)
     findMinIdsRec [] minIds = pure (minIds, True)
@@ -89,17 +92,18 @@ completeMinId mTxId minIds = do
         Just txOutId -> whenNothingQueryMinRefId (minMaTxOutId minIds) MaTxOutTxOutId txOutId
       pure $ MinIds mTxInId mTxOutId mMaTxOutId
 
-deleteTablesAfterBlockId :: MonadIO m => BlockId -> Maybe TxId -> MinIds -> ReaderT SqlBackend m ()
+deleteTablesAfterBlockId :: MonadIO m => BlockId -> Maybe TxId -> MinIds -> ReaderT SqlBackend m Word64
 deleteTablesAfterBlockId blkId mtxId minIds = do
   deleteWhere [AdaPotsBlockId >=. blkId]
   deleteWhere [ReverseIndexBlockId >=. blkId]
   deleteWhere [EpochParamBlockId >=. blkId]
-  deleteTablesAfterTxId mtxId (minTxInId minIds) (minTxOutId minIds) (minMaTxOutId minIds)
+  txInDeleted <- deleteTablesAfterTxId mtxId (minTxInId minIds) (minTxOutId minIds) (minMaTxOutId minIds)
   deleteWhere [BlockId >=. blkId]
+  pure txInDeleted
 
-deleteTablesAfterTxId :: MonadIO m => Maybe TxId -> Maybe TxInId -> Maybe TxOutId -> Maybe MaTxOutId -> ReaderT SqlBackend m ()
+deleteTablesAfterTxId :: MonadIO m => Maybe TxId -> Maybe TxInId -> Maybe TxOutId -> Maybe MaTxOutId -> ReaderT SqlBackend m Word64
 deleteTablesAfterTxId mtxId mtxInId mtxOutId mmaTxOutId = do
-  whenJust mtxInId $ \txInId -> deleteWhere [TxInId >=. txInId]
+  txInDeleted <- fromIntegral <$> maybe (pure 0) (\txInId -> deleteWhereCount [TxInId >=. txInId]) mtxInId
   whenJust mmaTxOutId $ \maTxOutId -> deleteWhere [MaTxOutId >=. maTxOutId]
   whenJust mtxOutId $ \txOutId -> deleteWhere [TxOutId >=. txOutId]
 
@@ -134,6 +138,7 @@ deleteTablesAfterTxId mtxId mtxInId mtxOutId mmaTxOutId = do
       queryFirstAndDeleteAfter PoolRelayUpdateId puid
       deleteWhere [PoolUpdateId >=. puid]
     deleteWhere [TxId >=. txId]
+  pure txInDeleted
 
 queryFirstAndDeleteAfter ::
   forall m record field.
@@ -174,7 +179,7 @@ deleteBlock block = do
   case mBlockId of
     Nothing -> pure False
     Just blockId -> do
-      deleteBlocksBlockId nullTracer blockId
+      void $ deleteBlocksBlockId nullTracer blockId
       pure True
 
 deleteEpochRows :: MonadIO m => Word64 -> ReaderT SqlBackend m ()

--- a/cardano-db/src/Cardano/Db/Migration.hs
+++ b/cardano-db/src/Cardano/Db/Migration.hs
@@ -137,22 +137,25 @@ runMigrations pgconfig quiet migrationDir mLogfiledir mToRun = do
         mVersion <- runWithConnectionNoLogging (PGPassCached pgconfig) querySchemaVersion
         case mVersion of
           Just (SchemaVersion _ v _) | v == hardCoded3_0 -> do
-            pure (filter (not . filterFix) scripts, False)
+            pure (filter (not . filterFix3_0) scripts, False)
           _ -> pure (scripts, True)
       Initial -> do
         mVersion <- runWithConnectionNoLogging (PGPassCached pgconfig) querySchemaVersion
         case mVersion of
           Just (SchemaVersion _ v _) | v == hardCoded3_0 -> do
-            pure (filter (\m -> not $ filterFix m || filterIndexes m) scripts, False)
+            pure (filter (\m -> not $ filterFix3_0 m || filterIndexes m) scripts, False)
           _ -> pure (filter (not . filterIndexes) scripts, True)
-      Fix -> pure (filter filterFix scripts, False)
+      Fix -> pure (filter filterFix3_0 scripts, False)
       Indexes -> pure (filter filterIndexes scripts, False)
 
-    filterFix (mv, _) = mvStage mv == 2 && mvVersion mv > hardCoded3_0
+    filterFix3_0 (mv, _) = mvStage mv == 2 && mvVersion mv > hardCoded3_0
     filterIndexes (mv, _) = mvStage mv == 4
 
 hardCoded3_0 :: Int
 hardCoded3_0 = 19
+
+_hardCoded3_1 :: Int
+_hardCoded3_1 = 25
 
 -- Build hash for each file found in a directory.
 validateMigrations :: MigrationDir -> [(Text, Text)] -> IO (Maybe (MigrationValidateError, Bool))

--- a/cardano-db/src/Cardano/Db/Migration/TxOut.hs
+++ b/cardano-db/src/Cardano/Db/Migration/TxOut.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Db.Migration.TxOut (
+  migrateTxOut,
+  isMigrated
+
+) where
+
+import Cardano.BM.Trace (Trace, logError, logInfo, logWarning)
+import Cardano.Db.Query
+import Cardano.Db.Schema
+import Cardano.Db.Text
+import Cardano.Db.Update
+import Control.Monad.Extra
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Trans.Reader (ReaderT)
+import Data.Text (Text)
+import Data.Word (Word64)
+import Database.Persist.Sql (SqlBackend, rawExecuteCount)
+
+migrateTxOut :: MonadIO m => ReaderT SqlBackend m ()
+migrateTxOut = migrateNextPage 0
+  where
+  migrateNextPage :: MonadIO m => Word64 -> ReaderT SqlBackend m ()
+  migrateNextPage offset = do
+    liftIO $ print offset
+    page <- getInputPage offset pageSize
+    mapM_ migratePair page
+    when (fromIntegral (length page) == pageSize) $
+      migrateNextPage $! offset + pageSize
+
+migratePair :: MonadIO m => (TxInId, TxId, Word64) -> ReaderT SqlBackend m ()
+migratePair (txInId, txId, index) =
+    updateTxOutConsumedByTxInIdUnique txId index txInId
+
+pageSize :: Word64
+pageSize = 100_000
+
+isMigrated :: MonadIO m => ReaderT SqlBackend m Bool
+isMigrated = do
+  columntExists <- rawExecuteCount
+            ( mconcat
+                [ "SELECT column_name FROM information_schema.columns"
+                , "WHERE table_name='tx_out' and column_name='consumed_by_tx_in_id'"
+                ]
+            )
+            []
+  pure (columntExists >= 1)
+
+-- runMigration :: MonadIO m => ReaderT SqlBackend m ()
+-- runMigration = do
+--   
+
+_validateMigration :: MonadIO m => Trace IO Text -> ReaderT SqlBackend m Bool
+_validateMigration trce = do
+  _migrated <- isMigrated
+--  unless migrated $ runMigration
+  txInCount <- countTxIn
+  consumedTxOut <- countConsumed
+  if txInCount > consumedTxOut
+  then do
+    liftIO $ logWarning trce $ mconcat
+      ["Found incomplete TxOut migration. There are"
+      , textShow txInCount, " TxIn, but only"
+      , textShow consumedTxOut, " consumed TxOut"
+      ]
+    pure False
+  else if txInCount == consumedTxOut
+  then do
+    liftIO $ logInfo trce "Found complete TxOut migration"
+    pure True
+  else do
+    liftIO $ logError trce $ mconcat
+      [ "The impossible happened! There are"
+      , textShow txInCount, " TxIn, but "
+      , textShow consumedTxOut, " consumed TxOut"
+      ]
+    pure False

--- a/cardano-db/src/Cardano/Db/Old/V13_1.hs
+++ b/cardano-db/src/Cardano/Db/Old/V13_1.hs
@@ -1,0 +1,6 @@
+module Cardano.Db.Old.V13_1 (
+  module X,
+) where
+
+import Cardano.Db.Old.V13_1.Query as X
+import Cardano.Db.Old.V13_1.Schema as X

--- a/cardano-db/src/Cardano/Db/Old/V13_1/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Old/V13_1/Schema.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Db.Old.V13_0.Schema where
+
+import Cardano.Db.Schema.Orphans ()
+import Cardano.Db.Types (DbLovelace, DbWord64)
+import Data.ByteString.Char8 (ByteString)
+import Data.Int (Int64)
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+import Data.Word (Word16, Word64)
+import Database.Persist.Documentation (deriveShowFields)
+import Database.Persist.TH
+
+share
+  [ mkPersist sqlSettings
+  , mkEntityDefList "entityDefs"
+  , deriveShowFields
+  ]
+  [persistLowerCase|
+
+
+  TxOut
+    txId                TxId                noreference
+    index               Word64              sqltype=txindex
+    address             Text
+    addressRaw          ByteString
+    addressHasScript    Bool
+    paymentCred         ByteString Maybe    sqltype=hash28type
+    stakeAddressId      StakeAddressId Maybe noreference
+    value               DbLovelace          sqltype=lovelace
+    dataHash            ByteString Maybe    sqltype=hash32type
+    inlineDatumId       DatumId Maybe       noreference
+    referenceScriptId   ScriptId Maybe      noreference
+    UniqueTxout         txId index          -- The (tx_id, index) pair must be unique.
+
+
+  |]

--- a/cardano-db/src/Cardano/Db/Query.hs
+++ b/cardano-db/src/Cardano/Db/Query.hs
@@ -569,7 +569,7 @@ queryTxId hash = do
   pure $ maybeToEither (DbLookupTxHash hash) entityKey (listToMaybe res)
 
 -- | Give a (tx hash, index) pair, return the TxOut value.
-queryTxOutValue :: MonadIO m => (ByteString, Word64) -> ReaderT SqlBackend m (Either LookupFail (TxId, DbLovelace))
+queryTxOutValue :: MonadIO m => (ByteString, Word64) -> ReaderT SqlBackend m (Either LookupFail (TxId, TxOutId, DbLovelace))
 queryTxOutValue (hash, index) = do
   res <- select $ do
     (tx :& txOut) <-
@@ -578,8 +578,8 @@ queryTxOutValue (hash, index) = do
           `innerJoin` table @TxOut
         `on` (\(tx :& txOut) -> tx ^. TxId ==. txOut ^. TxOutTxId)
     where_ (txOut ^. TxOutIndex ==. val index &&. tx ^. TxHash ==. val hash)
-    pure (txOut ^. TxOutTxId, txOut ^. TxOutValue)
-  pure $ maybeToEither (DbLookupTxHash hash) unValue2 (listToMaybe res)
+    pure (txOut ^. TxOutTxId, txOut ^. TxOutId, txOut ^. TxOutValue)
+  pure $ maybeToEither (DbLookupTxHash hash) unValue3 (listToMaybe res)
 
 -- | Give a (tx hash, index) pair, return the TxOut Credentials.
 queryTxOutCredentials :: MonadIO m => (ByteString, Word64) -> ReaderT SqlBackend m (Either LookupFail (Maybe ByteString, Bool))

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -147,6 +147,7 @@ share
     dataHash            ByteString Maybe    sqltype=hash32type
     inlineDatumId       DatumId Maybe       noreference
     referenceScriptId   ScriptId Maybe      noreference
+    consumedByTxInId    TxInId Maybe        noreference
     UniqueTxout         txId index          -- The (tx_id, index) pair must be unique.
 
   CollateralTxOut

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -71,6 +71,9 @@ share
     stageThree Int
     deriving Eq
 
+  SchemaExtra
+    log                 Text
+
   PoolHash
     hashRaw             ByteString          sqltype=hash28type
     view                Text

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -169,6 +169,7 @@ share
     txOutId             TxId                noreference         -- The transaction where this was created as an output.
     txOutIndex          Word64              sqltype=txindex
     redeemerId          RedeemerId Maybe    noreference
+    deriving Show
 
   CollateralTxIn
     txInId              TxId                noreference     -- The transaction where this is used as an input.

--- a/cardano-db/src/Cardano/Db/Update.hs
+++ b/cardano-db/src/Cardano/Db/Update.hs
@@ -1,0 +1,19 @@
+
+module Cardano.Db.Update (
+  updateTxOutConsumedByTxInId,
+  updateListTxOutConsumedByTxInId
+) where
+
+import Cardano.Db.Schema
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans.Reader (ReaderT)
+import Database.Persist ((=.))
+import Database.Persist.Class (update)
+import Database.Persist.Sql (SqlBackend)
+
+updateListTxOutConsumedByTxInId :: MonadIO m => [(TxOutId, TxInId)] -> ReaderT SqlBackend m ()
+updateListTxOutConsumedByTxInId = mapM_ (uncurry updateTxOutConsumedByTxInId)
+
+updateTxOutConsumedByTxInId :: MonadIO m => TxOutId -> TxInId -> ReaderT SqlBackend m ()
+updateTxOutConsumedByTxInId txOutId txInId =
+    update txOutId [TxOutConsumedByTxInId =. Just txInId]

--- a/cardano-db/src/Cardano/Db/Update.hs
+++ b/cardano-db/src/Cardano/Db/Update.hs
@@ -3,6 +3,7 @@
 module Cardano.Db.Update (
   setNullTxOut,
   updateTxOutConsumedByTxInId,
+  updateTxOutConsumedByTxInIdUnique,
   updateListTxOutConsumedByTxInId
 ) where
 
@@ -17,7 +18,7 @@ import Control.Monad.Trans.Reader (ReaderT)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Word (Word64)
-import Database.Persist ((=.))
+import Database.Persist (updateWhere, (=.), (==.))
 import Database.Persist.Class (update)
 import Database.Persist.Sql (SqlBackend)
 
@@ -27,6 +28,10 @@ updateListTxOutConsumedByTxInId = mapM_ (uncurry updateTxOutConsumedByTxInId)
 updateTxOutConsumedByTxInId :: MonadIO m => TxOutId -> TxInId -> ReaderT SqlBackend m ()
 updateTxOutConsumedByTxInId txOutId txInId =
     update txOutId [TxOutConsumedByTxInId =. Just txInId]
+
+updateTxOutConsumedByTxInIdUnique :: MonadIO m => TxId -> Word64 -> TxInId -> ReaderT SqlBackend m ()
+updateTxOutConsumedByTxInIdUnique txOutId index txInId =
+    updateWhere [TxOutTxId ==. txOutId, TxOutIndex ==. index] [TxOutConsumedByTxInId =. Just txInId]
 
 setNullTxOut :: MonadIO m => Trace IO Text -> MinIds -> Word64 -> ReaderT SqlBackend m ()
 setNullTxOut trce minIds txInDeleted = do

--- a/cardano-db/src/Cardano/Db/Update.hs
+++ b/cardano-db/src/Cardano/Db/Update.hs
@@ -1,12 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Db.Update (
+  setNullTxOut,
   updateTxOutConsumedByTxInId,
   updateListTxOutConsumedByTxInId
 ) where
 
+import Cardano.BM.Trace (Trace, logError)
+import Cardano.Db.MinId
 import Cardano.Db.Schema
-import Control.Monad.IO.Class (MonadIO)
+import Cardano.Db.Text
+import Cardano.Db.Query
+import Control.Monad.Extra (when, whenJust)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Reader (ReaderT)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Word (Word64)
 import Database.Persist ((=.))
 import Database.Persist.Class (update)
 import Database.Persist.Sql (SqlBackend)
@@ -17,3 +27,24 @@ updateListTxOutConsumedByTxInId = mapM_ (uncurry updateTxOutConsumedByTxInId)
 updateTxOutConsumedByTxInId :: MonadIO m => TxOutId -> TxInId -> ReaderT SqlBackend m ()
 updateTxOutConsumedByTxInId txOutId txInId =
     update txOutId [TxOutConsumedByTxInId =. Just txInId]
+
+setNullTxOut :: MonadIO m => Trace IO Text -> MinIds -> Word64 -> ReaderT SqlBackend m ()
+setNullTxOut trce minIds txInDeleted = do
+  whenJust (minTxInId minIds) $ \txInId -> do
+    txOutIds <- getTxOutConsumedAfter txInId
+    mapM_ setNullTxOutConsumedAfterTxInId txOutIds
+    let updatedEntries = fromIntegral (length txOutIds)
+    when (updatedEntries /= txInDeleted) $
+      liftIO $ logError trce $
+        Text.concat
+          [ "Deleted "
+          , textShow txInDeleted
+          , " inputs, but set to null only "
+          , textShow updatedEntries
+          , "consumed outputs. Please file an issue at https://github.com/input-output-hk/cardano-db-sync/issues"
+          ]
+
+-- | This requires an index at TxOutConsumedByTxInId.
+setNullTxOutConsumedAfterTxInId :: MonadIO m => TxOutId -> ReaderT SqlBackend m ()
+setNullTxOutConsumedAfterTxInId txOutId = do
+    update txOutId [TxOutConsumedByTxInId =. Nothing]

--- a/cardano-db/test/Test/IO/Cardano/Db/TotalSupply.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/TotalSupply.hs
@@ -53,6 +53,6 @@ initialSupplyTest =
           }
     _ <- insertTxIn (TxIn tx1Id (head tx0Ids) 0 Nothing)
     let addr = mkAddressHash bid1 tx1Id
-    _ <- insertTxOut $ TxOut tx1Id 0 (Text.pack addr) (BS.pack addr) False Nothing Nothing (DbLovelace 500000000) Nothing Nothing Nothing
+    _ <- insertTxOut $ TxOut tx1Id 0 (Text.pack addr) (BS.pack addr) False Nothing Nothing (DbLovelace 500000000) Nothing Nothing Nothing Nothing
     supply1 <- queryTotalSupply
     assertBool ("Total supply should be < " ++ show supply0) (supply1 < supply0)

--- a/cardano-db/test/Test/IO/Cardano/Db/Util.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Util.hs
@@ -100,4 +100,4 @@ testSlotLeader =
 mkTxOut :: BlockId -> TxId -> TxOut
 mkTxOut blkId txId =
   let addr = mkAddressHash blkId txId
-   in TxOut txId 0 (Text.pack addr) (BS.pack addr) False Nothing Nothing (DbLovelace 1000000000) Nothing Nothing Nothing
+   in TxOut txId 0 (Text.pack addr) (BS.pack addr) False Nothing Nothing (DbLovelace 1000000000) Nothing Nothing Nothing Nothing

--- a/schema/migration-2-0026-20230403.sql
+++ b/schema/migration-2-0026-20230403.sql
@@ -1,0 +1,19 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 26 THEN
+    EXECUTE 'ALTER TABLE "tx_out" ADD COLUMN "consumed_by_tx_in_id" INT8 NULL' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;

--- a/schema/migration-2-0027-20230501.sql
+++ b/schema/migration-2-0027-20230501.sql
@@ -1,0 +1,20 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 27 THEN
+    EXECUTE 'CREATe TABLE "schema_extra"("id" SERIAL8  PRIMARY KEY UNIQUE,"log" VARCHAR NOT NULL)' ;
+    EXECUTE 'ALTER TABLE "reverse_index" ALTER COLUMN "min_ids" SET NOT NULL' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;

--- a/schema/migration-3-0003-20230405.sql
+++ b/schema/migration-3-0003-20230405.sql
@@ -1,0 +1,4 @@
+
+-- Hand crafted indices for performance
+-- These indexes are used by queries db-sync does.
+CREATE INDEX IF NOT EXISTS idx_tx_out_consumed_by_tx_in_id ON tx_out (consumed_by_tx_in_id);


### PR DESCRIPTION
# Description

Fixes https://github.com/input-output-hk/cardano-db-sync/issues/1314

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [ ] Self-reviewed the diff

# Migrations

- [x] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

It will eventually be a b level breaking change. It needs a proper migration
