### PR TITLE
Populate epoch_table earlier

### DIFF
--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -107,6 +107,7 @@ library
 
                         Cardano.DbSync.Rollback
 
+                        Cardano.DbSync.Fix.EpochStake
                         Cardano.DbSync.Fix.PlutusDataBytes
                         Cardano.DbSync.Fix.PlutusScripts
                         Cardano.DbSync.LocalStateQuery

--- a/cardano-db-sync/src/Cardano/DbSync/Default.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Default.hs
@@ -47,6 +47,7 @@ import Database.Persist.SqlBackend.Internal.StatementCache
 import Ouroboros.Consensus.Cardano.Block (HardForkBlock (..))
 import qualified Ouroboros.Consensus.HardFork.Combinator as Consensus
 import Ouroboros.Network.Block (blockHash, blockNo, getHeaderFields, headerFieldBlockNo, unBlockNo)
+import Cardano.DbSync.Fix.EpochStake
 
 insertListBlocks ::
   SyncEnv ->
@@ -82,6 +83,7 @@ applyAndInsertBlockMaybe syncEnv cblk = do
               , ". Time to restore consistency."
               ]
           rollbackFromBlockNo syncEnv (blockNo cblk)
+          void $ migrateStakeDistr syncEnv (apOldLedger applyRes)
           insertBlock syncEnv cblk applyRes True tookSnapshot
           liftIO $ setConsistentLevel syncEnv Consistent
         Right blockId | Just (adaPots, slotNo, epochNo) <- getAdaPots applyRes -> do

--- a/cardano-db-sync/src/Cardano/DbSync/DepositMap.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/DepositMap.hs
@@ -1,0 +1,15 @@
+module Cardano.DbSync.DepositsMap where
+
+import Data.ByteString (ByteString)
+import Data.Strict.Map (Map)
+import qualified Data.Strict.Map as Map
+import Cardano.Ledger.Coin
+
+newtype DepositsMap = DepositsMap {unDepositsMap :: Map ByteString Coin}
+
+lookup :: ByteString -> DepositsMap  -> Maybe Coin
+lookup bs = Map.lookup bs . unDepositsMap
+
+empty :: DepositsMap
+empty = DepositsMap Map.empty
+

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Block.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Block.hs
@@ -203,7 +203,7 @@ blockProtoVersionPraos :: ShelleyBlock PraosStandard era -> Ledger.ProtVer
 blockProtoVersionPraos = Praos.hbProtVer . getHeaderBodyPraos . blockHeader
 
 blockSize :: ProtocolHeaderSupportsEnvelope p => ShelleyBlock p era -> Word64
