### PR TITLE
experiment with pgpass pointing to localhost

### DIFF
--- a/cardano-chain-gen/test/testfiles/pgpass-testing
+++ b/cardano-chain-gen/test/testfiles/pgpass-testing
@@ -1,1 +1,1 @@
-/var/run/postgresql:5432:testing:*:*
+localhost:5432:testing:*:*

--- a/cardano-db/test/Test/IO/Cardano/Db/PGConfig.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/PGConfig.hs
@@ -32,7 +32,7 @@ instance Eq PGConfig where
 
 pgFileReadTest :: IO ()
 pgFileReadTest = do
-  let expected = PGConfig "/var/run/postgresql" "5432" "testnet" "" "*"
+  let expected = PGConfig "localhost" "5432" "testnet" "" "*"
 
   currentDir <- getCurrentDirectory
   setEnv "OTHER_PG_PASS_ENV_VARIABLE" (currentDir </> "../config/pgpass-testnet")

--- a/config/pgpass-mainnet
+++ b/config/pgpass-mainnet
@@ -1,1 +1,1 @@
-/var/run/postgresql:5432:cexplorer:*:*
+localhost:5432:cexplorer:*:*

--- a/config/pgpass-testnet
+++ b/config/pgpass-testnet
@@ -1,1 +1,1 @@
-/var/run/postgresql:5432:testnet:*:*
+localhost:5432:testnet:*:*


### PR DESCRIPTION
# Description

Experimenting to see if setting pgpass to `locahost` would break things in CI/Linux as on MacOs `/var/run/postgresql` doesn't exists and connections to the database don't work. The error messages are quite cryptic when trying to work out the problem.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
