### PR TITLE
Cache epoch calculations to minimise use of DB queries

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -80,6 +80,11 @@ jobs:
         ls -al /var/run/postgresql/.s.PGSQL.5432 || true
         ls -al || true
 
+    - name: Debug Pkgconfig
+      run: |
+        echo $PKG_CONFIG_PATH
+        pkg-config --list-all
+
     - name: Haskell versions
       run: |
         ghc --version

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ gen/
 
 cardano-chain-gen/test/testfiles/temp/
 /secp256k1/
+
+.ghc.environment.*

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -103,7 +103,9 @@ library
                         Cardano.DbSync.Metrics
 
                         Cardano.DbSync.Cache
+                        Cardano.DbSync.Cache.Epoch
                         Cardano.DbSync.Cache.LRU
+                        Cardano.DbSync.Cache.Types
                         Cardano.DbSync.Default
                         Cardano.DbSync.Epoch
 
@@ -194,6 +196,7 @@ library
                       , typed-protocols
                       , unix
                       , vector
+                      , wide-word
                       , yaml
 
 executable cardano-db-sync

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -142,7 +142,7 @@ runDbSync metricsSetters knownMigrations iomgr trce params aop = do
 extractSyncOptions :: SyncNodeParams -> Bool -> SyncOptions
 extractSyncOptions snp aop =
   SyncOptions
-    { soptExtended = enpExtended snp
+    { soptExtended = enpExtended snp && enpHasCache snp
     , soptAbortOnInvalid = aop
     , soptCache = enpHasCache snp
     , soptSkipFix = enpSkipFix snp

--- a/cardano-db-sync/src/Cardano/DbSync/Api.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -83,11 +84,12 @@ import qualified Data.Strict.Maybe as Strict
 import Data.Time.Clock (getCurrentTime)
 import Database.Persist.Postgresql (ConnectionString)
 import Database.Persist.Sql (SqlBackend)
-import Ouroboros.Consensus.Block.Abstract (HeaderHash, Point (..), fromRawHash)
+import Ouroboros.Consensus.Block.Abstract (BlockProtocol, HeaderHash, Point (..), fromRawHash)
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types (SystemStart (..))
-import Ouroboros.Consensus.Config (TopLevelConfig)
-import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo)
+import Ouroboros.Consensus.Config (SecurityParam (..), TopLevelConfig, configSecurityParam)
+import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (pInfoConfig))
 import qualified Ouroboros.Consensus.Node.ProtocolInfo as Consensus
+import Ouroboros.Consensus.Protocol.Abstract (ConsensusProtocol)
 import Ouroboros.Network.Block (BlockNo (..), Point (..))
 import Ouroboros.Network.Magic (NetworkMagic (..))
 import qualified Ouroboros.Network.Point as Point
@@ -163,10 +165,10 @@ runExtraMigrationsMaybe env = do
   liftIO $ atomically $ writeTVar (envExtraMigrations env) (extraMigr {emRan = True})
 
 getSafeBlockNoDiff :: SyncEnv -> Word64
-getSafeBlockNoDiff _ = 2 * 2160
+getSafeBlockNoDiff syncEnv = 2 * getSecurityParam syncEnv
 
 getPruneInterval :: SyncEnv -> Word64
-getPruneInterval _ = 10 * 2160
+getPruneInterval syncEnv = 10 * getSecurityParam syncEnv
 
 whenConsumeTxOut :: MonadIO m => SyncEnv -> m () -> m ()
 whenConsumeTxOut env action = do
@@ -474,3 +476,15 @@ convertToPoint slot hashBlob =
   where
     convertHashBlob :: ByteString -> Maybe (HeaderHash CardanoBlock)
     convertHashBlob = Just . fromRawHash (Proxy @CardanoBlock)
+
+getSecurityParam :: SyncEnv -> Word64
+getSecurityParam syncEnv =
+  case envLedgerEnv syncEnv of
+    HasLedger hle -> getMaxRollbacks $ leProtocolInfo hle
+    NoLedger nle -> getMaxRollbacks $ nleProtocolInfo nle
+
+getMaxRollbacks ::
+  ConsensusProtocol (BlockProtocol blk) =>
+  ProtocolInfo IO blk ->
+  Word64
+getMaxRollbacks = maxRollbacks . configSecurityParam . pInfoConfig

--- a/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
@@ -15,7 +15,7 @@ module Cardano.DbSync.Api.Types (
 ) where
 
 import qualified Cardano.Db as DB
