### PR TITLE
Set database integration tests nonrequired for macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -158,7 +158,9 @@
             # integration tests. Add these back when we get beefier builders.
             nonRequiredMacOSPaths = [
               "checks.cardano-chain-gen:test:cardano-chain-gen"
+              "checks.cardano-db:test:test-db"
               "ghc927.checks.cardano-chain-gen:test:cardano-chain-gen"
+              "ghc927.checks.cardano-db:test:test-db"
             ];
 
             nonRequiredPaths =


### PR DESCRIPTION
# Description

Our builders don't seem to have enough memory to run postgres, so we mark those tests as nonrequired.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
