### PR TITLE
Allow to run docker with DISABLE_LEDGER (#1430)

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -150,10 +150,11 @@ for `docker` use `--workdir=`.
 
 Consult the configuration [docs](docs/configuration.md) for what these options mean, assuming you have read that
 they can be accessed via env variables passed to docker-compose. Leave out any that do not make sense, eg if
-you just want to disable the ledger use `EXTRA_DB_SYNC_ARGS=--disable-ledger docker-compose up`.
+you just want to disable the ledger use `DISABLE_LEDGER=Y docker-compose up`.
 
 ``` shell
-EXTRA_DB_SYNC_ARGS="--disable-ledger --disable-cache --disable-epoch" \
+DISABLE_LEDGER=Y \
+EXTRA_DB_SYNC_ARGS="--disable-cache --disable-epoch" \
 docker-compose up
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
   cardano-db-sync:
     image: inputoutput/cardano-db-sync:13.1.1.2
     environment:
+      - DISABLE_LEDGER=${DISABLE_LEDGER}
       - NETWORK=${NETWORK:-mainnet}
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -136,9 +136,13 @@ let
         set -euo pipefail
         ${scripts.mainnet.db-sync.passthru.service.restoreSnapshotScript}
 
-        exec $DBSYNC \
-          --schema-dir ${../schema} \
-          --state-dir ${scripts.mainnet.db-sync.passthru.service.stateDir} $@
+        if [[ "''${DISABLE_LEDGER:-N}" == "Y" ]]; then
+          LEDGER_OPTS="--disable-ledger"
+        else
+          LEDGER_OPTS="--state-dir ${scripts.mainnet.db-sync.passthru.service.stateDir}"
+        fi
+
+        exec $DBSYNC --schema-dir ${../schema} ''${LEDGER_OPTS} $@
       ${clusterStatements}
       else
         echo "Managed configuration for network "$NETWORK" does not exist"


### PR DESCRIPTION
# Description

Fixes #1430. This change allows users to pass an environment variable `DISABLE_LEDGER` to the docker container (and the NixOS module). If this flag is non-empty, it will pass `--disable-ledger` and omit the `--state-dir ...` option. 

Note that even when `services.cardano-db-sync.disableLedger` is true, `stateDir` is still defaulted and required, because we write `pgpass` there.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