-import Cardano.DbSync.Cache (Cache)
+import Cardano.DbSync.Cache.Types (Cache)
 import Cardano.DbSync.Config.Types (SyncProtocol)
 import Cardano.DbSync.Ledger.Types (HasLedgerEnv)
 import Cardano.DbSync.LocalStateQuery (NoLedgerEnv)

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Epoch.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Cardano.DbSync.Cache.Epoch (
+  readCacheEpoch,
+  readEpochBlockDiffFromCache,
+  readLastMapEpochFromCache,
+  rollbackMapEpochInCache,
+  writeEpochBlockDiffToCache,
+  writeToMapEpochCache,
+) where
+
+import qualified Cardano.Db as DB
+import Cardano.DbSync.Api.Types (LedgerEnv (..), SyncEnv (..))
+import Cardano.DbSync.Cache.Types (Cache (..), CacheEpoch (..), CacheInternal (..), EpochBlockDiff (..))
+import Cardano.DbSync.Era.Shelley.Generic.StakeDist (getSecurityParameter)
+import Cardano.DbSync.Error (SyncNodeError (..))
+import Cardano.DbSync.LocalStateQuery (NoLedgerEnv (..))
+import Cardano.Prelude
+import Control.Concurrent.Class.MonadSTM.Strict (readTVarIO, writeTVar)
+import Data.Map.Strict (deleteMin, insert, lookupMax, size, split)
+import Database.Persist.Postgresql (SqlBackend)
+import Cardano.DbSync.Ledger.Types (HasLedgerEnv(..))
+
+-------------------------------------------------------------------------------------
+-- Epoch Cache
+-------------------------------------------------------------------------------------
+readCacheEpoch :: (MonadIO m) => Cache -> m (Maybe CacheEpoch)
+readCacheEpoch cache =
+  case cache of
+    UninitiatedCache -> pure Nothing
+    Cache ci -> do
+      cacheEpoch <- liftIO $ readTVarIO (cEpoch ci)
+      pure $ Just cacheEpoch
+
+readEpochBlockDiffFromCache :: (MonadIO m) => Cache -> m (Maybe EpochBlockDiff)
+readEpochBlockDiffFromCache cache =
+  case cache of
+    UninitiatedCache -> pure Nothing
+    Cache ci -> do
+      cE <- liftIO $ readTVarIO (cEpoch ci)
+      case (ceMapEpoch cE, ceEpochBlockDiff cE) of
+        (_, epochInternal) -> pure epochInternal
+
+readLastMapEpochFromCache :: Cache -> IO (Maybe DB.Epoch)
+readLastMapEpochFromCache cache =
+  case cache of
+    UninitiatedCache -> pure Nothing
+    Cache ci -> do
+      cE <- readTVarIO (cEpoch ci)
+      let mapEpoch = ceMapEpoch cE
+      -- making sure db sync wasn't restarted on the last block in epoch
+      if length mapEpoch == 1
+        then pure Nothing
+        else case lookupMax mapEpoch of
+          Nothing -> pure Nothing
+          Just (_, ep) -> pure $ Just ep
+
+rollbackMapEpochInCache :: (MonadIO m) => CacheInternal -> DB.BlockId -> m (Either SyncNodeError ())
+rollbackMapEpochInCache cache blockId = do
+  cE <- liftIO $ readTVarIO (cEpoch cache)
+  -- split the map and delete anything after blockId including it self as new blockId might be
+  -- given when inserting the block again when doing rollbacks.
+  let (newMapEpoch, _) = split blockId (ceMapEpoch cE)
+  writeToCache cache (CacheEpoch newMapEpoch (ceEpochBlockDiff cE))
+
+writeEpochBlockDiffToCache ::
+  (MonadIO m) =>
+  Cache ->
+  EpochBlockDiff ->
+  ReaderT SqlBackend m (Either SyncNodeError ())
+writeEpochBlockDiffToCache cache epCurrent =
+  case cache of
+    UninitiatedCache -> pure $ Left $ NEError "writeEpochBlockDiffToCache: Cache is UninitiatedCache"
+    Cache ci -> do
+      cE <- liftIO $ readTVarIO (cEpoch ci)
+      case (ceMapEpoch cE, ceEpochBlockDiff cE) of
+        (epochLatest, _) -> writeToCache ci (CacheEpoch epochLatest (Just epCurrent))
+
+-- | Insert an epoch into Map Epoch cache. A blockId is used as the key which was generated when inserting the block
+-- | into the db. This is so we have a historic representation of an epoch after every block is inserted.
+-- | This becomes usefull when syncing and doing rollbacks and saves on expensive db queries to calculte an epoch.
+writeToMapEpochCache ::
+  (MonadIO m) =>
+  SyncEnv ->
+  Cache ->
+  DB.Epoch ->
+  ReaderT SqlBackend m (Either SyncNodeError ())
+writeToMapEpochCache syncEnv cache latestEpoch = do
+  -- this can also be tought of as max rollback number
+  let securityParam =
+        case envLedgerEnv syncEnv of
+          HasLedger hle -> getSecurityParameter $ leProtocolInfo hle
+          NoLedger nle -> getSecurityParameter $ nleProtocolInfo nle
+  case cache of
+    UninitiatedCache -> pure $ Left $ NEError "writeToMapEpochCache: Cache is UninitiatedCache"
+    Cache ci -> do
+      -- get EpochBlockDiff so we can use the BlockId we stored when inserting blocks
+      epochInternalCE <- readEpochBlockDiffFromCache cache
+      case epochInternalCE of
+        Nothing -> pure $ Left $ NEError "writeToMapEpochCache: No epochInternalEpochCache"
+        Just ei -> do
+          cE <- liftIO $ readTVarIO (cEpoch ci)
+          let currentBlockId = ebdBlockId ei
+              mapEpoch = ceMapEpoch cE
+              -- To make sure our Map Epoch doesn't get too large so we use something slightly bigger than K value "securityParam"
+              -- and once the map gets larger than that number we delete the first inserted item making room for another Epoch.
+              scaledMapEpoch =
+                if size mapEpoch > fromEnum securityParam
+                  then deleteMin mapEpoch
+                  else mapEpoch
+
+          let updatedMapEpoch = insert currentBlockId latestEpoch scaledMapEpoch
+          writeToCache ci (CacheEpoch updatedMapEpoch (ceEpochBlockDiff cE))
+
+------------------------------------------------------------------
+-- Helpers
+------------------------------------------------------------------
+
+writeToCache :: (MonadIO m) => CacheInternal -> CacheEpoch -> m (Either SyncNodeError ())
+writeToCache ci newCacheEpoch = do
+  void $ liftIO $ atomically $ writeTVar (cEpoch ci) newCacheEpoch
+  pure $ Right ()

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Epoch.hs
@@ -15,12 +15,12 @@ import Cardano.DbSync.Api.Types (LedgerEnv (..), SyncEnv (..))
 import Cardano.DbSync.Cache.Types (Cache (..), CacheEpoch (..), CacheInternal (..), EpochBlockDiff (..))
 import Cardano.DbSync.Era.Shelley.Generic.StakeDist (getSecurityParameter)
 import Cardano.DbSync.Error (SyncNodeError (..))
+import Cardano.DbSync.Ledger.Types (HasLedgerEnv (..))
 import Cardano.DbSync.LocalStateQuery (NoLedgerEnv (..))
 import Cardano.Prelude
 import Control.Concurrent.Class.MonadSTM.Strict (readTVarIO, writeTVar)
 import Data.Map.Strict (deleteMin, insert, lookupMax, size, split)
 import Database.Persist.Postgresql (SqlBackend)
