### PR TITLE
Remove cardano-chain-gen:test:cardano-chain-gen from macos required c…

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -154,16 +154,24 @@
 
         hydraJobs =
           let
-            nonRequiredPaths = [
-              ".*musl\\.devShells\\..*"
+            # TODO: macOS builders are resource-constrained and cannot run the detabase
+            # integration tests. Add these back when we get beefier builders.
+            nonRequiredMacOSPaths = [
+              "checks.cardano-chain-gen:test:cardano-chain-gen"
+              "ghc927.checks.cardano-chain-gen:test:cardano-chain-gen"
             ];
+
+            nonRequiredPaths =
+              if hostPlatform.isMacOS then
+                nonRequiredMacOSPaths
+              else [];
+
           in
           pkgs.callPackages iohkNix.utils.ciJobsAggregates
             {
               inherit ciJobs;
-              nonRequiredPaths = map (r: p: builtins.match r p != null) nonRequiredPaths;
+              nonRequiredPaths = map lib.hasPrefix nonRequiredPaths;
             } // ciJobs;
-
       }) // {
 
         # allows precise paths (avoid fallbacks) with nix build/eval:


### PR DESCRIPTION
# Description

Move MacOS database integration tests to "nonrequired" checks, since the macOS builders are too constrained to run postgres (apparently). We can update these if we get beefier runners.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
