### PR TITLE
Add a CI fourmolu check

### DIFF
--- a/.github/workflows/check-fourmolu.yml
+++ b/.github/workflows/check-fourmolu.yml
@@ -1,0 +1,21 @@
+name: Check Fourmolu
+
+on:
+  push: {}
+  merge_group: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run fourmolu
+        uses: haskell-actions/run-fourmolu@v9
+        with:
+          version: "0.10.1.0"

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -1,0 +1,32 @@
+name: Check HLint
+
+on:
+  push: {}
+  merge_group: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: sudo apt-get -y install libtinfo5
+
+      - name: Set up HLint
+        uses: rwe/actions-hlint-setup@v1
+        with:
+          version: "3.2.7"
+
+      - name: Run HLint
+        uses: rwe/actions-hlint-run@v2
+        with:
+          path: "."
+          fail-on: error
+
+

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
         inputs.customConfig;
 
       overlays = [
-        # crypto needs to come before hasell.nix. 
+        # crypto needs to come before haskell.nix.
         # FIXME: _THIS_IS_BAD_
         iohkNix.overlays.crypto
         haskellNix.overlay
@@ -138,6 +138,8 @@
           crossPlatforms = p:
             lib.optional hostPlatform.isLinux p.musl64;
         }).ciJobs ({
+          inherit hlint fourmolu;
+
           packages = {
             inherit scripts;
             inherit (pkgs) cardano-node cardano-smash-server-no-basic-auth checkCabalProject;
@@ -146,7 +148,6 @@
           inherit (pkgs) dockerImage;
           checks = {
             inherit nixosTests;
-            inherit hlint;
           };
           cardano-db-sync-linux = import ./nix/binary-release.nix {
             inherit pkgs project;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -10,6 +10,10 @@ in {
     modules = [{packages.cardano-smash-server.flags.disable-basic-auth = true;}];
   }).exes.cardano-smash-server;
 
+  haskell-language-server = haskell-nix.tool compiler "haskell-language-server" {
+    src = haskell-nix.sources."hls-1.10";
+  };
+
   hlint = haskell-nix.tool compiler "hlint" {
     version = "3.2.7";
   };


### PR DESCRIPTION
# Description

Fixes #1439. Added:

 * Fourmolu/Hlint checks to nix
 * Fourmolu/Hlint checks to GitHub workflows

Note that fourmolu 0.10.1.0 requires ghc-9.2, so we have to duplicate the compiler variants. `compiler-nix-name` and `flake.variants` have been lifted to `flake.nix` as `defaultCompiler` and `extraCompilers`. The duplication still exists, but this will at least allow us to keep them close together.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