-import Cardano.DbSync.Ledger.Types (HasLedgerEnv(..))
 
 -------------------------------------------------------------------------------------
 -- Epoch Cache

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Cardano.DbSync.Cache.Types (
+  Cache (..),
+  CacheNew (..),
+  CacheEpoch (..),
+  CacheInternal (..),
+  EpochBlockDiff (..),
+  StakeAddrCache,
+  StakePoolCache,
+
+  -- * Inits
+  uninitiatedCache,
+  initCacheStatistics,
+  newEmptyCache,
+
+  -- * CacheStatistics
+  CacheStatistics (..),
+  textShowStats,
+) where
+
+import qualified Cardano.Db as DB
+import Cardano.DbSync.Cache.LRU (LRUCache)
+import qualified Cardano.DbSync.Cache.LRU as LRU
+import Cardano.DbSync.Types (DataHash, PoolKeyHash, StakeCred)
+import Cardano.Ledger.Mary.Value (AssetName, PolicyID)
+import Cardano.Prelude
+import Control.Concurrent.Class.MonadSTM.Strict (
+  StrictTVar,
+  newTVarIO,
+  readTVarIO,
+ )
+import qualified Data.Map.Strict as Map
+import Data.Time.Clock (UTCTime)
+import Data.WideWord.Word128 (Word128)
+import Ouroboros.Consensus.Cardano.Block (StandardCrypto)
+
+type StakeAddrCache = Map StakeCred DB.StakeAddressId
+
+type StakePoolCache = Map PoolKeyHash DB.PoolHashId
+
+-- The 'UninitiatedCache' makes it possible to call functions in this module
+-- without having actually initiated the cache yet. It is used by genesis
+-- insertions, where the cache has not been initiated yet.
+data Cache
+  = UninitiatedCache
+  | Cache !CacheInternal
+
+data CacheNew
+  = CacheNew
+  | DontCacheNew
+  | EvictAndReturn
+  deriving (Eq)
+
+data CacheInternal = CacheInternal
+  { cStakeCreds :: !(StrictTVar IO StakeAddrCache)
+  , cPools :: !(StrictTVar IO StakePoolCache)
+  , cDatum :: !(StrictTVar IO (LRUCache DataHash DB.DatumId))
+  , cMultiAssets :: !(StrictTVar IO (LRUCache (PolicyID StandardCrypto, AssetName) DB.MultiAssetId))
+  , cPrevBlock :: !(StrictTVar IO (Maybe (DB.BlockId, ByteString)))
+  , cStats :: !(StrictTVar IO CacheStatistics)
+  , cEpoch :: !(StrictTVar IO CacheEpoch)
+  }
+
+data CacheStatistics = CacheStatistics
+  { credsHits :: !Word64
+  , credsQueries :: !Word64
+  , poolsHits :: !Word64
+  , poolsQueries :: !Word64
+  , datumHits :: !Word64
+  , datumQueries :: !Word64
+  , multiAssetsHits :: !Word64
+  , multiAssetsQueries :: !Word64
+  , prevBlockHits :: !Word64
+  , prevBlockQueries :: !Word64
+  }
+
+-- When inserting Txs and Blocks we also caculate values which can later be used when calculating a Epochs.
+-- For this reason we store these values in cache.
+data EpochBlockDiff = EpochBlockDiff
+  { ebdBlockId :: !DB.BlockId
+  -- ^ The blockId of the current block, this is used as the key for MapEpoch.
+  , ebdFees :: !Word64
+  , ebdOutSum :: !Word128
+  , ebdTxCount :: !Word64
+  , ebdEpochNo :: !Word64
+  , ebdTime :: !UTCTime
+  }
+  deriving (Show)
+
+data CacheEpoch = CacheEpoch
+  { ceMapEpoch :: !(Map DB.BlockId DB.Epoch)
+  , ceEpochBlockDiff :: !(Maybe EpochBlockDiff)
+  }
+  deriving (Show)
+
+textShowStats :: Cache -> IO Text
+textShowStats UninitiatedCache = pure "UninitiatedCache"
+textShowStats (Cache ic) = do
+  stats <- readTVarIO $ cStats ic
+  creds <- readTVarIO (cStakeCreds ic)
+  pools <- readTVarIO (cPools ic)
+  datums <- readTVarIO (cDatum ic)
+  mAssets <- readTVarIO (cMultiAssets ic)
+  pure $
+    mconcat
+      [ "\nCache Statistics:"
+      , "\n  Stake Addresses: "
+      , "cache size: "
+      , DB.textShow (Map.size creds)
+      , if credsQueries stats == 0
+          then ""
+          else ", hit rate: " <> DB.textShow (100 * credsHits stats `div` credsQueries stats) <> "%"
+      , ", hits: "
+      , DB.textShow (credsHits stats)
+      , ", misses: "
+      , DB.textShow (credsQueries stats - credsHits stats)
+      , "\n  Pools: "
+      , "cache size: "
+      , DB.textShow (Map.size pools)
+      , if poolsQueries stats == 0
+          then ""
+          else ", hit rate: " <> DB.textShow (100 * poolsHits stats `div` poolsQueries stats) <> "%"
+      , ", hits: "
+      , DB.textShow (poolsHits stats)
+      , ", misses: "
+      , DB.textShow (poolsQueries stats - poolsHits stats)
+      , "\n  Datums: "
+      , "cache capacity: "
+      , DB.textShow (LRU.getCapacity datums)
+      , ", cache size: "
+      , DB.textShow (LRU.getSize datums)
+      , if datumQueries stats == 0
+          then ""
+          else ", hit rate: " <> DB.textShow (100 * datumHits stats `div` datumQueries stats) <> "%"
+      , ", hits: "
+      , DB.textShow (datumHits stats)
+      , ", misses: "
+      , DB.textShow (datumQueries stats - datumHits stats)
+      , "\n  Multi Assets: "
+      , "cache capacity: "
+      , DB.textShow (LRU.getCapacity mAssets)
+      , ", cache size: "
+      , DB.textShow (LRU.getSize mAssets)
+      , if multiAssetsQueries stats == 0
+          then ""
+          else ", hit rate: " <> DB.textShow (100 * multiAssetsHits stats `div` multiAssetsQueries stats) <> "%"
+      , ", hits: "
+      , DB.textShow (multiAssetsHits stats)
+      , ", misses: "
+      , DB.textShow (multiAssetsQueries stats - multiAssetsHits stats)
+      , "\n  Previous Block: "
+      , if prevBlockQueries stats == 0
+          then ""
+          else "hit rate: " <> DB.textShow (100 * prevBlockHits stats `div` prevBlockQueries stats) <> "%"
+      , ", hits: "
+      , DB.textShow (prevBlockHits stats)
+      , ", misses: "
+      , DB.textShow (prevBlockQueries stats - prevBlockHits stats)
+      ]
+
+uninitiatedCache :: Cache
+uninitiatedCache = UninitiatedCache
+
+newEmptyCache :: (MonadIO m) => Word64 -> Word64 -> m Cache
+newEmptyCache maCapacity daCapacity =
+  liftIO . fmap Cache $
+    CacheInternal
+      <$> newTVarIO Map.empty
+      <*> newTVarIO Map.empty
+      <*> newTVarIO (LRU.empty daCapacity)
+      <*> newTVarIO (LRU.empty maCapacity)
+      <*> newTVarIO Nothing
+      <*> newTVarIO initCacheStatistics
+      <*> newTVarIO initCacheEpoch
+
+initCacheStatistics :: CacheStatistics
+initCacheStatistics = CacheStatistics 0 0 0 0 0 0 0 0 0 0
+
+initCacheEpoch :: CacheEpoch
+initCacheEpoch = CacheEpoch mempty Nothing

--- a/cardano-db-sync/src/Cardano/DbSync/Database.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Database.hs
@@ -32,7 +32,8 @@ import Ouroboros.Consensus.HeaderValidation hiding (TipInfo)
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Network.Block (Point (..))
 import Ouroboros.Network.Point (blockPointHash, blockPointSlot)
-import Cardano.DbSync.Api.Types (SyncEnv (..), ConsistentLevel (..))
+import Cardano.DbSync.Api.Types (SyncEnv (..), ConsistentLevel (..), LedgerEnv (..))
+import Cardano.DbSync.Ledger.Types (CardanoLedgerState(..), SnapshotPoint (..))
 
 data NextState
   = Continue

