### PR TITLE
fix: Hardcode Byron software version

### DIFF
--- a/cardano-chain-gen/test/testfiles/config-alonzo/test-config.json
+++ b/cardano-chain-gen/test/testfiles/config-alonzo/test-config.json
@@ -1,8 +1,6 @@
 {
   "AlonzoGenesisFile": "genesis.alonzo.json",
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 0,
   "ByronGenesisFile": "genesis.byron.json",
   "ByronGenesisHash": "865a9da19944fc00cefe5a0cdcb6dc9d3964a74681d9488ab79967f13a6400b3",
   "LastKnownBlockVersion-Alt": 0,

--- a/cardano-chain-gen/test/testfiles/config-hf-epoch1/test-config.json
+++ b/cardano-chain-gen/test/testfiles/config-hf-epoch1/test-config.json
@@ -1,8 +1,6 @@
 {
   "AlonzoGenesisFile": "genesis.alonzo.json",
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 0,
   "ByronGenesisFile": "genesis.byron.json",
   "ByronGenesisHash": "865a9da19944fc00cefe5a0cdcb6dc9d3964a74681d9488ab79967f13a6400b3",
   "LastKnownBlockVersion-Alt": 0,

--- a/cardano-chain-gen/test/testfiles/config-shelley/test-config.json
+++ b/cardano-chain-gen/test/testfiles/config-shelley/test-config.json
@@ -1,8 +1,6 @@
 {
   "AlonzoGenesisFile": "genesis.alonzo.json",
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 0,
   "ByronGenesisFile": "genesis.byron.json",
   "ByronGenesisHash": "462bb9869a5a6e4325cc294ca659d68607e8a6f37b5be96ea663fdedfe2b5949",
   "LastKnownBlockVersion-Alt": 0,

--- a/cardano-chain-gen/test/testfiles/config/test-config.json
+++ b/cardano-chain-gen/test/testfiles/config/test-config.json
@@ -1,8 +1,6 @@
 {
   "AlonzoGenesisFile": "genesis.alonzo.json",
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 0,
   "ByronGenesisFile": "genesis.byron.json",
   "ByronGenesisHash": "865a9da19944fc00cefe5a0cdcb6dc9d3964a74681d9488ab79967f13a6400b3",
   "LastKnownBlockVersion-Alt": 0,

--- a/cardano-chain-gen/test/testfiles/config2/test-config.json
+++ b/cardano-chain-gen/test/testfiles/config2/test-config.json
@@ -1,8 +1,6 @@
 {
   "AlonzoGenesisFile": "genesis.alonzo.json",
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 0,
   "ByronGenesisFile": "genesis.byron.json",
   "ByronGenesisHash": "d004b9e1a42b7329e52a112c8c006e6261e887013309afeca611f049f96cecd4",
   "LastKnownBlockVersion-Alt": 0,

--- a/cardano-chain-gen/test/testfiles/config3/test-config.json
+++ b/cardano-chain-gen/test/testfiles/config3/test-config.json
@@ -1,8 +1,6 @@
 {
   "AlonzoGenesisFile": "genesis.alonzo.json",
   "AlonzoGenesisHash": "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874",
-  "ApplicationName": "cardano-sl",
-  "ApplicationVersion": 0,
   "ByronGenesisFile": "genesis.byron.json",
   "ByronGenesisHash": "d004b9e1a42b7329e52a112c8c006e6261e887013309afeca611f049f96cecd4",
   "LastKnownBlockVersion-Alt": 0,

--- a/cardano-db-sync/src/Cardano/DbSync/Config.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config.hs
@@ -86,7 +86,6 @@ coalesceConfig pcfg ncfg adjustGenesisPath = do
       , dncShelleyGenesisHash = ncShelleyGenesisHash ncfg
       , dncAlonzoGenesisFile = adjustGenesisFilePath adjustGenesisPath (ncAlonzoGenesisFile ncfg)
       , dncAlonzoGenesisHash = ncAlonzoGenesisHash ncfg
-      , dncByronSoftwareVersion = ncByronSotfwareVersion ncfg
       , dncByronProtocolVersion = ncByronProtocolVersion ncfg
       , dncShelleyHardFork = ncShelleyHardFork ncfg
       , dncAllegraHardFork = ncAllegraHardFork ncfg

--- a/cardano-db-sync/src/Cardano/DbSync/Config/Cardano.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config/Cardano.hs
@@ -14,6 +14,7 @@ module Cardano.DbSync.Config.Cardano (
 ) where
 
 import qualified Cardano.Chain.Genesis as Byron
+import Cardano.Chain.Update (ApplicationName (..), SoftwareVersion (..))
 import qualified Cardano.Crypto.Hash.Class as Crypto
 import Cardano.Crypto.ProtocolMagic (ProtocolMagicId (..))
 import Cardano.Db (textShow)
@@ -92,7 +93,7 @@ mkProtocolInfoCardano ge shelleyCred =
           { Consensus.byronGenesis = byronGenesis
           , Consensus.byronPbftSignatureThreshold = Consensus.PBftSignatureThreshold <$> dncPBftSignatureThreshold dnc
           , Consensus.byronProtocolVersion = dncByronProtocolVersion dnc
-          , Consensus.byronSoftwareVersion = dncByronSoftwareVersion dnc
+          , Consensus.byronSoftwareVersion = mkByronSoftwareVersion
           , Consensus.byronLeaderCredentials = Nothing
           , Consensus.byronMaxTxCapacityOverrides = TxLimits.mkOverrides TxLimits.noOverridesMeasure
           }
@@ -140,3 +141,10 @@ mkProtVer a b =
   case mkVersion64 a of
     Nothing -> panic $ "Impossible: Invalid version generated: " <> textShow a
     Just v -> ProtVer v (fromIntegral b)
+
+mkByronSoftwareVersion :: SoftwareVersion
+mkByronSoftwareVersion =
+  SoftwareVersion name ver
+  where
+    name = ApplicationName "cardano-sl"
+    ver = 1

--- a/cardano-db-sync/src/Cardano/DbSync/Config/Node.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config/Node.hs
@@ -34,7 +34,6 @@ data NodeConfig = NodeConfig
   , ncAlonzoGenesisFile :: !GenesisFile
   , ncAlonzoGenesisHash :: !GenesisHashAlonzo
   , ncRequiresNetworkMagic :: !RequiresNetworkMagic
-  , ncByronSotfwareVersion :: !Byron.SoftwareVersion
   , ncByronProtocolVersion :: !Byron.ProtocolVersion
   , -- Shelley hardfok parameters
     ncShelleyHardFork :: !Shelley.TriggerHardFork
@@ -72,7 +71,6 @@ instance FromJSON NodeConfig where
           <*> fmap GenesisFile (o .: "AlonzoGenesisFile")
           <*> fmap GenesisHashAlonzo (o .: "AlonzoGenesisHash")
           <*> o .: "RequiresNetworkMagic"
-          <*> parseByronSoftwareVersion o
           <*> parseByronProtocolVersion o
           <*> parseShelleyHardForkEpoch o
           <*> parseAllegraHardForkEpoch o
@@ -86,12 +84,6 @@ instance FromJSON NodeConfig where
           <$> o .: "LastKnownBlockVersion-Major"
           <*> o .: "LastKnownBlockVersion-Minor"
           <*> o .: "LastKnownBlockVersion-Alt"
-
-      parseByronSoftwareVersion :: Object -> Parser Byron.SoftwareVersion
-      parseByronSoftwareVersion o =
-        Byron.SoftwareVersion
-          <$> fmap Byron.ApplicationName (o .: "ApplicationName")
-          <*> o .: "ApplicationVersion"
 
       parseShelleyHardForkEpoch :: Object -> Parser Shelley.TriggerHardFork
       parseShelleyHardForkEpoch o =

--- a/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
@@ -99,7 +99,6 @@ data SyncNodeConfig = SyncNodeConfig
   , dncShelleyGenesisHash :: !GenesisHashShelley
   , dncAlonzoGenesisFile :: !GenesisFile
   , dncAlonzoGenesisHash :: !GenesisHashAlonzo
-  , dncByronSoftwareVersion :: !Byron.SoftwareVersion
   , dncByronProtocolVersion :: !Byron.ProtocolVersion
   , dncShelleyHardFork :: !TriggerHardFork
   , dncAllegraHardFork :: !TriggerHardFork


### PR DESCRIPTION
# Description

Cardano Node no longer provides this as configuration. Fixes #1473 

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
