### PR TITLE
Reduce cyclic errors by separating out Ledger & Api

### DIFF
--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -43,6 +43,7 @@ library
   exposed-modules:      Cardano.DbSync
 
                         Cardano.DbSync.Api
+                        Cardano.DbSync.Api.Types
                         Cardano.DbSync.Config
                         Cardano.DbSync.Config.Alonzo
                         Cardano.DbSync.Config.Byron
@@ -95,8 +96,9 @@ library
 
                         Cardano.DbSync.Era.Util
 
-                        Cardano.DbSync.LedgerEvent
-                        Cardano.DbSync.LedgerState
+                        Cardano.DbSync.Ledger.Event
+                        Cardano.DbSync.Ledger.State
+                        Cardano.DbSync.Ledger.Types
 
                         Cardano.DbSync.Metrics
 

--- a/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Cardano.DbSync.Api.Types (
+  SyncEnv (..),
+  SyncOptions (..),
+  InsertOptions (..),
+  LedgerEnv (..),
+  RunMigration,
+  FixesRan (..),
+  ConsistentLevel (..),
+  ExtraMigrations (..),
+  EpochState (..),
+) where
+
+import qualified Cardano.Db as DB
+import Cardano.DbSync.Cache (Cache)
+import Cardano.DbSync.Config.Types (SyncProtocol)
+import Cardano.DbSync.Ledger.Types (HasLedgerEnv)
+import Cardano.DbSync.LocalStateQuery (NoLedgerEnv)
+import Cardano.DbSync.Types (FetchResult, PoolFetchRetry)
+import Cardano.Prelude (Bool, Eq, IO, Show, Word64)
+import Cardano.Slotting.Slot (EpochNo (..))
+import Control.Concurrent.Class.MonadSTM.Strict (
+  StrictTVar,
+ )
+import Control.Concurrent.Class.MonadSTM.Strict.TBQueue (StrictTBQueue)
+import qualified Data.Strict.Maybe as Strict
+import Data.Time.Clock (UTCTime)
+import Database.Persist.Postgresql (ConnectionString)
+import Database.Persist.Sql (SqlBackend)
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types (SystemStart (..))
+import Ouroboros.Network.Magic (NetworkMagic (..))
+
+data SyncEnv = SyncEnv
+  { envProtocol :: !SyncProtocol
+  , envNetworkMagic :: !NetworkMagic
+  , envSystemStart :: !SystemStart
+  , envConnString :: ConnectionString
+  , envRunDelayedMigration :: RunMigration
+  , envBackend :: !(StrictTVar IO (Strict.Maybe SqlBackend))
+  , envConsistentLevel :: !(StrictTVar IO ConsistentLevel)
+  , envIsFixed :: !(StrictTVar IO FixesRan)
+  , envIndexes :: !(StrictTVar IO Bool)
+  , envOptions :: !SyncOptions
+  , envCache :: !Cache
+  , envExtraMigrations :: !(StrictTVar IO ExtraMigrations)
+  , envOfflineWorkQueue :: !(StrictTBQueue IO PoolFetchRetry)
+  , envOfflineResultQueue :: !(StrictTBQueue IO FetchResult)
+  , envEpochState :: !(StrictTVar IO EpochState)
+  , envEpochSyncTime :: !(StrictTVar IO UTCTime)
+  , envLedgerEnv :: !LedgerEnv
+  }
+
+data SyncOptions = SyncOptions
+  { soptExtended :: !Bool
+  , soptAbortOnInvalid :: !Bool
+  , soptCache :: !Bool
+  , soptSkipFix :: !Bool
+  , soptOnlyFix :: !Bool
+  , soptInsertOptions :: !InsertOptions
+  , snapshotEveryFollowing :: !Word64
+  , snapshotEveryLagging :: !Word64
+  }
+
+data InsertOptions = InsertOptions
+  { ioMultiAssets :: !Bool
+  , ioMetadata :: !Bool
+  , ioPlutusExtra :: !Bool
+  , ioOfflineData :: !Bool
+  }
+
+-- A representation of if we are using a ledger or not given CLI options
+data LedgerEnv where
+  HasLedger :: HasLedgerEnv -> LedgerEnv
+  NoLedger :: NoLedgerEnv -> LedgerEnv
+
+type RunMigration = DB.MigrationToRun -> IO ()
+
+data FixesRan = NoneFixRan | DataFixRan | AllFixRan
+
+data ConsistentLevel = Consistent | DBAheadOfLedger | Unchecked
+  deriving (Show, Eq)
+
+data ExtraMigrations = ExtraMigrations
+  { emRan :: Bool
+  , emConsume :: Bool
+  , emPrune :: Bool
+  }
+  deriving (Show)
+
+data EpochState = EpochState
+  { esInitialized :: !Bool
+  , esEpochNo :: !(Strict.Maybe EpochNo)
+  }