--- a/cardano-db-sync/src/Cardano/DbSync/Default.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Default.hs
@@ -11,13 +11,7 @@ module Cardano.DbSync.Default (
 import Cardano.BM.Trace (logInfo)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
-import Cardano.DbSync.Api.Types (
-  ConsistentLevel (..),
-  InsertOptions (..),
-  LedgerEnv (..),
-  SyncEnv (..),
-  SyncOptions (..),
- )
+import Cardano.DbSync.Api.Types (ConsistentLevel (..), InsertOptions (..), LedgerEnv (..), SyncEnv (..), SyncOptions (..))
 import Cardano.DbSync.Cache.Types (textShowStats)
 import Cardano.DbSync.Epoch (epochHandler)
 import Cardano.DbSync.Era.Byron.Insert (insertByronBlock)

--- a/cardano-db-sync/src/Cardano/DbSync/Default.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Default.hs
@@ -182,6 +182,7 @@ insertBlock syncEnv cblk applyRes firstAfterRollback tookSnapshot = do
     iopts = getInsertOptions syncEnv
 
     updateEpoch details isNewEpochEvent =
+      -- if have --dissable-epoch && --dissable-cache then no need to run this function
       when (soptExtended $ envOptions syncEnv)
         . newExceptT
         $ epochHandler

--- a/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
@@ -52,7 +52,6 @@ epochHandler syncEnv trce cache isNewEpochEvent (BlockDetails cblk details) =
           updateEpochStart syncEnv cache details isNewEpochEvent True
         Byron.ABOBBlock _blk ->
           updateEpochStart syncEnv cache details isNewEpochEvent False
-    -- BlockByron {} -> updateEpochStart syncEnv cache details isNewEpochEvent
     BlockShelley {} -> epochSlotTimecheck
     BlockAllegra {} -> epochSlotTimecheck
     BlockMary {} -> epochSlotTimecheck

--- a/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
@@ -1,159 +1,317 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Cardano.DbSync.Epoch (
-  epochStartup,
-  epochInsert,
+  epochHandler,
 ) where
 
 import Cardano.BM.Trace (Trace, logError, logInfo)
 import qualified Cardano.Chain.Block as Byron
-import Cardano.Db (EntityField (..), EpochId)
 import qualified Cardano.Db as DB
+import Cardano.DbSync.Api (getTrace)
+import Cardano.DbSync.Api.Types (SyncEnv)
+import Cardano.DbSync.Cache.Epoch (readEpochBlockDiffFromCache, readLastMapEpochFromCache, writeToMapEpochCache)
+import Cardano.DbSync.Cache.Types (Cache (..), EpochBlockDiff (..))
 import Cardano.DbSync.Error
-import Cardano.DbSync.Types
+import Cardano.DbSync.Types (
+  BlockDetails (BlockDetails),
+  SlotDetails (..),
+  SyncState (SyncFollowing),
+ )
 import Cardano.DbSync.Util
 import Cardano.Prelude hiding (from, on, replace)
-import Cardano.Slotting.Slot (EpochNo (..))
+import Cardano.Slotting.Slot (unEpochNo)
 import Control.Monad.Logger (LoggingT)
 import Control.Monad.Trans.Control (MonadBaseControl)
-import Data.IORef (IORef, atomicWriteIORef, newIORef, readIORef)
-import Database.Esqueleto.Experimental (
-  SqlBackend,
-  desc,
-  from,
-  limit,
-  orderBy,
-  replace,
-  select,
-  table,
-  unValue,
-  val,
-  where_,
-  (==.),
-  (^.),
- )
+import Database.Esqueleto.Experimental (SqlBackend, replace)
 import Ouroboros.Consensus.Byron.Ledger (ByronBlock (..))
 import Ouroboros.Consensus.Cardano.Block (HardForkBlock (..))
-import System.IO.Unsafe (unsafePerformIO)
 
 -- Populating the Epoch table has two mode:
 --  * SyncLagging: when the node is far behind the chain tip and is just updating the DB. In this
 --    mode, the row for an epoch is only calculated and inserted when at the end of the epoch.
 --  * Following: When the node is at or close to the chain tip, the row for a given epoch is
 --    updated on each new block.
---
--- When in syncing mode, the row for the current epoch being synced may be incorrect.
-epochStartup :: Bool -> Trace IO Text -> SqlBackend -> IO ()
-epochStartup isExtended trce backend =
-  when isExtended $ do
-    DB.runDbIohkLogging backend trce $ do
-      liftIO . logInfo trce $ "epochStartup: Checking"
-      mlbe <- queryLatestEpochNo
-      case mlbe of
-        Nothing ->
-          pure ()
-        Just lbe -> do
-          let backOne = if lbe == 0 then 0 else lbe - 1
-          liftIO $ atomicWriteIORef latestCachedEpochVar (Just backOne)
 
-epochInsert :: Trace IO Text -> BlockDetails -> ReaderT SqlBackend (LoggingT IO) (Either SyncNodeError ())
-epochInsert trce (BlockDetails cblk details) = do
+epochHandler ::
+  SyncEnv ->
+  Trace IO Text ->
+  Cache ->
+  Bool ->
+  BlockDetails ->
+  ReaderT SqlBackend (LoggingT IO) (Either SyncNodeError ())
+epochHandler syncEnv trce cache isNewEpochEvent (BlockDetails cblk details) =
   case cblk of
     BlockByron bblk ->
       case byronBlockRaw bblk of
-        Byron.ABOBBoundary {} ->
+        Byron.ABOBBoundary {} -> do
           -- For the OBFT era there are no boundary blocks so we ignore them even in
-          -- the Ouroboros Classic era.
-          pure $ Right ()
+          -- the Ouroboros Classic era but count
+          updateEpochStart syncEnv cache details isNewEpochEvent True
         Byron.ABOBBlock _blk ->
-          insertBlock trce details
-    BlockShelley {} -> epochUpdate
-    BlockAllegra {} -> epochUpdate
-    BlockMary {} -> epochUpdate
-    BlockAlonzo {} -> epochUpdate
-    BlockBabbage {} -> epochUpdate
+          updateEpochStart syncEnv cache details isNewEpochEvent False
+    -- BlockByron {} -> updateEpochStart syncEnv cache details isNewEpochEvent
+    BlockShelley {} -> epochSlotTimecheck
+    BlockAllegra {} -> epochSlotTimecheck
+    BlockMary {} -> epochSlotTimecheck
+    BlockAlonzo {} -> epochSlotTimecheck
+    BlockBabbage {} -> epochSlotTimecheck
     BlockConway {} -> panic "TODO: Conway not supported yet"
   where
     -- What we do here is completely independent of Shelley/Allegra/Mary eras.
-    epochUpdate :: ReaderT SqlBackend (LoggingT IO) (Either SyncNodeError ())
-    epochUpdate = do
+    epochSlotTimecheck :: ReaderT SqlBackend (LoggingT IO) (Either SyncNodeError ())
+    epochSlotTimecheck = do
       when (sdSlotTime details > sdCurrentTime details) $
         liftIO . logError trce $
           mconcat
             ["Slot time '", textShow (sdSlotTime details), "' is in the future"]
-      insertBlock trce details
+      updateEpochStart syncEnv cache details isNewEpochEvent False
 
--- -------------------------------------------------------------------------------------------------
-
-insertBlock ::
-  Trace IO Text ->
+updateEpochStart ::
+  SyncEnv ->
+  Cache ->
   SlotDetails ->
+  Bool ->
+  Bool ->
   ReaderT SqlBackend (LoggingT IO) (Either SyncNodeError ())
-insertBlock trce details = do
-  mLatestCachedEpoch <- liftIO $ readIORef latestCachedEpochVar
-  let lastCachedEpoch = fromMaybe 0 mLatestCachedEpoch
-      epochNum = unEpochNo (sdEpochNo details)
-
-  -- These cases are listed from the least likey to occur to the most
-  -- likley to keep the logic sane.
+updateEpochStart syncEnv cache slotDetails isNewEpochEvent isBoundaryBlock = do
+  mLastMapEpochFromCache <- liftIO $ readLastMapEpochFromCache cache
+  mEpochBlockDiff <- liftIO $ readEpochBlockDiffFromCache cache
+  let curEpochNo = unEpochNo $ sdEpochNo slotDetails
 
   if
-      | epochNum > 0 && isNothing mLatestCachedEpoch ->
-          updateEpochNum 0 trce
-      | epochNum >= lastCachedEpoch + 2 ->
-          updateEpochNum (lastCachedEpoch + 1) trce
-      | getSyncStatus details == SyncFollowing ->
-          -- Following the chain very closely.
-          updateEpochNum epochNum trce
+      -- The tip has been reached so now replace/update the epoch every block.
+      | getSyncStatus slotDetails == SyncFollowing ->
+          handleEpochWhenFollowing syncEnv cache mLastMapEpochFromCache mEpochBlockDiff curEpochNo
+      -- When syncing we check if current block is the first block in an epoch.
+      -- If so then it's time to put the previous epoch into the DB.
+      | isNewEpochEvent ->
+          updateEpochWhenSyncing syncEnv cache mEpochBlockDiff mLastMapEpochFromCache curEpochNo isBoundaryBlock
+      -- we're syncing and the epochNo are the same so we just update the cache until above check passes.
       | otherwise ->
+          handleEpochCachingWhenSyncing
+            syncEnv
+            cache
+            mLastMapEpochFromCache
+            mEpochBlockDiff
+
+-----------------------------------------------------------------------------------------------------
+-- When Following
+-----------------------------------------------------------------------------------------------------
+
+-- When updating an epoch whilst following we have the opertunity to try and use the cacheEpoch values
+-- to calculate our epoch rather than querying the db which is expensive.
+handleEpochWhenFollowing ::
+  (MonadBaseControl IO m, MonadIO m) =>
+  SyncEnv ->
+  Cache ->
+  Maybe DB.Epoch ->
+  Maybe EpochBlockDiff ->
+  Word64 ->
+  ReaderT SqlBackend m (Either SyncNodeError ())
+handleEpochWhenFollowing syncEnv cache newestEpochFromMap epochBlockDiffCache epochNo = do
+  case newestEpochFromMap of
+    Just newestEpochFromMapache -> do
+      case epochBlockDiffCache of
+        Nothing -> pure $ Left $ NEError "replaceEpoch: No epochBlockDiffCache"
+        Just currentEpCache -> makeEpochWithCacheWhenFollowing syncEnv cache newestEpochFromMapache currentEpCache epochNo
+
+    -- If there isn't an epoch in cache, let's see if we can get one from the db. Otherwise
+    -- calculate the epoch using the expensive db query.
+    Nothing -> do
+      mNewestEpochFromDb <- DB.queryLatestEpoch
+      case mNewestEpochFromDb of
+        -- no latest epoch in db (very unlikely) so lets use expensive db query
+        Nothing -> do
+          makeEpochWithDBQuery syncEnv cache Nothing epochNo "handleEpochWhenFollowing"
+        Just newestEpochFromDb -> do
+          -- is the epoch from db different to current epochNo then we need to make expensive query
+          if DB.epochNo newestEpochFromDb /= epochNo
+            then makeEpochWithDBQuery syncEnv cache Nothing epochNo "handleEpochWhenFollowing"
+            else
+              case epochBlockDiffCache of
+                -- There should never be no EpochBlockDiff in cache at this point in the pipeline but just incase!
+                Nothing -> pure $ Left $ NEError "replaceEpoch: No epochBlockDiffCache"
+                -- Let's use both values aquired to calculate our new epoch.
+                Just currentEpCache -> makeEpochWithCacheWhenFollowing syncEnv cache newestEpochFromDb currentEpCache epochNo
+
+-- Update the epoch in cache and db, which could be either an update or insert
+-- dependent on if epoch already exists.
+makeEpochWithCacheWhenFollowing ::
+  (MonadBaseControl IO m, MonadIO m) =>
+  SyncEnv ->
+  Cache ->
+  DB.Epoch ->
+  EpochBlockDiff ->
+  Word64 ->
+  ReaderT SqlBackend m (Either SyncNodeError ())
+makeEpochWithCacheWhenFollowing syncEnv cache newestEpochFromMapache currentEpCache epochNo = do
+  let calculatedEpoch = calculateNewEpoch newestEpochFromMapache currentEpCache
+  -- if the epoch already exists then we update it otherwise create new entry.
+  mEpochID <- DB.queryForEpochId epochNo
+  case mEpochID of
+    Nothing -> do
+      _ <- writeToMapEpochCache syncEnv cache calculatedEpoch
+      (\_ -> Right ()) <$> DB.insertEpoch calculatedEpoch
+    Just epochId -> do
+      _ <- writeToMapEpochCache syncEnv cache calculatedEpoch
+      Right <$> replace epochId calculatedEpoch
+
+-----------------------------------------------------------------------------------------------------
+-- When Syncing
+-----------------------------------------------------------------------------------------------------
+
+-- This function is called once every epoch on the very first block of the new epoch.
+-- At that point we can get the previously accumilated data from previous epoch and insert/update it into the db.
+-- Whilst at the same time store the current block data into epoch cache.
+updateEpochWhenSyncing ::
+  (MonadBaseControl IO m, MonadIO m) =>
+  SyncEnv ->
+  Cache ->
+  Maybe EpochBlockDiff ->
+  Maybe DB.Epoch ->
+  Word64 ->
+  Bool ->
+  ReaderT SqlBackend m (Either SyncNodeError ())
+updateEpochWhenSyncing syncEnv cache mEpochBlockDiff mLastMapEpochFromCache epochNo isBoundaryBlock = do
+  let trce = getTrace syncEnv
+      -- make sure to count block if it's a boundary block
+      additionalBlockCount = if isBoundaryBlock then 1 else 0
+
+  case mEpochBlockDiff of
+    -- if the flag --disable-cahce is active then we won't have an EpochBlockDiff and instead want to
+    -- use expensive query to make the epoch.
+    Nothing -> pure $ Left $ NEError "updateEpochWhenSyncing: No mEpochBlockDiff"
+    Just epochBlockDiffCache ->
+      case mLastMapEpochFromCache of
+        -- if there is no Map Epoch in cache here, then the server must have restarted and failed on the last
+        -- block of the previous epoch and the current block is the first in new Epoch.
+        -- We must now use a db query to calculate and insert previous epoch as the cache for the epoch was lost.
+        Nothing -> do
+          let calculatedEpoch = initCalculateNewEpoch epochBlockDiffCache additionalBlockCount
+          _ <- makeEpochWithDBQuery syncEnv cache (Just calculatedEpoch) epochNo "updateEpochWhenSyncing"
           pure $ Right ()
+        -- simply use cache
+        Just lastMapEpochFromCache -> do
+          let calculatedEpoch = initCalculateNewEpoch epochBlockDiffCache additionalBlockCount
+          void $ writeToMapEpochCache syncEnv cache calculatedEpoch
+          mEpochID <- DB.queryForEpochId epochNo
+          case mEpochID of
+            Nothing -> do
+              liftIO . logInfo trce $ epochSucessMsg "Inserted" "updateEpochWhenSyncing" "Cache" lastMapEpochFromCache
+              _ <- DB.insertEpoch lastMapEpochFromCache
+              pure $ Right ()
+            Just epochId -> do
+              liftIO . logInfo trce $ epochSucessMsg "Replaced" "updateEpochWhenSyncing" "Cache" calculatedEpoch
+              Right <$> replace epochId calculatedEpoch
 
--- -------------------------------------------------------------------------------------------------
+-- When syncing, on every block we update the Map epoch in cache. Making sure to handle restarts
+handleEpochCachingWhenSyncing ::
+  (MonadBaseControl IO m, MonadIO m) =>
+  SyncEnv ->
+  Cache ->
+  Maybe DB.Epoch ->
+  Maybe EpochBlockDiff ->
+  ReaderT SqlBackend m (Either SyncNodeError ())
+handleEpochCachingWhenSyncing syncEnv cache newestEpochFromMap epochBlockDiffCache = do
+  case (newestEpochFromMap, epochBlockDiffCache) of
+    (Just newestEpMap, Just currentEpC) -> do
+      let calculatedEpoch = calculateNewEpoch newestEpMap currentEpC
+      writeToMapEpochCache syncEnv cache calculatedEpoch
+    -- when we don't have a newestEpochFromMap the server must have been restarted.
+    -- so we need to replenish the cache using expensive db query.
+    (Nothing, Just currentEpC) -> do
+      newEpoch <- DB.queryCalcEpochEntry $ ebdEpochNo currentEpC
+      writeToMapEpochCache syncEnv cache newEpoch
+    -- There will always be a EpochBlockDiff at this point in time
+    (_, _) -> pure $ Left $ NEError "handleEpochCachingWhenSyncing: No caches available to update cache"
 
-{-# NOINLINE latestCachedEpochVar #-}
-latestCachedEpochVar :: IORef (Maybe Word64)
-latestCachedEpochVar = unsafePerformIO $ newIORef Nothing -- Gets updated later.
+-----------------------------------------------------------------------------------------------------
+-- Helper functions
+-----------------------------------------------------------------------------------------------------
 
-updateEpochNum :: (MonadBaseControl IO m, MonadIO m) => Word64 -> Trace IO Text -> ReaderT SqlBackend m (Either SyncNodeError ())
-updateEpochNum epochNum trce = do
-  mid <- queryEpochId epochNum
-  res <- maybe insertEpoch updateEpoch mid
-  liftIO $ atomicWriteIORef latestCachedEpochVar (Just epochNum)
-  pure res
-  where
-    updateEpoch :: MonadIO m => EpochId -> ReaderT SqlBackend m (Either SyncNodeError ())
-    updateEpoch epochId = do
-      epoch <- DB.queryCalcEpochEntry epochNum
-      Right <$> replace epochId epoch
-
-    insertEpoch :: (MonadBaseControl IO m, MonadIO m) => ReaderT SqlBackend m (Either SyncNodeError ())
-    insertEpoch = do
-      epoch <- DB.queryCalcEpochEntry epochNum
-      liftIO . logInfo trce $ "epochPluginInsertBlockDetails: epoch " <> textShow epochNum
-      void $ DB.insertEpoch epoch
+-- This is an expensive DB query so we minimise it's use to
+-- server restarts when syncing or folloing and rollbacks
+makeEpochWithDBQuery ::
+  (MonadBaseControl IO m, MonadIO m) =>
+  SyncEnv ->
+  Cache ->
+  Maybe DB.Epoch ->
+  Word64 ->
+  Text ->
+  ReaderT SqlBackend m (Either SyncNodeError ())
+makeEpochWithDBQuery syncEnv cache mInitEpoch epochNo callSiteMsg = do
+  let trce = getTrace syncEnv
+  calcEpoch <- DB.queryCalcEpochEntry epochNo
+  mEpochID <- DB.queryForEpochId epochNo
+  let epochInitOrCalc = fromMaybe calcEpoch mInitEpoch
+  case mEpochID of
+    Nothing -> do
+      _ <- writeToMapEpochCache syncEnv cache epochInitOrCalc
+      _ <- DB.insertEpoch calcEpoch
+      liftIO . logInfo trce $ epochSucessMsg "Inserted " callSiteMsg "DB query" calcEpoch
       pure $ Right ()
+    Just epochId -> do
+      -- write the newly calculated epoch to cache.
+      _ <- writeToMapEpochCache syncEnv cache epochInitOrCalc
+      liftIO . logInfo trce $ epochSucessMsg "Replaced " callSiteMsg "DB query" calcEpoch
+      Right <$> replace epochId calcEpoch
 
--- -------------------------------------------------------------------------------------------------
+-- Because we store a Map of epochs, at every iteration we take the newest epoch and it's values
+-- We then add those to the data we kept when inserting the txs & block inside the EpochBlockDiff cache.
+calculateNewEpoch ::
+  DB.Epoch ->
+  EpochBlockDiff ->
+  DB.Epoch
+calculateNewEpoch newestEpochMapCache epochBlockDiffCache =
+  -- if the bellow doesn't equal, then it must be a the first block in new epoch thus we initiate the values.
+  -- rather than adding them to the newest epoch we have in the Map Epoch.
+  if DB.epochNo newestEpochMapCache == ebdEpochNo epochBlockDiffCache
+    then do
+      let newBlkCount = DB.epochBlkCount newestEpochMapCache + 1
+          newOutSum = DB.epochOutSum newestEpochMapCache + ebdOutSum epochBlockDiffCache
+          newFees = DB.unDbLovelace (DB.epochFees newestEpochMapCache) + ebdFees epochBlockDiffCache
+          newTxCount = fromIntegral (DB.epochTxCount newestEpochMapCache) + ebdTxCount epochBlockDiffCache
+          newEpochNo = ebdEpochNo epochBlockDiffCache
+          newStartTime = DB.epochStartTime newestEpochMapCache
+          newEndTime = ebdTime epochBlockDiffCache
+      DB.Epoch
+        { DB.epochOutSum = newOutSum
+        , DB.epochFees = DB.DbLovelace newFees
+        , DB.epochTxCount = fromIntegral newTxCount
+        , DB.epochBlkCount = fromIntegral newBlkCount
+        , DB.epochNo = newEpochNo
+        , DB.epochStartTime = newStartTime
+        , DB.epochEndTime = newEndTime
+        }
+    else initCalculateNewEpoch epochBlockDiffCache 0
 
--- | Get the PostgreSQL row index (EpochId) that matches the given epoch number.
-queryEpochId :: MonadIO m => Word64 -> ReaderT SqlBackend m (Maybe EpochId)
-queryEpochId epochNum = do
-  res <- select $ do
-    epoch <- from $ table @DB.Epoch
-    where_ (epoch ^. DB.EpochNo ==. val epochNum)
-    pure (epoch ^. EpochId)
-  pure $ unValue <$> listToMaybe res
+initCalculateNewEpoch :: EpochBlockDiff -> Word64 -> DB.Epoch
+initCalculateNewEpoch epochBlockDiffCache boundaryBlockcount =
+  DB.Epoch
+    { DB.epochOutSum = ebdOutSum epochBlockDiffCache
+    , DB.epochFees = DB.DbLovelace $ ebdFees epochBlockDiffCache
+    , DB.epochTxCount = ebdTxCount epochBlockDiffCache
+    , DB.epochBlkCount = 1 + boundaryBlockcount
+    , DB.epochNo = ebdEpochNo epochBlockDiffCache
+    , -- as this is the first block in epoch the end time and start time are the same
+      DB.epochStartTime = ebdTime epochBlockDiffCache
+    , DB.epochEndTime = ebdTime epochBlockDiffCache
+    }
 
--- | Get the epoch number of the most recent epoch in the Epoch table.
-queryLatestEpochNo :: MonadIO m => ReaderT SqlBackend m (Maybe Word64)
-queryLatestEpochNo = do
-  res <- select $ do
-    epoch <- from $ table @DB.Epoch
-    orderBy [desc (epoch ^. DB.EpochNo)]
-    limit 1
-    pure (epoch ^. DB.EpochNo)
-  pure $ unValue <$> listToMaybe res
+epochSucessMsg :: Text -> Text -> Text -> DB.Epoch -> Text
+epochSucessMsg insertOrReplace callSite cacheOrDB newEpoch =
+  mconcat
+    [ "\n"
+    , insertOrReplace
+    , " epoch "
+    , DB.textShow $ DB.epochNo newEpoch
+    , " from "
+    , callSite
+    , " with "
+    , cacheOrDB
+    , ". \n epoch: "
+    , DB.textShow newEpoch
+    ]

--- a/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
@@ -130,12 +130,11 @@ handleEpochWhenFollowing syncEnv cache newestEpochFromMap epochBlockDiffCache ep
           -- is the epoch from db different to current epochNo then we need to make expensive query
           if DB.epochNo newestEpochFromDb /= epochNo
             then makeEpochWithDBQuery syncEnv cache Nothing epochNo "handleEpochWhenFollowing"
-            else
-              case epochBlockDiffCache of
-                -- There should never be no EpochBlockDiff in cache at this point in the pipeline but just incase!
-                Nothing -> pure $ Left $ NEError "replaceEpoch: No epochBlockDiffCache"
-                -- Let's use both values aquired to calculate our new epoch.
-                Just currentEpCache -> makeEpochWithCacheWhenFollowing syncEnv cache newestEpochFromDb currentEpCache epochNo
+            else case epochBlockDiffCache of
+              -- There should never be no EpochBlockDiff in cache at this point in the pipeline but just incase!
+              Nothing -> pure $ Left $ NEError "replaceEpoch: No epochBlockDiffCache"
+              -- Let's use both values aquired to calculate our new epoch.
+              Just currentEpCache -> makeEpochWithCacheWhenFollowing syncEnv cache newestEpochFromDb currentEpCache epochNo
 
 -- Update the epoch in cache and db, which could be either an update or insert
 -- dependent on if epoch already exists.

--- a/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
@@ -183,7 +183,9 @@ updateEpochWhenSyncing syncEnv cache mEpochBlockDiff mLastMapEpochFromCache epoc
   case mEpochBlockDiff of
     -- if the flag --disable-cahce is active then we won't have an EpochBlockDiff and instead want to
     -- use expensive query to make the epoch.
-    Nothing -> pure $ Left $ NEError "updateEpochWhenSyncing: No mEpochBlockDiff"
+    Nothing -> do
+      newEpoch <- DB.queryCalcEpochEntry epochNo
+      writeToMapEpochCache syncEnv cache newEpoch
     Just epochBlockDiffCache ->
       case mLastMapEpochFromCache of
         -- if there is no Map Epoch in cache here, then the server must have restarted and failed on the last

--- a/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Epoch.hs
@@ -177,8 +177,9 @@ updateEpochWhenSyncing ::
   ReaderT SqlBackend m (Either SyncNodeError ())
 updateEpochWhenSyncing syncEnv cache mEpochBlockDiff mLastMapEpochFromCache epochNo isBoundaryBlock = do
   let trce = getTrace syncEnv
-      -- make sure to count block if it's a boundary block
-      additionalBlockCount = if isBoundaryBlock then 1 else 0
+      isFirstEpoch = epochNo == 0
+      -- count boundary block in the first epoch
+      additionalBlockCount = if isBoundaryBlock && isFirstEpoch then 1 else 0
 
   case mEpochBlockDiff of
     -- if the flag --disable-cahce is active then we won't have an EpochBlockDiff and instead want to

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Adjust.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Adjust.hs
@@ -9,9 +9,13 @@ module Cardano.DbSync.Era.Shelley.Adjust (
 
 import Cardano.BM.Trace (Trace, logInfo)
 import qualified Cardano.Db as Db
-import Cardano.DbSync.Cache
+import Cardano.DbSync.Cache (
+  queryPoolKeyWithCache,
+  queryStakeAddrWithCache,
+ )
+import Cardano.DbSync.Cache.Types (Cache, CacheNew (..))
 import qualified Cardano.DbSync.Era.Shelley.Generic.Rewards as Generic
-import Cardano.DbSync.Types
+import Cardano.DbSync.Types (StakeCred)
 import Cardano.Ledger.BaseTypes (Network)
 import Cardano.Prelude hiding (from, groupBy, on)
 import Cardano.Slotting.Slot (EpochNo (..))

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
@@ -15,7 +15,7 @@ import Cardano.BM.Trace (Trace, logError, logInfo)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
 import Cardano.DbSync.Api.Types (SyncEnv)
-import Cardano.DbSync.Cache
+import Cardano.DbSync.Cache.Types (Cache (..), uninitiatedCache)
 import qualified Cardano.DbSync.Era.Shelley.Generic.Util as Generic
 import Cardano.DbSync.Era.Shelley.Insert
 import Cardano.DbSync.Era.Util (liftLookupFail)

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -30,6 +30,7 @@ import qualified Cardano.Crypto.Hashing as Crypto
 import Cardano.Db (DbLovelace (..), DbWord64 (..), PoolUrl (..))
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (InsertOptions (..), SyncEnv (..))
 import Cardano.DbSync.Cache (
   insertBlockAndCache,
   insertDatumAndCache,
@@ -80,7 +81,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text.Encoding as Text
 import Database.Persist.Sql (SqlBackend)
 import Ouroboros.Consensus.Cardano.Block (StandardCrypto)
-import Cardano.DbSync.Api.Types (InsertOptions (..), SyncEnv (..))
 
 {- HLINT ignore "Reduce duplication" -}
 

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs
@@ -19,7 +19,8 @@ import Cardano.BM.Trace (Trace, logInfo)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
 import Cardano.DbSync.Api.Types (SyncEnv (..))
-import Cardano.DbSync.Cache
+import Cardano.DbSync.Cache (queryPoolKeyWithCache, queryStakeAddrWithCache)
+import Cardano.DbSync.Cache.Types (Cache, CacheNew (..))
 import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Util (liftLookupFail)
 import Cardano.DbSync.Error

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Grouped.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Grouped.hs
@@ -44,6 +44,8 @@ data BlockGroupedData = BlockGroupedData
   , groupedTxOut :: ![(ExtendedTxOut, [MissingMaTxOut])]
   , groupedTxMetadata :: ![DB.TxMetadata]
   , groupedTxMint :: ![DB.MaTxMint]
+  , groupedTxFees :: !Word64
+  , groupedTxOutSum :: !Word64
   }
 
 -- | While we collect data, we don't have access yet to the 'TxOutId', since
@@ -67,7 +69,7 @@ data ExtendedTxIn = ExtendedTxIn
   deriving (Show)
 
 instance Monoid BlockGroupedData where
-  mempty = BlockGroupedData [] [] [] []
+  mempty = BlockGroupedData [] [] [] [] 0 0
 
 instance Semigroup BlockGroupedData where
   tgd1 <> tgd2 =
@@ -76,6 +78,8 @@ instance Semigroup BlockGroupedData where
       (groupedTxOut tgd1 <> groupedTxOut tgd2)
       (groupedTxMetadata tgd1 <> groupedTxMetadata tgd2)
       (groupedTxMint tgd1 <> groupedTxMint tgd2)
+      (groupedTxFees tgd1 + groupedTxFees tgd2)
+      (groupedTxOutSum tgd1 + groupedTxOutSum tgd2)
 
 insertBlockGroupedData ::
   (MonadBaseControl IO m, MonadIO m) =>

--- a/cardano-db-sync/src/Cardano/DbSync/Ledger/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Ledger/Types.hs
@@ -18,7 +18,7 @@ import Cardano.DbSync.Types (
   CardanoBlock,
   CardanoInterpreter,
   PoolKeyHash,
-  SlotDetails,
+  SlotDetails, CardanoPoint,
  )
 import Cardano.Ledger.Alonzo.Scripts (Prices)
 import qualified Cardano.Ledger.BaseTypes as Ledger
@@ -136,3 +136,5 @@ newtype LedgerDB = LedgerDB
 instance Anchorable (WithOrigin SlotNo) CardanoLedgerState CardanoLedgerState where
   asAnchor = id
   getAnchorMeasure _ = getTipSlot . clsState
+
+data SnapshotPoint = OnDisk LedgerStateFile | InMemory CardanoPoint

--- a/cardano-db-sync/src/Cardano/DbSync/Sync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Sync.hs
@@ -32,11 +32,10 @@ import qualified Cardano.Crypto as Crypto
 import Cardano.Db (runDbIohkLogging)
 import qualified Cardano.Db as Db
 import Cardano.DbSync.Api
-import Cardano.DbSync.Api.Types (ConsistentLevel (..), FixesRan (..), RunMigration, SyncEnv, SyncOptions (..), envConnString, envLedgerEnv, envNetworkMagic, envOptions)
+import Cardano.DbSync.Api.Types (ConsistentLevel (..), FixesRan (..), RunMigration, SyncEnv, SyncOptions (..), envConnString, envLedgerEnv, envNetworkMagic, envOptions, LedgerEnv (..))
 import Cardano.DbSync.Config
 import Cardano.DbSync.Database
 import Cardano.DbSync.DbAction
-import Cardano.DbSync.Epoch
 import Cardano.DbSync.Era
 import Cardano.DbSync.Error
 import Cardano.DbSync.Fix.PlutusDataBytes
@@ -179,7 +178,6 @@ runSyncNode metricsSetters trce iomgr dbConnString ranMigrations runMigrationFnc
               logInfo trce "Migrating to a no ledger schema"
               Db.noLedgerMigrations backend trce
           lift $ orDie renderSyncNodeError $ insertValidateGenesisDist syncEnv (dncNetworkName syncNodeConfig) genCfg (useShelleyInit syncNodeConfig)
-          liftIO $ epochStartup (enpExtended syncNodeParams) trce backend
 
     case genCfg of
       GenesisCardano {} -> do

--- a/cardano-db-tool/src/Cardano/DbTool/PrepareSnapshot.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/PrepareSnapshot.hs
@@ -13,6 +13,7 @@ import Data.Version (makeVersion, showVersion, versionBranch)
 import Ouroboros.Network.Block hiding (blockHash)
 import Paths_cardano_db_tool (version)
 import System.Info (arch, os)
+import Cardano.DbSync.Ledger.Types (LedgerStateFile (..))
 
 newtype PrepareSnapshotArgs = PrepareSnapshotArgs
   { unPrepareSnapshotArgs :: LedgerStateDir

--- a/cardano-db-tool/src/Cardano/DbTool/Validate/Ledger.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/Validate/Ledger.hs
@@ -8,6 +8,7 @@ import Cardano.DbSync.Config
 import Cardano.DbSync.Config.Cardano
 import Cardano.DbSync.Error
 import Cardano.DbSync.Ledger.State
+import Cardano.DbSync.Ledger.Types (CardanoLedgerState (..), LedgerStateFile (..))
 import Cardano.DbSync.Tracing.ToObjectOrphans ()
 import Cardano.DbTool.Validate.Balance (ledgerAddrBalance)
 import Cardano.DbTool.Validate.Util

--- a/cardano-db/src/Cardano/Db/Query.hs
+++ b/cardano-db/src/Cardano/Db/Query.hs
@@ -28,7 +28,6 @@ module Cardano.Db.Query (
   queryLatestBlock,
   queryLatestPoints,
   queryLatestEpochNo,
-  queryEpochNoForLastTwoBlocks,
   queryLatestBlockId,
   queryLatestSlotNo,
   queryMeta,
@@ -498,17 +497,6 @@ queryLatestEpochNo = do
     limit 1
     pure (blk ^. BlockEpochNo)
   pure $ fromMaybe 0 (unValue =<< listToMaybe res)
-
--- return the epochNo for last 2 blocks
-queryEpochNoForLastTwoBlocks :: MonadIO m => ReaderT SqlBackend m [Word64]
-queryEpochNoForLastTwoBlocks = do
-  res <- select $ do
-    blk <- from $ table @Block
-    where_ (isJust $ blk ^. BlockSlotNo)
-    orderBy [desc (blk ^. BlockEpochNo)]
-    limit 2
-    pure (blk ^. BlockEpochNo)
-  pure $ [fromMaybe 0 (unValue x) | x <- res]
 
 -- | Get 'BlockId' of the latest block.
 queryLatestBlockId :: MonadIO m => ReaderT SqlBackend m (Maybe BlockId)


### PR DESCRIPTION
# Description
_This was originally https://github.com/input-output-hk/cardano-db-sync/pull/1380 but everything blew up when I tried to squash the commit history 😢_

This fixes https://github.com/input-output-hk/cardano-db-sync/issues/708 which introduces a Cache to minimise the expensive DB lookup / Calculations used when working out new Epoch which happens as a reaction to new Blocks being added and in following mode.

To achieve this we're keeping Epoch and last know blockId in cache. Then on each new lookup instead of calculating from zero we can do a lookup of only the blocks we are missing and add the results to our epoch in cache. Thus resulting in a new Epoch that can then both be updated in cache and db with minimal overhead.

This PR also includes "Disabling the epoch table when there is no cache".

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
