### PR TITLE
Write the ledger state file asynchronously

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Database.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Database.hs
@@ -32,7 +32,7 @@ import Ouroboros.Consensus.HeaderValidation hiding (TipInfo)
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Network.Block (Point (..))
 import Ouroboros.Network.Point (blockPointHash, blockPointSlot)
-import Cardano.DbSync.Api.Types (SyncEnv (..), LedgerEnv (..), ConsistentLevel (..))
+import Cardano.DbSync.Api.Types (SyncEnv (..), ConsistentLevel (..))
 
 data NextState
   = Continue

--- a/cardano-db-sync/src/Cardano/DbSync/DbAction.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/DbAction.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Cardano.DbSync.DbAction (
@@ -48,7 +47,9 @@ newDbActionQueue :: IO DbActionQueue
 newDbActionQueue =
   -- Use an odd number here so that the db_tip_height metric increments by this odd number
   -- when syncing, instead of incrementing by say 100.
-  DbActionQueue <$> TBQ.newTBQueueIO 117
+  -- The pipeline queue in the LocalChainSync machinery is 50 elements long
+  -- so we should not exceed that.
+  DbActionQueue <$> TBQ.newTBQueueIO 47
 
 writeDbActionQueue :: DbActionQueue -> DbAction -> STM ()
 writeDbActionQueue (DbActionQueue q) = TBQ.writeTBQueue q

--- a/cardano-db-sync/src/Cardano/DbSync/Ledger/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Ledger/Types.hs
@@ -28,6 +28,7 @@ import Cardano.Slotting.Slot (
   SlotNo (..),
   WithOrigin (..),
  )
+import Control.Concurrent.STM.TBQueue (TBQueue)
 import Control.Concurrent.Class.MonadSTM.Strict (
   StrictTVar,
  )
@@ -56,6 +57,7 @@ data HasLedgerEnv = HasLedgerEnv
   , leSnapshotEveryLagging :: !Word64
   , leInterpreter :: !(StrictTVar IO (Strict.Maybe CardanoInterpreter))
   , leStateVar :: !(StrictTVar IO (Strict.Maybe LedgerDB))
+  , leStateWriteQueue :: !(TBQueue (FilePath, CardanoLedgerState))
   }
 
 data CardanoLedgerState = CardanoLedgerState


### PR DESCRIPTION
In epoch above 340 or so, encoding and writing a ledger state file to disk can take 10 minutes or more. Better to do this asynchronously.

Closes: https://github.com/input-output-hk/cardano-db-sync/issues/1426
