### PR TITLE
fourmolu everything

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Add your description here, if it fixes a particular issue please provide a [link
 - [ ] Commits have useful messages
 - [ ] New tests are added if needed and existing tests are updated
 - [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
-- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
+- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
 - [ ] Self-reviewed the diff
 
 # Migrations

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -6,6 +6,7 @@ The ``cardano-db-sync`` development is primarily based on the Nix infrastructure
 
 On how to set up Nix for ``cardano-db-sync`` development, please see `Building Cardano Node with nix <https://github.com/input-output-hk/cardano-node/tree/master/doc/getting-started/building-the-node-using-nix.md>`_.
 
+Our formater of choice is [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 We have a script `scripts/fourmolize.sh` that can be run once fourmolu is intalled locally.
 
 Roles and Responsibilities
 ==========================

--- a/cardano-chain-gen/Setup.hs
+++ b/cardano-chain-gen/Setup.hs
@@ -1,30 +1,30 @@
-
-import           Cardano.Crypto.Hash
-import           Control.Monad (foldM, forM)
+import Cardano.Crypto.Hash
+import Control.Monad (foldM, forM)
 
 import qualified Data.ByteString.Char8 as BS
 
 import qualified Data.List as List
 
-import           Distribution.PackageDescription (extraSrcFiles)
-import           Distribution.Simple (UserHooks (..), defaultMainWithHooks, simpleUserHooks)
-import           Distribution.Simple.BuildPaths (autogenPackageModulesDir)
-import           Distribution.Simple.LocalBuildInfo (LocalBuildInfo (..))
-import           Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFileEx)
-import           Distribution.Verbosity (normal)
+import Distribution.PackageDescription (extraSrcFiles)
+import Distribution.Simple (UserHooks (..), defaultMainWithHooks, simpleUserHooks)
+import Distribution.Simple.BuildPaths (autogenPackageModulesDir)
+import Distribution.Simple.LocalBuildInfo (LocalBuildInfo (..))
+import Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFileEx)
+import Distribution.Verbosity (normal)
 
-import           System.Directory (listDirectory)
-import           System.FilePath (pathSeparator, takeDirectory, takeExtension, takeFileName)
+import System.Directory (listDirectory)
+import System.FilePath (pathSeparator, takeDirectory, takeExtension, takeFileName)
 
 main :: IO ()
 main = defaultMainWithHooks generateHooks
   where
     generateHooks :: UserHooks
     generateHooks =
-      simple { buildHook   = \p l h f -> generate l >> buildHook simple p l h f
-             , haddockHook = \p l h f -> generate l >> haddockHook simple p l h f
-             , replHook    = \p l h f args -> generate l >> replHook simple p l h f args
-             }
+      simple
+        { buildHook = \p l h f -> generate l >> buildHook simple p l h f
+        , haddockHook = \p l h f -> generate l >> haddockHook simple p l h f
+        , replHook = \p l h f args -> generate l >> replHook simple p l h f args
+        }
 
     simple = simpleUserHooks
 
@@ -32,25 +32,25 @@ main = defaultMainWithHooks generateHooks
     generate locInfo =
       generateMigrations locInfo "schema" (autogenPackageModulesDir locInfo)
 
-
 generateMigrations :: LocalBuildInfo -> FilePath -> FilePath -> IO ()
 generateMigrations locInfo srcDir outDir = do
-    -- Given the migrationDirectories (usually just a single directory)
-    collectMigrationSql <- forM migrationDirectories $ \path -> do
-      fmap (\x -> path <> [pathSeparator] <> x ) <$> listDirectory path
+  -- Given the migrationDirectories (usually just a single directory)
+  collectMigrationSql <- forM migrationDirectories $ \path -> do
+    fmap (\x -> path <> [pathSeparator] <> x) <$> listDirectory path
 
-    createDirectoryIfMissingVerbose normal True "gen"
-    sqls <- forM (concat collectMigrationSql) build
-    buildMigrationModule $ List.sortOn snd sqls
+  createDirectoryIfMissingVerbose normal True "gen"
+  sqls <- forM (concat collectMigrationSql) build
+  buildMigrationModule $ List.sortOn snd sqls
   where
-
     -- Find directories listed in cabal file with *.sql extensions
     -- eg schema/*.sql
     --
     migrationDirectories :: [FilePath]
-    migrationDirectories = takeDirectory <$>
-      filter ((== ".sql") . takeExtension)
-      (extraSrcFiles $ localPkgDescr locInfo)
+    migrationDirectories =
+      takeDirectory
+        <$> filter
+          ((== ".sql") . takeExtension)
+          (extraSrcFiles $ localPkgDescr locInfo)
 
     hashAs :: ByteString -> Hash Blake2b_256 ByteString
     hashAs = hashWith id
@@ -60,32 +60,27 @@ generateMigrations locInfo srcDir outDir = do
       file <- BS.readFile filepath
       pure (hashToStringAsHex . hashAs $ file, takeFileName filepath)
 
-
     buildMigrationModule :: [(String, FilePath)] -> IO ()
     buildMigrationModule sqls =
-      let buildLine (hashedFile, filepath) = "    KnownMigration \"" ++ hashedFile ++ "\" \"" ++ filepath ++ "\"" in
-
-      rewriteFileEx normal "gen/MigrationValidations.hs" $
-        unlines
-          [ "{-# LANGUAGE OverloadedStrings #-}"
-          , "module MigrationValidations"
-          , "  ( KnownMigration (..)"
-          , "  , knownMigrations"
-          , "  ) where"
-          , ""
-          , "import Prelude"
-          , "import Data.Text"
-          , ""
-          , "data KnownMigration = KnownMigration"
-          , "  { hash :: !Text"
-          , "  , filepath :: !Text"
-          , "  } deriving (Eq, Show)"
-          , ""
-          , "knownMigrations :: [KnownMigration]"
-          , "knownMigrations = "
-          , "  [ " ++ (List.intercalate "\n  , " . fmap buildLine $ sqls)
-          , "  ]"
-          ]
-
-
-
+      let buildLine (hashedFile, filepath) = "    KnownMigration \"" ++ hashedFile ++ "\" \"" ++ filepath ++ "\""
+       in rewriteFileEx normal "gen/MigrationValidations.hs" $
+            unlines
+              [ "{-# LANGUAGE OverloadedStrings #-}"
+              , "module MigrationValidations"
+              , "  ( KnownMigration (..)"
+              , "  , knownMigrations"
+              , "  ) where"
+              , ""
+              , "import Prelude"
+              , "import Data.Text"
+              , ""
+              , "data KnownMigration = KnownMigration"
+              , "  { hash :: !Text"
+              , "  , filepath :: !Text"
+              , "  } deriving (Eq, Show)"
+              , ""
+              , "knownMigrations :: [KnownMigration]"
+              , "knownMigrations = "
+              , "  [ " ++ (List.intercalate "\n  , " . fmap buildLine $ sqls)
+              , "  ]"
+              ]

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Generic.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Generic.hs
@@ -108,7 +108,7 @@ resolveUTxOIndex index st = toLeft $ case index of
     toLeft (Just (txIn, txOut)) = Right ((txIn, txOut), UTxOInput txIn)
 
 resolveStakeCreds ::
-  (EraCrypto era ~ StandardCrypto) =>
+  EraCrypto era ~ StandardCrypto =>
   StakeIndex ->
   LedgerState (ShelleyBlock p era) ->
   Either ForgingError (StakeCredential StandardCrypto)
@@ -162,7 +162,7 @@ resolveStakeCreds indx st = case indx of
     toEither (Just a) = Right a
 
 resolvePool ::
-  (EraCrypto era ~ StandardCrypto) =>
+  EraCrypto era ~ StandardCrypto =>
   PoolIndex ->
   LedgerState (ShelleyBlock p era) ->
   KeyHash 'StakePool StandardCrypto

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Other.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Other.hs
@@ -43,7 +43,7 @@ import Control.Monad (forM_, void)
 import Data.Text (Text)
 import Ouroboros.Consensus.Cardano.Block (StandardCrypto)
 import Ouroboros.Network.Block (blockPoint)
-import Test.Cardano.Db.Mock.Config (getPoolLayer, startDBSync, stopDBSync, withFullConfig, babbageConfigDir)
+import Test.Cardano.Db.Mock.Config (babbageConfigDir, getPoolLayer, startDBSync, stopDBSync, withFullConfig)
 import Test.Cardano.Db.Mock.Examples (mockBlock0)
 import Test.Cardano.Db.Mock.UnifiedApi (
   fillEpochPercentage,

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Validate.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Validate.hs
@@ -208,7 +208,7 @@ assertCertCounts env expected =
       pure (registr - 5, deregistr, deleg - 5, withdrawal)
 
 assertRewardCounts ::
-  (EraCrypto era ~ StandardCrypto) =>
+  EraCrypto era ~ StandardCrypto =>
   DBSyncEnv ->
   LedgerState (ShelleyBlock p era) ->
   Bool ->

--- a/cardano-db-sync/Setup.hs
+++ b/cardano-db-sync/Setup.hs
@@ -1,34 +1,33 @@
-
-import           Cardano.Crypto.Hash
-import           Control.Monad (foldM, forM)
+import Cardano.Crypto.Hash
+import Control.Monad (foldM, forM)
 
 import qualified Data.ByteString.Char8 as BS
-import           Data.Char (isDigit)
+import Data.Char (isDigit)
 import qualified Data.List as List
-import           Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe)
 
-import           Distribution.PackageDescription (extraSrcFiles)
-import           Distribution.Simple (UserHooks (..), defaultMainWithHooks, simpleUserHooks)
-import           Distribution.Simple.BuildPaths (autogenPackageModulesDir)
-import           Distribution.Simple.LocalBuildInfo (LocalBuildInfo (..))
-import           Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFileEx)
-import           Distribution.Verbosity (normal)
+import Distribution.PackageDescription (extraSrcFiles)
+import Distribution.Simple (UserHooks (..), defaultMainWithHooks, simpleUserHooks)
+import Distribution.Simple.BuildPaths (autogenPackageModulesDir)
+import Distribution.Simple.LocalBuildInfo (LocalBuildInfo (..))
+import Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFileEx)
+import Distribution.Verbosity (normal)
 
-import           System.Directory (listDirectory)
-import           System.FilePath (pathSeparator, takeDirectory, takeExtension, takeFileName)
+import System.Directory (listDirectory)
+import System.FilePath (pathSeparator, takeDirectory, takeExtension, takeFileName)
 
-import           Text.Read (readMaybe)
-
+import Text.Read (readMaybe)
 
 main :: IO ()
 main = defaultMainWithHooks generateHooks
   where
     generateHooks :: UserHooks
     generateHooks =
-      simple { buildHook   = \p l h f -> generate l >> buildHook simple p l h f
-             , haddockHook = \p l h f -> generate l >> haddockHook simple p l h f
-             , replHook    = \p l h f args -> generate l >> replHook simple p l h f args
-             }
+      simple
+        { buildHook = \p l h f -> generate l >> buildHook simple p l h f
+        , haddockHook = \p l h f -> generate l >> haddockHook simple p l h f
+        , replHook = \p l h f args -> generate l >> replHook simple p l h f args
+        }
 
     simple = simpleUserHooks
 
@@ -36,28 +35,28 @@ main = defaultMainWithHooks generateHooks
     generate locInfo =
       generateMigrations locInfo "schema" (autogenPackageModulesDir locInfo)
 
-
 generateMigrations :: LocalBuildInfo -> FilePath -> FilePath -> IO ()
 generateMigrations locInfo srcDir outDir = do
-    -- Given the migrationDirectories (usually just a single directory)
-    collectMigrationSql <-
-      forM migrationDirectories $ \path -> do
-        fmap (\x -> path <> [pathSeparator] <> x )
-          . filter isOfficialMigrationFile
-          <$> listDirectory path
+  -- Given the migrationDirectories (usually just a single directory)
+  collectMigrationSql <-
+    forM migrationDirectories $ \path -> do
+      fmap (\x -> path <> [pathSeparator] <> x)
+        . filter isOfficialMigrationFile
+        <$> listDirectory path
 
-    createDirectoryIfMissingVerbose normal True "gen"
-    sqls <- forM (concat collectMigrationSql) build
-    buildMigrationModule $ List.sortOn snd sqls
+  createDirectoryIfMissingVerbose normal True "gen"
+  sqls <- forM (concat collectMigrationSql) build
+  buildMigrationModule $ List.sortOn snd sqls
   where
-
     -- Find directories listed in cabal file with *.sql extensions
     -- eg schema/*.sql
     --
     migrationDirectories :: [FilePath]
-    migrationDirectories = takeDirectory <$>
-      filter ((== ".sql") . takeExtension)
-      (extraSrcFiles $ localPkgDescr locInfo)
+    migrationDirectories =
+      takeDirectory
+        <$> filter
+          ((== ".sql") . takeExtension)
+          (extraSrcFiles $ localPkgDescr locInfo)
 
     hashAs :: ByteString -> Hash Blake2b_256 ByteString
     hashAs = hashWith id
@@ -67,38 +66,36 @@ generateMigrations locInfo srcDir outDir = do
       file <- BS.readFile filepath
       pure (hashToStringAsHex . hashAs $ file, takeFileName filepath)
 
-
     buildMigrationModule :: [(String, FilePath)] -> IO ()
     buildMigrationModule sqls =
-      let buildLine (hashedFile, filepath) = "KnownMigration \"" ++ hashedFile ++ "\" \"" ++ filepath ++ "\"" in
-
-      rewriteFileEx normal "gen/MigrationValidations.hs" $
-        unlines
-          [ "{-# LANGUAGE OverloadedStrings #-}"
-          , "module MigrationValidations"
-          , "  ( KnownMigration (..)"
-          , "  , knownMigrations"
-          , "  ) where"
-          , ""
-          , "import Prelude"
-          , "import Data.Text"
-          , ""
-          , "data KnownMigration = KnownMigration"
-          , "  { hash :: !Text"
-          , "  , filepath :: !Text"
-          , "  } deriving (Eq, Show)"
-          , ""
-          , "knownMigrations :: [KnownMigration]"
-          , "knownMigrations = "
-          , "  [ " ++ (List.intercalate "\n  , " . fmap buildLine $ sqls)
-          , "  ]"
-          ]
+      let buildLine (hashedFile, filepath) = "KnownMigration \"" ++ hashedFile ++ "\" \"" ++ filepath ++ "\""
+       in rewriteFileEx normal "gen/MigrationValidations.hs" $
+            unlines
+              [ "{-# LANGUAGE OverloadedStrings #-}"
+              , "module MigrationValidations"
+              , "  ( KnownMigration (..)"
+              , "  , knownMigrations"
+              , "  ) where"
+              , ""
+              , "import Prelude"
+              , "import Data.Text"
+              , ""
+              , "data KnownMigration = KnownMigration"
+              , "  { hash :: !Text"
+              , "  , filepath :: !Text"
+              , "  } deriving (Eq, Show)"
+              , ""
+              , "knownMigrations :: [KnownMigration]"
+              , "knownMigrations = "
+              , "  [ " ++ (List.intercalate "\n  , " . fmap buildLine $ sqls)
+              , "  ]"
+              ]
 
 -- We only care about "official" migrations, with a `mvStage` version >=1 and <= 4.
 isOfficialMigrationFile :: FilePath -> Bool
 isOfficialMigrationFile fn =
-    let stage = readStageFromFilename (takeFileName fn)
-     in takeExtension fn == ".sql" && stage >= 1 && stage <= 4
+  let stage = readStageFromFilename (takeFileName fn)
+   in takeExtension fn == ".sql" && stage >= 1 && stage <= 4
   where
     -- Reimplement part of `parseMigrationVersionFromFile` because that function is not avaliable
     -- here. Defaults to a stage value of `0`.

--- a/cardano-db-sync/src/Cardano/DbSync/Cache.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache.hs
@@ -65,7 +65,7 @@ import Ouroboros.Consensus.Cardano.Block (StandardCrypto)
 -- NOTE: BlockId is cleaned up on rollbacks, since it may get reinserted on
 -- a different id.
 -- NOTE: Other tables are not cleaned up since they are not rollbacked.
-rollbackCache :: (MonadIO m) => Cache -> DB.BlockId -> ReaderT SqlBackend m ()
+rollbackCache :: MonadIO m => Cache -> DB.BlockId -> ReaderT SqlBackend m ()
 rollbackCache UninitiatedCache _ = pure ()
 rollbackCache (Cache cache) blockId = do
   liftIO $ do
@@ -81,7 +81,7 @@ getCacheStatistics cs =
 
 queryRewardAccountWithCache ::
   forall m.
-  (MonadIO m) =>
+  MonadIO m =>
   Cache ->
   CacheNew ->
   Ledger.RewardAcnt StandardCrypto ->
@@ -91,7 +91,7 @@ queryRewardAccountWithCache cache cacheNew rwdAcc =
 
 queryRewardAccountWithCacheRetBs ::
   forall m.
-  (MonadIO m) =>
+  MonadIO m =>
   Cache ->
   CacheNew ->
   Ledger.RewardAcnt StandardCrypto ->
@@ -101,7 +101,7 @@ queryRewardAccountWithCacheRetBs cache cacheNew rwdAcc =
 
 queryStakeAddrWithCache ::
   forall m.
-  (MonadIO m) =>
+  MonadIO m =>
   Cache ->
   CacheNew ->
   Network ->
@@ -112,7 +112,7 @@ queryStakeAddrWithCache cache cacheNew nw cred =
 
 queryStakeAddrWithCacheRetBs ::
   forall m.
-  (MonadIO m) =>
+  MonadIO m =>
   Cache ->
   CacheNew ->
   Network ->
@@ -130,7 +130,7 @@ queryStakeAddrWithCacheRetBs cache cacheNew nw cred = do
       pure mAddrId
 
 queryStakeAddrAux ::
-  (MonadIO m) =>
+  MonadIO m =>
   CacheNew ->
   StakeAddrCache ->
   StrictTVar IO CacheStatistics ->
@@ -154,7 +154,7 @@ queryStakeAddrAux cacheNew mp sts nw cred =
         (err, _) -> pure (err, mp)
 
 queryPoolKeyWithCache ::
-  (MonadIO m) =>
+  MonadIO m =>
   Cache ->
   CacheNew ->
   PoolKeyHash ->
@@ -233,7 +233,7 @@ insertPoolKeyWithCache cache cacheNew pHash =
           pure phId
 
 queryMAWithCache ::
-  (MonadIO m) =>
+  MonadIO m =>
   Cache ->
   PolicyID StandardCrypto ->
   AssetName ->
@@ -262,7 +262,7 @@ queryMAWithCache cache policyId asset =
           pure maId
 
 queryPrevBlockWithCache ::
-  (MonadIO m) =>
+  MonadIO m =>
   Text ->
   Cache ->
   ByteString ->
@@ -283,7 +283,7 @@ queryPrevBlockWithCache msg cache hsh =
         Nothing -> queryFromDb ci
   where
     queryFromDb ::
-      (MonadIO m) =>
+      MonadIO m =>
       CacheInternal ->
       ExceptT SyncNodeError (ReaderT SqlBackend m) DB.BlockId
     queryFromDb ci = do
@@ -306,7 +306,7 @@ insertBlockAndCache cache block =
       pure bid
 
 queryDatum ::
-  (MonadIO m) =>
+  MonadIO m =>
   Cache ->
   DataHash ->
   ReaderT SqlBackend m (Maybe DB.DatumId)

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Epoch.hs
@@ -25,7 +25,7 @@ import Database.Persist.Postgresql (SqlBackend)
 -------------------------------------------------------------------------------------
 -- Epoch Cache
 -------------------------------------------------------------------------------------
-readCacheEpoch :: (MonadIO m) => Cache -> m (Maybe CacheEpoch)
+readCacheEpoch :: MonadIO m => Cache -> m (Maybe CacheEpoch)
 readCacheEpoch cache =
   case cache of
     UninitiatedCache -> pure Nothing
@@ -33,7 +33,7 @@ readCacheEpoch cache =
       cacheEpoch <- liftIO $ readTVarIO (cEpoch ci)
       pure $ Just cacheEpoch
 
-readEpochBlockDiffFromCache :: (MonadIO m) => Cache -> m (Maybe EpochBlockDiff)
+readEpochBlockDiffFromCache :: MonadIO m => Cache -> m (Maybe EpochBlockDiff)
 readEpochBlockDiffFromCache cache =
   case cache of
     UninitiatedCache -> pure Nothing
@@ -56,7 +56,7 @@ readLastMapEpochFromCache cache =
           Nothing -> pure Nothing
           Just (_, ep) -> pure $ Just ep
 
-rollbackMapEpochInCache :: (MonadIO m) => CacheInternal -> DB.BlockId -> m (Either SyncNodeError ())
+rollbackMapEpochInCache :: MonadIO m => CacheInternal -> DB.BlockId -> m (Either SyncNodeError ())
 rollbackMapEpochInCache cache blockId = do
   cE <- liftIO $ readTVarIO (cEpoch cache)
   -- split the map and delete anything after blockId including it self as new blockId might be
@@ -65,7 +65,7 @@ rollbackMapEpochInCache cache blockId = do
   writeToCache cache (CacheEpoch newMapEpoch (ceEpochBlockDiff cE))
 
 writeEpochBlockDiffToCache ::
-  (MonadIO m) =>
+  MonadIO m =>
   Cache ->
   EpochBlockDiff ->
   ReaderT SqlBackend m (Either SyncNodeError ())
@@ -81,7 +81,7 @@ writeEpochBlockDiffToCache cache epCurrent =
 -- | into the db. This is so we have a historic representation of an epoch after every block is inserted.
 -- | This becomes usefull when syncing and doing rollbacks and saves on expensive db queries to calculte an epoch.
 writeToMapEpochCache ::
-  (MonadIO m) =>
+  MonadIO m =>
   SyncEnv ->
   Cache ->
   DB.Epoch ->
@@ -117,7 +117,7 @@ writeToMapEpochCache syncEnv cache latestEpoch = do
 -- Helpers
 ------------------------------------------------------------------
 
-writeToCache :: (MonadIO m) => CacheInternal -> CacheEpoch -> m (Either SyncNodeError ())
+writeToCache :: MonadIO m => CacheInternal -> CacheEpoch -> m (Either SyncNodeError ())
 writeToCache ci newCacheEpoch = do
   void $ liftIO $ atomically $ writeTVar (cEpoch ci) newCacheEpoch
   pure $ Right ()

--- a/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Cache/Types.hs
@@ -167,7 +167,7 @@ textShowStats (Cache ic) = do
 uninitiatedCache :: Cache
 uninitiatedCache = UninitiatedCache
 
-newEmptyCache :: (MonadIO m) => Word64 -> Word64 -> m Cache
+newEmptyCache :: MonadIO m => Word64 -> Word64 -> m Cache
 newEmptyCache maCapacity daCapacity =
   liftIO . fmap Cache $
     CacheInternal

--- a/cardano-db-sync/src/Cardano/DbSync/Database.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Database.hs
@@ -15,10 +15,12 @@ module Cardano.DbSync.Database (
 
 import Cardano.BM.Trace (logDebug, logError, logInfo)
 import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (ConsistentLevel (..), LedgerEnv (..), SyncEnv (..))
 import Cardano.DbSync.DbAction
 import Cardano.DbSync.Default
 import Cardano.DbSync.Error
 import Cardano.DbSync.Ledger.State
+import Cardano.DbSync.Ledger.Types (CardanoLedgerState (..), SnapshotPoint (..))
 import Cardano.DbSync.Metrics
 import Cardano.DbSync.Rollback
 import Cardano.DbSync.Types
@@ -32,8 +34,6 @@ import Ouroboros.Consensus.HeaderValidation hiding (TipInfo)
 import Ouroboros.Consensus.Ledger.Extended
 import Ouroboros.Network.Block (Point (..))
 import Ouroboros.Network.Point (blockPointHash, blockPointSlot)
-import Cardano.DbSync.Api.Types (SyncEnv (..), ConsistentLevel (..), LedgerEnv (..))
-import Cardano.DbSync.Ledger.Types (CardanoLedgerState(..), SnapshotPoint (..))
 
 data NextState
   = Continue

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Genesis.hs
@@ -18,6 +18,7 @@ import qualified Cardano.Chain.UTxO as Byron
 import qualified Cardano.Crypto as Crypto
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (SyncEnv)
 import Cardano.DbSync.Config.Types
 import qualified Cardano.DbSync.Era.Byron.Util as Byron
 import Cardano.DbSync.Era.Util (liftLookupFail)
@@ -32,7 +33,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Database.Persist.Sql (SqlBackend)
 import Paths_cardano_db_sync (version)
-import Cardano.DbSync.Api.Types (SyncEnv)
 
 -- | Idempotent insert the initial Genesis distribution transactions into the DB.
 -- If these transactions are already in the DB, they are validated.

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ParamProposal.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ParamProposal.hs
@@ -61,7 +61,7 @@ data ParamProposal = ParamProposal
   , pppMaxCollateralInputs :: !(Maybe Natural)
   }
 
-convertParamProposal :: (EraCrypto era ~ StandardCrypto) => Witness era -> Shelley.Update era -> [ParamProposal]
+convertParamProposal :: EraCrypto era ~ StandardCrypto => Witness era -> Shelley.Update era -> [ParamProposal]
 convertParamProposal witness (Shelley.Update pp epoch) =
   case witness of
     Shelley {} -> shelleyParamProposal epoch pp

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Offline/Http.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Offline/Http.hs
@@ -95,13 +95,13 @@ httpGetPoolOfflineData manager request poolUrl mHash = do
                     ( "application/json"
                         `BS.isInfixOf` ct
                         || "text/plain"
-                        `BS.isInfixOf` ct
+                          `BS.isInfixOf` ct
                         || "binary/octet-stream"
-                        `BS.isInfixOf` ct
+                          `BS.isInfixOf` ct
                         || "application/octet-stream"
-                        `BS.isInfixOf` ct
+                          `BS.isInfixOf` ct
                         || "application/binary"
-                        `BS.isInfixOf` ct
+                          `BS.isInfixOf` ct
                     )
                     . left
                     $ FEBadContentType poolUrl (Text.decodeLatin1 ct)

--- a/cardano-db-sync/src/Cardano/DbSync/Ledger/State.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Ledger/State.hs
@@ -696,7 +696,7 @@ getRegisteredPools st =
 
 getRegisteredPoolShelley ::
   forall p era.
-  (EraCrypto era ~ StandardCrypto) =>
+  EraCrypto era ~ StandardCrypto =>
   LedgerState (ShelleyBlock p era) ->
   Set.Set PoolKeyHash
 getRegisteredPoolShelley lState =

--- a/cardano-db-sync/src/Cardano/DbSync/Ledger/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Ledger/Types.hs
@@ -17,8 +17,9 @@ import Cardano.DbSync.Ledger.Event (LedgerEvent)
 import Cardano.DbSync.Types (
   CardanoBlock,
   CardanoInterpreter,
+  CardanoPoint,
   PoolKeyHash,
-  SlotDetails, CardanoPoint,
+  SlotDetails,
  )
 import Cardano.Ledger.Alonzo.Scripts (Prices)
 import qualified Cardano.Ledger.BaseTypes as Ledger
@@ -28,10 +29,10 @@ import Cardano.Slotting.Slot (
   SlotNo (..),
   WithOrigin (..),
  )
-import Control.Concurrent.STM.TBQueue (TBQueue)
 import Control.Concurrent.Class.MonadSTM.Strict (
   StrictTVar,
  )
+import Control.Concurrent.STM.TBQueue (TBQueue)
 
 import qualified Data.Set as Set
 import qualified Data.Strict.Maybe as Strict

--- a/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Rollback.hs
@@ -11,6 +11,7 @@ module Cardano.DbSync.Rollback (
 import Cardano.BM.Trace (Trace, logInfo)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api
+import Cardano.DbSync.Api.Types (SyncEnv (..))
 import Cardano.DbSync.Cache
 import Cardano.DbSync.Era.Util
 import Cardano.DbSync.Error
@@ -23,12 +24,11 @@ import Database.Persist.Sql (SqlBackend)
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (getOneEraHash)
 import Ouroboros.Network.Block
 import Ouroboros.Network.Point
-import Cardano.DbSync.Api.Types (SyncEnv (..))
 
 -- Rollbacks are done in an Era generic way based on the 'Point' we are
 -- rolling back to.
 rollbackFromBlockNo ::
-  (MonadIO m) =>
+  MonadIO m =>
   SyncEnv ->
   BlockNo ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
@@ -62,7 +62,7 @@ prepareRollback syncEnv point serverTip = do
   where
     trce = getTrace syncEnv
 
-    action :: (MonadIO m) => ExceptT SyncNodeError (ReaderT SqlBackend m) Bool
+    action :: MonadIO m => ExceptT SyncNodeError (ReaderT SqlBackend m) Bool
     action = do
       case getPoint point of
         Origin -> do

--- a/cardano-db-sync/src/Cardano/DbSync/Sync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Sync.hs
@@ -32,7 +32,7 @@ import qualified Cardano.Crypto as Crypto
 import Cardano.Db (runDbIohkLogging)
 import qualified Cardano.Db as Db
 import Cardano.DbSync.Api
-import Cardano.DbSync.Api.Types (ConsistentLevel (..), FixesRan (..), RunMigration, SyncEnv, SyncOptions (..), envConnString, envLedgerEnv, envNetworkMagic, envOptions, LedgerEnv (..))
+import Cardano.DbSync.Api.Types (ConsistentLevel (..), FixesRan (..), LedgerEnv (..), RunMigration, SyncEnv, SyncOptions (..), envConnString, envLedgerEnv, envNetworkMagic, envOptions)
 import Cardano.DbSync.Config
 import Cardano.DbSync.Database
 import Cardano.DbSync.DbAction
@@ -334,12 +334,13 @@ dbSyncProtocols syncEnv metricsSetters _version codecs _connectionId =
                             (runOfflineFetchThread syncEnv)
                         )
                         ( race_
-                            (runPipelinedPeer
+                            ( runPipelinedPeer
                                 localChainSyncTracer
                                 (cChainSyncCodec codecs)
                                 channel
                                 ( chainSyncClientPeerPipelined $
-                                      chainSyncClient metricsSetters tracer (fst <$> latestPoints) currentTip actionQueue)
+                                    chainSyncClient metricsSetters tracer (fst <$> latestPoints) currentTip actionQueue
+                                )
                             )
                             (runLedgerStateWriteThread tracer (envLedgerEnv syncEnv))
                         )

--- a/cardano-db-tool/src/Cardano/DbTool/PrepareSnapshot.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/PrepareSnapshot.hs
@@ -6,6 +6,7 @@ module Cardano.DbTool.PrepareSnapshot (
 import Cardano.Db
 import Cardano.DbSync.Config.Types hiding (LogFileDir)
 import Cardano.DbSync.Ledger.State
+import Cardano.DbSync.Ledger.Types (LedgerStateFile (..))
 import Cardano.Prelude (Word64, fromMaybe)
 import Control.Monad
 import qualified Data.ByteString.Base16 as Base16
@@ -13,7 +14,6 @@ import Data.Version (makeVersion, showVersion, versionBranch)
 import Ouroboros.Network.Block hiding (blockHash)
 import Paths_cardano_db_tool (version)
 import System.Info (arch, os)
-import Cardano.DbSync.Ledger.Types (LedgerStateFile (..))
 
 newtype PrepareSnapshotArgs = PrepareSnapshotArgs
   { unPrepareSnapshotArgs :: LedgerStateDir

--- a/cardano-db/Setup.hs
+++ b/cardano-db/Setup.hs
@@ -1,2 +1,3 @@
-import           Distribution.Simple
+import Distribution.Simple
+
 main = defaultMain

--- a/cardano-db/src/Cardano/Db/Query.hs
+++ b/cardano-db/src/Cardano/Db/Query.hs
@@ -158,6 +158,7 @@ import Database.Esqueleto.Experimental (
   orderBy,
   persistIdField,
   select,
+  selectOne,
   subList_select,
   sum_,
   table,
@@ -174,7 +175,7 @@ import Database.Esqueleto.Experimental (
   (?.),
   (^.),
   (||.),
-  type (:&) ((:&)), selectOne,
+  type (:&) ((:&)),
  )
 import Database.Persist.Class.PersistQuery (selectList)
 import Database.Persist.Types (SelectOpt (Asc))
@@ -292,10 +293,10 @@ queryBlockId hash = do
   pure $ maybeToEither (DbLookupBlockHash hash) unValue (listToMaybe res)
 
 -----------------------------------------------------------------------------------------------
+
 -- | Calculate the Epoch table entry for the specified epoch.
 -- When syncing the chain or filling an empty table, this is called at each epoch boundary to
 -- calculate the Epoch entry for the last epoch.
-
 queryCalcEpochEntry :: MonadIO m => Word64 -> ReaderT SqlBackend m Epoch
 queryCalcEpochEntry epochNum = do
   blockResult <- select $ do
@@ -334,8 +335,8 @@ queryLatestEpoch = do
 queryTxWithBlocks ::
   MonadIO m =>
   Word64 ->
-  [(Value Word64, Value (Maybe UTCTime), Value (Maybe UTCTime))]
-  -> ReaderT SqlBackend m Epoch
+  [(Value Word64, Value (Maybe UTCTime), Value (Maybe UTCTime))] ->
+  ReaderT SqlBackend m Epoch
 queryTxWithBlocks epochNum blockResult = do
   txRes <- select $ do
     (tx :& blk) <-

--- a/cardano-smash-server/Setup.hs
+++ b/cardano-smash-server/Setup.hs
@@ -1,2 +1,3 @@
-import           Distribution.Simple
+import Distribution.Simple
+
 main = defaultMain

--- a/cardano-smash-server/src/Cardano/SMASH/Server/Api.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/Api.hs
@@ -150,9 +150,9 @@ smashApi :: Proxy SmashAPI
 smashApi = Proxy
 
 -- For now, we just ignore the @Body@ definition.
-instance (HasSwagger api) => HasSwagger (Body name :> api) where
+instance HasSwagger api => HasSwagger (Body name :> api) where
   toSwagger _ = toSwagger (Proxy :: Proxy api)
 
 -- For now, we just ignore the @BasicAuth@ definition.
-instance (HasSwagger api) => HasSwagger (BasicAuth name typo :> api) where
+instance HasSwagger api => HasSwagger (BasicAuth name typo :> api) where
   toSwagger _ = toSwagger (Proxy :: Proxy api)

--- a/cardano-smash-server/src/Cardano/SMASH/Server/FetchPolicies.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/FetchPolicies.hs
@@ -83,7 +83,7 @@ httpClientFetchPolicies smashURL = runExceptT $ do
   pure policyResult
 
 -- | A simple HTTP call for remote server.
-httpApiCall :: forall a. (FromJSON a) => Request -> ExceptT HttpClientError IO a
+httpApiCall :: forall a. FromJSON a => Request -> ExceptT HttpClientError IO a
 httpApiCall request = do
   httpResult <- httpJSONEither request
   let httpResponseBody = getResponseBody httpResult

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -11,4 +11,5 @@ let-style: auto
 in-style: right-align
 unicode: never
 respectful: true
+single-constraint-parens: never
 fixities: []


### PR DESCRIPTION
# Description

looks like most of the project was fourmolu-rised but `./cardano-chain-gen/` after running `fourmolu --mode inplace $(find . -name '*.hs')` in root directory.

Added `single-constraint-parens=never` to `fourmolu.yaml` file as the default in version 0.12 was changed to use `always` by default.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (which can be run with `scripts/fourmolize.sh`
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