-blockSize = fromIntegral . pHeaderSize . blockHeader
+blockSize = fromIntegral . pHeaderBlockSize . blockHeader
 
 blockTxs ::
   ( ShelleyBasedEra era

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/StakeDist.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/StakeDist.hs
@@ -68,44 +68,51 @@ getSecurityParameter = maxRollbacks . configSecurityParam . pInfoConfig
 getStakeSlice ::
   ConsensusProtocol (BlockProtocol blk) =>
   ProtocolInfo IO blk ->
-  EpochNo ->
-  Word64 ->
   Word64 ->
   ExtLedgerState CardanoBlock ->
+  Bool ->
   StakeSliceRes
-getStakeSlice pInfo epoch !sliceIndex !minSliceSize els =
+getStakeSlice pInfo !epochBlockNo els isMigration =
   case ledgerState els of
     LedgerStateByron _ -> NoSlices
-    LedgerStateShelley sls -> genericStakeSlice pInfo epoch sliceIndex minSliceSize sls
-    LedgerStateAllegra als -> genericStakeSlice pInfo epoch sliceIndex minSliceSize als
-    LedgerStateMary mls -> genericStakeSlice pInfo epoch sliceIndex minSliceSize mls
-    LedgerStateAlonzo als -> genericStakeSlice pInfo epoch sliceIndex minSliceSize als
-    LedgerStateBabbage bls -> genericStakeSlice pInfo epoch sliceIndex minSliceSize bls
+    LedgerStateShelley sls -> genericStakeSlice pInfo epochBlockNo sls isMigration
+    LedgerStateAllegra als -> genericStakeSlice pInfo epochBlockNo als isMigration
+    LedgerStateMary mls -> genericStakeSlice pInfo epochBlockNo mls isMigration
+    LedgerStateAlonzo als -> genericStakeSlice pInfo epochBlockNo als isMigration
+    LedgerStateBabbage bls -> genericStakeSlice pInfo epochBlockNo bls isMigration
     LedgerStateConway _cls -> panic "TODO: Conway not supported yet"
 
 genericStakeSlice ::
   forall era c blk p.
   (c ~ StandardCrypto, EraCrypto era ~ c, ConsensusProtocol (BlockProtocol blk)) =>
   ProtocolInfo IO blk ->
-  EpochNo ->
-  Word64 ->
   Word64 ->
   LedgerState (ShelleyBlock p era) ->
+  Bool ->
   StakeSliceRes
-genericStakeSlice pInfo epoch sliceIndex minSliceSize lstate
+genericStakeSlice pInfo epochBlockNo lstate isMigration
   | index > delegationsLen = NoSlices
   | index == delegationsLen = Slice (emptySlice epoch) True
-  | index + epochSliceSize > delegationsLen = Slice (mkSlice (delegationsLen - index)) True
-  | otherwise = Slice (mkSlice epochSliceSize) False
+  | index + size > delegationsLen = Slice (mkSlice (delegationsLen - index)) True
+  | otherwise = Slice (mkSlice size) False
   where
-    -- We use 'ssStakeSet' here instead of 'ssStateMark' because the stake addresses for the
+    epoch :: EpochNo
+    epoch = 1 + Shelley.nesEL (Consensus.shelleyLedgerState lstate)
+
+    minSliceSize :: Word64
+    minSliceSize = 2000
+
+    -- On mainnet this is 2160
+    k :: Word64
+    k = getSecurityParameter pInfo
+
+    -- We use 'ssStakeMark' here instead of 'ssStateMark' because the stake addresses for the
     -- later may not have been added to the database yet. That means that when these values
     -- are added to the database, the epoch number where they become active is the current
     -- epoch plus one.
-
     stakeSnapshot :: Ledger.SnapShot c
     stakeSnapshot =
-      Ledger.ssStakeSet . Shelley.esSnapshots . Shelley.nesEs $
+      Ledger.ssStakeMark . Shelley.esSnapshots . Shelley.nesEs $
         Consensus.shelleyLedgerState lstate
 
     delegations :: VMap.KVVector VB VB (Credential 'Staking c, KeyHash 'StakePool c)
@@ -127,10 +134,6 @@ genericStakeSlice pInfo epoch sliceIndex minSliceSize lstate
     epochSliceSize =
       max minSliceSize defaultEpochSliceSize
       where
-        -- On mainnet this is 2160
-        k :: Word64
-        k = getSecurityParameter pInfo
-
         -- On mainnet this is 21600
         expectedBlocks :: Word64
         expectedBlocks = 10 * k
@@ -142,20 +145,29 @@ genericStakeSlice pInfo epoch sliceIndex minSliceSize lstate
 
     -- The starting index of the data in the delegation vector.
     index :: Word64
-    index = sliceIndex * epochSliceSize
+    index
+      | isMigration = 0
+      | epochBlockNo < k = 0
+      | otherwise = (epochBlockNo - k) * epochSliceSize
+
+    size :: Word64
+    size
+      | isMigration , epochBlockNo + 1 < k = 0
+      | isMigration = (epochBlockNo + 1 - k) * epochSliceSize
+      | otherwise = epochSliceSize
 
     mkSlice :: Word64 -> StakeSlice
-    mkSlice size =
+    mkSlice actualSize =
       StakeSlice
         { sliceEpochNo = epoch
         , sliceDistr = distribution
         }
       where
         delegationsSliced :: VMap VB VB (Credential 'Staking c) (KeyHash 'StakePool c)
-        delegationsSliced = VMap $ VG.slice (fromIntegral index) (fromIntegral size) delegations
+        delegationsSliced = VMap $ VG.slice (fromIntegral index) (fromIntegral actualSize) delegations
 
         distribution :: Map StakeCred (Coin, PoolKeyHash)
         distribution =
           VMap.toMap $
             VMap.mapMaybe id $
-              VMap.mapWithKey (\k p -> (,p) <$> lookupStake k) delegationsSliced
+              VMap.mapWithKey (\a p -> (,p) <$> lookupStake a) delegationsSliced

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Epoch.hs
@@ -45,6 +45,7 @@ insertStakeSlice _ Generic.NoSlices = pure ()
 insertStakeSlice syncEnv (Generic.Slice slice finalSlice) = do
   insertEpochStake (envCache syncEnv) network (Generic.sliceEpochNo slice) (Map.toList $ Generic.sliceDistr slice)
   when finalSlice $ do
+    lift $ DB.updateSetComplete $ unEpochNo $ Generic.sliceEpochNo slice
     size <- lift $ DB.queryEpochStakeCount (unEpochNo $ Generic.sliceEpochNo slice)
     liftIO . logInfo tracer $ mconcat ["Inserted ", show size, " EpochStake for ", show (Generic.sliceEpochNo slice)]
   where

--- a/cardano-db-sync/src/Cardano/DbSync/Fix/EpochStake.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Fix/EpochStake.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Cardano.DbSync.Fix.EpochStake where
+
+import Cardano.DbSync.Api
+import Cardano.DbSync.LedgerState
+import qualified Cardano.Db as DB
+import qualified Data.Map.Strict as Map
+import Cardano.DbSync.Era.Shelley.Generic.StakeDist hiding (getStakeSlice)
+import qualified Data.Strict.Maybe as Strict
+import Database.Persist.Sql (SqlBackend)
+import Cardano.Prelude
+import Cardano.BM.Trace (logInfo, logWarning)
+import Cardano.DbSync.Era.Shelley.Insert.Epoch
+import Cardano.DbSync.Error
+import Control.Monad.Trans.Control
+
+migrateStakeDistr :: (MonadIO m, MonadBaseControl IO m) => SyncEnv -> Strict.Maybe CardanoLedgerState -> ExceptT SyncNodeError (ReaderT SqlBackend m) Bool
+migrateStakeDistr env mcls =
+  case (envLedgerEnv env, mcls) of
+    (HasLedger lenv, Strict.Just cls) -> do
+      ems <- lift DB.queryAllExtraMigrations
+      runWhen (DB.isStakeDistrComplete ems) $ do
+        liftIO $ logInfo trce "Starting Stake Distribution migration on table epoch_stake"
+        let stakeSlice = getStakeSlice lenv cls True
+        case stakeSlice of
+          NoSlices ->
+            liftIO $ logInsert 0
+          Slice (StakeSlice _epochNo distr) isFinal -> do
+            liftIO $ logInsert (Map.size distr)
+            insertStakeSlice env stakeSlice
+            (mminEpoch, mmaxEpoch) <- lift DB.queryMinMaxEpochStake
+            liftIO $ logMinMax mminEpoch mmaxEpoch
+            case (mminEpoch, mmaxEpoch) of
+              (Just minEpoch, Just maxEpoch) -> do
+                lift $ DB.insertEpochStakeProgress (mkProgress True <$> [minEpoch..(maxEpoch-1)])
+                lift $ DB.insertEpochStakeProgress [mkProgress isFinal maxEpoch]
+              _ -> pure ()
+        lift $ DB.insertExtraMigration DB.StakeDistrEnded
+        liftIO $ logInfo trce "Starting Stake Distribution migration on table epoch_stake"
+    _ -> pure False
+  where
+    trce = getTrace env
+    mkProgress isCompleted e =
+      DB.EpochStakeProgress
+      { DB.epochStakeProgressEpochNo = e
+      , DB.epochStakeProgressCompleted = isCompleted
+      }
+
+    logInsert :: Int -> IO ()
+    logInsert n
+      | n == 0 = logInfo trce "No missing epoch_stake found"
+      | n > 100000 = logWarning trce $ "Found " <> DB.textShow n <> " epoch_stake. This may take a while"
+      | otherwise = logInfo trce $ "Found " <> DB.textShow n <> " epoch_stake"
+
+    logMinMax mmin mmax =
+      logInfo trce $ mconcat
+        [ "Min epoch_stake at "
+        ,  DB.textShow mmin
+        , " and max at "
+        , DB.textShow mmax
+        ]
+
+    runWhen :: Monad m => Bool -> m () -> m Bool
+    runWhen a action = do
+      if a then action >> pure True else pure False

--- a/cardano-db-sync/src/Cardano/DbSync/LedgerState.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/LedgerState.hs
@@ -27,6 +27,8 @@ module Cardano.DbSync.LedgerState (
   loadLedgerAtPoint,
   hashToAnnotation,
   getHeaderHash,
+  getStakeSlice,
+  getSliceMeta,
 ) where
 
 import Cardano.BM.Trace (Trace, logInfo, logWarning)
@@ -200,6 +202,7 @@ data ApplyResult = ApplyResult
   { apPrices :: !(Strict.Maybe Prices) -- prices after the block application
   , apPoolsRegistered :: !(Set.Set PoolKeyHash) -- registered before the block application
   , apNewEpoch :: !(Strict.Maybe Generic.NewEpoch) -- Only Just for a single block at the epoch boundary
+  , apOldLedger :: !(Strict.Maybe CardanoLedgerState)
   , apSlotDetails :: !SlotDetails
   , apStakeSlice :: !Generic.StakeSliceRes
   , apEvents :: ![LedgerEvent]
@@ -211,6 +214,7 @@ defaultApplyResult slotDetails =
     { apPrices = Strict.Nothing
     , apPoolsRegistered = Set.empty
     , apNewEpoch = Strict.Nothing
+    , apOldLedger = Strict.Nothing
     , apSlotDetails = slotDetails
     , apStakeSlice = Generic.NoSlices
     , apEvents = []
@@ -318,8 +322,9 @@ applyBlock env blk = do
             { apPrices = getPrices newState
             , apPoolsRegistered = getRegisteredPools oldState
             , apNewEpoch = maybeToStrict newEpoch
+            , apOldLedger = Strict.Just oldState
             , apSlotDetails = details
-            , apStakeSlice = stakeSlice newState details
+            , apStakeSlice = getStakeSlice env newState False
             , apEvents = ledgerEvents
             }
     pure (oldState, appResult)
@@ -354,20 +359,20 @@ applyBlock env blk = do
     applyToEpochBlockNo _ _ GenesisEpochBlockNo = EpochBlockNo 0
     applyToEpochBlockNo _ _ EBBEpochBlockNo = EpochBlockNo 0
 
-    stakeSliceMinSize :: Word64
-    stakeSliceMinSize = 2000
+getStakeSlice :: HasLedgerEnv -> CardanoLedgerState -> Bool -> Generic.StakeSliceRes
+getStakeSlice env cls isMigration =
+  case clsEpochBlockNo cls of
+    EpochBlockNo n ->
+      Generic.getStakeSlice
+        (leProtocolInfo env)
+        n
+        (clsState cls)
+        isMigration
+    _ -> Generic.NoSlices
 
-    stakeSlice :: CardanoLedgerState -> SlotDetails -> Generic.StakeSliceRes
-    stakeSlice cls details =
-      case clsEpochBlockNo cls of
-        EpochBlockNo n ->
-          Generic.getStakeSlice
-            (leProtocolInfo env)
-            (sdEpochNo details)
-            n
-            stakeSliceMinSize
-            (clsState cls)
-        _ -> Generic.NoSlices
+getSliceMeta :: Generic.StakeSliceRes -> Maybe (Bool, EpochNo)
+getSliceMeta (Generic.Slice (Generic.StakeSlice epochNo _) isFinal) = Just (isFinal, epochNo)
+getSliceMeta _ = Nothing
 
 storeSnapshotAndCleanupMaybe ::
   HasLedgerEnv ->

--- a/cardano-db/src/Cardano/Db/Query.hs
+++ b/cardano-db/src/Cardano/Db/Query.hs
@@ -51,6 +51,8 @@ module Cardano.Db.Query (
   existsPoolMetadataRefId,
   queryAdaPotsId,
   queryBlockHeight,
+  queryAllExtraMigrations,
+  queryMinMaxEpochStake,
   -- queries used in smash
   queryPoolOfflineData,
   queryPoolRegister,
@@ -121,7 +123,7 @@ import Data.ByteString.Char8 (ByteString)
 import Data.Fixed (Micro)
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Ratio (numerator)
-import Data.Text (Text)
+import Data.Text (Text, unpack)
 import Data.Time.Clock (UTCTime (..))
 import Data.Tuple.Extra (uncurry3)
 import Data.Word (Word64)
@@ -690,6 +692,27 @@ queryBlockHeight = do
     limit 1
     pure (blk ^. BlockBlockNo)
   pure $ unValue =<< listToMaybe res
+
+queryAllExtraMigrations :: MonadIO m => ReaderT SqlBackend m [ExtraMigration]
+queryAllExtraMigrations = do
+  res <- select $ do
+    ems <- from $ table @ExtraMigrations
+    pure (ems ^. ExtraMigrationsToken)
+  pure $  read . unpack . unValue <$> res
+
+queryMinMaxEpochStake :: MonadIO m => ReaderT SqlBackend m (Maybe Word64, Maybe Word64)
+queryMinMaxEpochStake = do
+  maxEpoch <- select $ do
+    es <- from $ table @EpochStake
+    orderBy [desc (es ^. EpochStakeId)]
+    limit 1
+    pure (es ^. EpochStakeEpochNo)
+  minEpoch <- select $ do
+    es <- from $ table @EpochStake
+    orderBy [asc (es ^. EpochStakeId)]
+    limit 1
+    pure (es ^. EpochStakeEpochNo)
+  pure (unValue <$> listToMaybe minEpoch, unValue <$> listToMaybe maxEpoch)
 
 {--------------------------------------------
   Queries use in SMASH

--- a/cardano-db/src/Cardano/Db/Schema.hs
+++ b/cardano-db/src/Cardano/Db/Schema.hs
@@ -323,6 +323,11 @@ share
     epochNo             Word64              sqltype=word31type
     UniqueStake         epochNo addrId poolId
 
+  EpochStakeProgress
+    epochNo             Word64              sqltype=word31type
+    completed           Bool
+    UniqueEpochStakeProgress epochNo
+
   Treasury
     addrId              StakeAddressId      noreference
     certIndex           Word16
@@ -483,6 +488,10 @@ share
     hash                ByteString          sqltype=hash32type
     costs               Text                sqltype=jsonb
     UniqueCostModel     hash
+
+  ExtraMigrations
+    token               Text
+    description         Text Maybe
 
   -- -----------------------------------------------------------------------------------------------
   -- Pool offline (ie not on the blockchain) data.

--- a/cardano-db/src/Cardano/Db/Types.hs
+++ b/cardano-db/src/Cardano/Db/Types.hs
@@ -19,6 +19,9 @@ module Cardano.Db.Types (
   PoolCertAction (..),
   CertNo (..),
   PoolCert (..),
+  ExtraMigration (..),
+  isStakeDistrComplete,
+  extraDescription,
   deltaCoinToDbInt65,
   integerToDbInt65,
   lovelaceToAda,
@@ -158,6 +161,18 @@ data PoolCert = PoolCert
   , pcCertNo :: !CertNo
   }
   deriving (Eq, Show)
+
+data ExtraMigration =
+  StakeDistrEnded
+  deriving (Eq, Show, Read)
+
+isStakeDistrComplete :: [ExtraMigration] -> Bool
+isStakeDistrComplete = elem StakeDistrEnded
+
+extraDescription :: ExtraMigration -> Text
+extraDescription StakeDistrEnded =
+  "The epoch_stake table has been migrated. It is now populated earlier during the previous era. \
+  \Also the epoch_stake_progress table is introduced."
 
 instance Ord PoolCert where
   compare a b = compare (pcCertNo a) (pcCertNo b)

--- a/schema/migration-2-0026-20230713.sql
+++ b/schema/migration-2-0026-20230713.sql
@@ -1,0 +1,21 @@
+-- Persistent generated migration.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 26 THEN
+    EXECUTE 'CREATe TABLE "epoch_stake_progress"("id" SERIAL8  PRIMARY KEY UNIQUE,"epoch_no" word31type NOT NULL,"completed" BOOLEAN NOT NULL)' ;
+    EXECUTE 'ALTER TABLE "epoch_stake_progress" ADD CONSTRAINT "unique_epoch_stake_progress" UNIQUE("epoch_no")' ;
+    EXECUTE 'CREATe TABLE "extra_migrations"("id" SERIAL8  PRIMARY KEY UNIQUE,"token" VARCHAR NOT NULL,"description" VARCHAR NULL)' ;
+    -- Hand written SQL statements can be added here.
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/cardano-db-sync/issues/1406
This populates the table `epoch_stake` earlier. It starts k blocks after the start of the previous epoch than it does now. It also adds an `epoch_stake_progress` table which shows if the insertions are completed.

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [x] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type ~a,~ b ~or c~
- [x] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [x] Resyncing and running the migrations provided will result in the same database semantically

A migrations is added with an adjusting procedure. On an upgrade this procedure will insert the missing entries that should have been inserted earlier.