--- a/cardano-db-sync/src/Cardano/DbSync/Database.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Database.hs
@@ -18,7 +18,7 @@ import Cardano.DbSync.Api
 import Cardano.DbSync.DbAction
 import Cardano.DbSync.Default
 import Cardano.DbSync.Error
-import Cardano.DbSync.LedgerState
+import Cardano.DbSync.Ledger.State
 import Cardano.DbSync.Metrics
 import Cardano.DbSync.Rollback
 import Cardano.DbSync.Types
@@ -32,6 +32,7 @@ import Ouroboros.Consensus.HeaderValidation hiding (TipInfo)
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Network.Block (Point (..))
 import Ouroboros.Network.Point (blockPointHash, blockPointSlot)
+import Cardano.DbSync.Api.Types (SyncEnv (..), LedgerEnv (..), ConsistentLevel (..))
 
 data NextState
   = Continue

--- a/cardano-db-sync/src/Cardano/DbSync/Default.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Default.hs
@@ -11,6 +11,7 @@ module Cardano.DbSync.Default (
 import Cardano.BM.Trace (logInfo)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (ConsistentLevel (..), InsertOptions (..), LedgerEnv (..), SyncEnv (..), SyncOptions (..))
 import Cardano.DbSync.Cache
 import Cardano.DbSync.Epoch
 import Cardano.DbSync.Era.Byron.Insert (insertByronBlock)
@@ -21,7 +22,7 @@ import Cardano.DbSync.Era.Shelley.Insert (insertShelleyBlock, mkAdaPots)
 import Cardano.DbSync.Era.Shelley.Insert.Epoch (insertPoolDepositRefunds, insertRewards)
 import Cardano.DbSync.Era.Shelley.Validate (validateEpochRewards)
 import Cardano.DbSync.Error
-import Cardano.DbSync.LedgerState (
+import Cardano.DbSync.Ledger.State (
   ApplyResult (..),
   LedgerEvent (..),
   applyBlockAndSnapshot,

--- a/cardano-db-sync/src/Cardano/DbSync/Era.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Cardano.DbSync.Era (
@@ -8,7 +7,7 @@ module Cardano.DbSync.Era (
   insertValidateGenesisDist,
 ) where
 
-import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (SyncEnv)
 import Cardano.DbSync.Config
 import qualified Cardano.DbSync.Era.Byron.Genesis as Byron
 import qualified Cardano.DbSync.Era.Shelley.Genesis as Shelley

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
@@ -32,6 +32,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Database.Persist.Sql (SqlBackend)
 import Paths_cardano_db_sync (version)
+import Cardano.DbSync.Api.Types (SyncEnv)
 
 -- | Idempotent insert the initial Genesis distribution transactions into the DB.
 -- If these transactions are already in the DB, they are validated.

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs
@@ -25,6 +25,7 @@ import qualified Cardano.Crypto as Crypto (serializeCborHash)
 import Cardano.Db (DbLovelace (..))
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (SyncEnv (..))
 import Cardano.DbSync.Cache
 import qualified Cardano.DbSync.Era.Byron.Util as Byron
 import Cardano.DbSync.Era.Util (liftLookupFail)

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
@@ -14,6 +14,7 @@ module Cardano.DbSync.Era.Shelley.Genesis (
 import Cardano.BM.Trace (Trace, logError, logInfo)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (SyncEnv)
 import Cardano.DbSync.Cache
 import qualified Cardano.DbSync.Era.Shelley.Generic.Util as Generic
 import Cardano.DbSync.Era.Shelley.Insert

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -67,6 +67,7 @@ import qualified Data.Strict.Maybe as Strict
 import qualified Data.Text.Encoding as Text
 import Database.Persist.Sql (SqlBackend)
 import Ouroboros.Consensus.Cardano.Block (StandardCrypto)
+import Cardano.DbSync.Api.Types (InsertOptions (..), SyncEnv (..))
 
 {- HLINT ignore "Reduce duplication" -}
 

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs
@@ -18,6 +18,7 @@ module Cardano.DbSync.Era.Shelley.Insert.Epoch (
 import Cardano.BM.Trace (Trace, logInfo)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (SyncEnv (..))
 import Cardano.DbSync.Cache
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Util (liftLookupFail)

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Grouped.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Grouped.hs
@@ -17,6 +17,7 @@ import Cardano.BM.Trace (Trace, logWarning)
 import Cardano.Db (DbLovelace (..), minIdsToText, textShow)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (SyncEnv)
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Shelley.Query
 import Cardano.DbSync.Era.Util

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Offline.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Offline.hs
@@ -15,6 +15,7 @@ import Cardano.BM.Trace (Trace, logInfo)
 import Cardano.Db
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (InsertOptions (..), SyncEnv, envOfflineResultQueue, envOfflineWorkQueue)
 import Cardano.DbSync.Era.Shelley.Offline.Http
 import Cardano.DbSync.Era.Shelley.Offline.Query
 import Cardano.DbSync.Types

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Validate.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Validate.hs
@@ -13,7 +13,7 @@ import Cardano.BM.Trace (Trace, logError, logInfo, logWarning)
 import Cardano.Db (DbLovelace, RewardSource)
 import qualified Cardano.Db as Db
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
-import Cardano.DbSync.LedgerEvent
+import Cardano.DbSync.Ledger.Event
 import Cardano.DbSync.Types
 import Cardano.DbSync.Util (textShow)
 import Cardano.Ledger.Coin (Coin (..))

--- a/cardano-db-sync/src/Cardano/DbSync/Ledger/Event.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Ledger/Event.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
-module Cardano.DbSync.LedgerEvent (
+module Cardano.DbSync.Ledger.Event (
   LedgerEvent (..),
   convertAuxLedgerEvent,
   convertPoolRewards,

--- a/cardano-db-sync/src/Cardano/DbSync/Ledger/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Ledger/Types.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Cardano.DbSync.Ledger.Types where
+
+import Cardano.BM.Trace (Trace)
+import Cardano.Binary (Decoder, Encoding, FromCBOR (..), ToCBOR (..))
+import Cardano.DbSync.Config.Types (LedgerStateDir)
+import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
+import Cardano.DbSync.Ledger.Event (LedgerEvent)
+import Cardano.DbSync.Types (
+  CardanoBlock,
+  CardanoInterpreter,
+  PoolKeyHash,
+  SlotDetails,
+ )
+import Cardano.Ledger.Alonzo.Scripts (Prices)
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import Cardano.Prelude hiding (atomically)
+import Cardano.Slotting.Slot (
+  EpochNo (..),
+  SlotNo (..),
+  WithOrigin (..),
+ )
+import Control.Concurrent.Class.MonadSTM.Strict (
+  StrictTVar,
+ )
+
+import qualified Data.Set as Set
+import qualified Data.Strict.Maybe as Strict
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types (SystemStart (..))
+import Ouroboros.Consensus.Ledger.Abstract (getTipSlot)
+import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
+import qualified Ouroboros.Consensus.Node.ProtocolInfo as Consensus
+import Ouroboros.Network.AnchoredSeq (Anchorable (..), AnchoredSeq (..))
+import Prelude (fail, id)
+
+--------------------------------------------------------------------------
+-- Ledger Types
+--------------------------------------------------------------------------
+
+data HasLedgerEnv = HasLedgerEnv
+  { leTrace :: Trace IO Text
+  , leProtocolInfo :: !(Consensus.ProtocolInfo IO CardanoBlock)
+  , leDir :: !LedgerStateDir
+  , leNetwork :: !Ledger.Network
+  , leSystemStart :: !SystemStart
+  , leAbortOnPanic :: !Bool
+  , leSnapshotEveryFollowing :: !Word64
+  , leSnapshotEveryLagging :: !Word64
+  , leInterpreter :: !(StrictTVar IO (Strict.Maybe CardanoInterpreter))
+  , leStateVar :: !(StrictTVar IO (Strict.Maybe LedgerDB))
+  }
+
+data CardanoLedgerState = CardanoLedgerState
+  { clsState :: !(ExtLedgerState CardanoBlock)
+  , clsEpochBlockNo :: !EpochBlockNo
+  }
+
+-- The height of the block in the current Epoch. We maintain this
+-- data next to the ledger state and store it in the same blob file.
+data EpochBlockNo
+  = GenesisEpochBlockNo
+  | EBBEpochBlockNo
+  | EpochBlockNo !Word64
+
+instance ToCBOR EpochBlockNo where
+  toCBOR GenesisEpochBlockNo = toCBOR (0 :: Word8)
+  toCBOR EBBEpochBlockNo = toCBOR (1 :: Word8)
+  toCBOR (EpochBlockNo n) =
+    toCBOR (2 :: Word8) <> toCBOR n
+
+instance FromCBOR EpochBlockNo where
+  fromCBOR = do
+    tag :: Word8 <- fromCBOR
+    case tag of
+      0 -> pure GenesisEpochBlockNo
+      1 -> pure EBBEpochBlockNo
+      2 -> EpochBlockNo <$> fromCBOR
+      n -> fail $ "unexpected EpochBlockNo value " <> show n
+encodeCardanoLedgerState :: (ExtLedgerState CardanoBlock -> Encoding) -> CardanoLedgerState -> Encoding
+encodeCardanoLedgerState encodeExt cls =
+  mconcat
+    [ encodeExt (clsState cls)
+    , toCBOR (clsEpochBlockNo cls)
+    ]
+
+decodeCardanoLedgerState ::
+  (forall s. Decoder s (ExtLedgerState CardanoBlock)) ->
+  (forall s. Decoder s CardanoLedgerState)
+decodeCardanoLedgerState decodeExt = do
+  ldgrState <- decodeExt
+  CardanoLedgerState ldgrState <$> fromCBOR
+
+data LedgerStateFile = LedgerStateFile
+  { lsfSlotNo :: !SlotNo
+  , lsfHash :: !ByteString
+  , lsNewEpoch :: !(Strict.Maybe EpochNo)
+  , lsfFilePath :: !FilePath
+  }
+  deriving (Show)
+
+-- The result of applying a new block. This includes all the data that insertions require.
+data ApplyResult = ApplyResult
+  { apPrices :: !(Strict.Maybe Prices) -- prices after the block application
+  , apPoolsRegistered :: !(Set.Set PoolKeyHash) -- registered before the block application
+  , apNewEpoch :: !(Strict.Maybe Generic.NewEpoch) -- Only Just for a single block at the epoch boundary
+  , apSlotDetails :: !SlotDetails
+  , apStakeSlice :: !Generic.StakeSliceRes
+  , apEvents :: ![LedgerEvent]
+  }
+
+defaultApplyResult :: SlotDetails -> ApplyResult
+defaultApplyResult slotDetails =
+  ApplyResult
+    { apPrices = Strict.Nothing
+    , apPoolsRegistered = Set.empty
+    , apNewEpoch = Strict.Nothing
+    , apSlotDetails = slotDetails
+    , apStakeSlice = Generic.NoSlices
+    , apEvents = []
+    }
+
+newtype LedgerDB = LedgerDB
+  { ledgerDbCheckpoints :: AnchoredSeq (WithOrigin SlotNo) CardanoLedgerState CardanoLedgerState
+  }
+
+instance Anchorable (WithOrigin SlotNo) CardanoLedgerState CardanoLedgerState where
+  asAnchor = id
+  getAnchorMeasure _ = getTipSlot . clsState

--- a/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
@@ -23,6 +23,7 @@ import Database.Persist.Sql (SqlBackend)
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (getOneEraHash)
 import Ouroboros.Network.Block
 import Ouroboros.Network.Point
+import Cardano.DbSync.Api.Types (SyncEnv (..))
 
 -- Rollbacks are done in an Era generic way based on the 'Point' we are
 -- rolling back to.

--- a/cardano-db-tool/src/Cardano/DbTool/PrepareSnapshot.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/PrepareSnapshot.hs
@@ -5,7 +5,7 @@ module Cardano.DbTool.PrepareSnapshot (
 
 import Cardano.Db
 import Cardano.DbSync.Config.Types hiding (LogFileDir)
-import Cardano.DbSync.LedgerState
+import Cardano.DbSync.Ledger.State
 import Cardano.Prelude (Word64, fromMaybe)
 import Control.Monad
 import qualified Data.ByteString.Base16 as Base16

--- a/cardano-db-tool/src/Cardano/DbTool/Validate/Ledger.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/Validate/Ledger.hs
@@ -7,7 +7,7 @@ import qualified Cardano.Db as DB
 import Cardano.DbSync.Config
 import Cardano.DbSync.Config.Cardano
 import Cardano.DbSync.Error
-import Cardano.DbSync.LedgerState
+import Cardano.DbSync.Ledger.State
 import Cardano.DbSync.Tracing.ToObjectOrphans ()
 import Cardano.DbTool.Validate.Balance (ledgerAddrBalance)
 import Cardano.DbTool.Validate.Util


### PR DESCRIPTION
# Description

Due to some of the structure of the files we'd end up with scenarios like:
```
mkSyncEnvFromConfig ::
  Trace IO Text ->
  ConnectionString ->
  SyncOptions ->
  Maybe LedgerStateDir ->
  Bool ->
  GenesisConfig ->
  Bool ->
  Bool ->
  Bool ->
  Bool ->
  RunMigration ->
```
Having 4 `Bools` might cause issues if inserted in an incorrect order. The solution is to pass `SyncNodeParams` but doing so causes a cyclic dependency error.  This PR separates files apart to fix the cyclic dependency error.
 
# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
