### PR TITLE
Fix Hydra failures

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -21,6 +21,9 @@ packages:
   cardano-smash-server
   cardano-chain-gen
 
+package cardano-chain-gen
+  ghc-options: -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wunused-imports
+
 package cardano-db
   ghc-options: -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wunused-imports -Wunused-packages
 

--- a/cabal.project
+++ b/cabal.project
@@ -22,7 +22,7 @@ packages:
   cardano-chain-gen
 
 package cardano-chain-gen
-  ghc-options: -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wunused-imports
+  ghc-options: -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wunused-imports -Wunused-packages
 
 package cardano-db
   ghc-options: -Wall -Werror -Wredundant-constraints -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wunused-imports -Wunused-packages

--- a/cardano-chain-gen/cardano-chain-gen.cabal
+++ b/cardano-chain-gen/cardano-chain-gen.cabal
@@ -30,12 +30,14 @@ library
   hs-source-dirs:       src
 
   ghc-options:          -Wall
+                        -Werror
                         -Wcompat
-                        -fwarn-redundant-constraints
-                        -fwarn-incomplete-patterns
-                        -fwarn-unused-imports
+                        -Wredundant-constraints
+                        -Wincomplete-patterns
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
+                        -Wunused-imports
+                        -Wunused-packages
 
   exposed-modules:
                         Cardano.Mock.Chain
@@ -56,49 +58,26 @@ library
   build-depends:        base                            >= 4.14         && < 5
                       , async
                       , aeson
-                      , binary
                       , bytestring
-                      , cardano-api
                       , cardano-binary
-                      , cardano-client
-                      , cardano-crypto
                       , cardano-crypto-class
-                      , cardano-crypto-praos
-                      , cardano-crypto-wrapper
-                      , cardano-data
                       , cardano-ledger-allegra
                       , cardano-ledger-alonzo
                       , cardano-ledger-babbage
                       , cardano-ledger-binary
-                      , cardano-ledger-byron
                       , cardano-ledger-core
                       , cardano-ledger-shelley
                       , cardano-ledger-mary
-                      , cardano-node
                       , cardano-prelude
-                      , cardano-protocol-tpraos
                       , cardano-slotting
                       , cardano-strict-containers
                       , cborg
-                      , vector-map
                       , containers
                       , contra-tracer
                       , directory
-                      , esqueleto
                       , extra
-                      , filepath
-                      , groups
-                      , http-client
-                      , http-client-tls
-                      , http-types
-                      , iohk-monitoring
-                      , io-classes
-                      , lifted-base
-                      , memory
                       , mtl
-                      , monad-control
                       , microlens
-                      , network-mux
                       , nothunks
                       , ouroboros-consensus
                       , ouroboros-consensus-cardano
@@ -108,29 +87,12 @@ library
                       , ouroboros-network-api
                       , ouroboros-network-framework
                       , ouroboros-network-protocols
-                      , persistent
-                      , persistent-postgresql
                       , plutus-core
-                      , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib}
-                      , pretty-show
-                      , prometheus
-                      , random-shuffle
+                      , plutus-ledger-api:{plutus-ledger-api-testlib}
                       , serialise
-                      , set-algebra
-                      , small-steps
-                      , split
-                      , stm
-                      , strict
                       , strict-stm
-                      , swagger2
                       , text
-                      , time
-                      , transformers
-                      , transformers-except
                       , typed-protocols
-                      , unix
-                      , vector
-                      , yaml
 
 test-suite cardano-chain-gen
   type:                 exitcode-stdio-1.0
@@ -140,12 +102,15 @@ test-suite cardano-chain-gen
   hs-source-dirs:       test
 
   ghc-options:          -Wall
+                        -Wall
+                        -Werror
                         -Wcompat
-                        -fwarn-redundant-constraints
-                        -fwarn-incomplete-patterns
-                        -fwarn-unused-imports
+                        -Wredundant-constraints
+                        -Wincomplete-patterns
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
+                        -Wunused-imports
+                        -Wunused-packages
                         -Wno-unsafe
                         -threaded
 
@@ -202,11 +167,6 @@ test-suite cardano-chain-gen
                       , esqueleto
                       , extra
                       , filepath
-                      , mtl
-                      , io-classes
-                      , optparse-applicative
-                      , ouroboros-network
-                      , plutus-ledger-api
                       , silently
                       , stm
                       , strict-stm
@@ -220,10 +180,7 @@ test-suite cardano-chain-gen
                       , monad-logger
                       , ouroboros-consensus
                       , ouroboros-consensus-cardano
-                      , ouroboros-consensus-protocol
-                      , ouroboros-network
                       , ouroboros-network-api
-                      , ouroboros-network-framework
                       , persistent
                       , persistent-postgresql
                       , postgresql-simple

--- a/cardano-chain-gen/src/Cardano/Mock/ChainSync/State.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/ChainSync/State.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Mock.ChainSync.State (
   ChainProducerState (..),

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Alonzo/ScriptsExamples.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Alonzo/ScriptsExamples.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Mock.Forging.Tx.Alonzo.ScriptsExamples (
   alwaysSucceedsScript,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1691699219,
-        "narHash": "sha256-7FZMW/xsi09C/fjVWYJfkuIewH9L1MGqrQmDW2YW9TE=",
+        "lastModified": 1691400306,
+        "narHash": "sha256-8YdXsDhMzLyDcU9LoAbMER2RXJ60ntQ0tpDLIsqvO/k=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "eb83cd680bb3ee49cb3cccf1548d6911fba3363f",
+        "rev": "8a16db9be7cbf3270de8b9366ab71df8c3359f0f",
         "type": "github"
       },
       "original": {
@@ -360,11 +360,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1691627137,
-        "narHash": "sha256-PcNZKon4f8e5QGcK3frc7NL4A7VT/XYwV7pLX9cqfPE=",
+        "lastModified": 1691488289,
+        "narHash": "sha256-nbX4MVLR1EprW150IbONfDmRfdwLiQO+XLeMsSFB7FQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c80aff637d5864de25f2c38a813544cb624deed2",
+        "rev": "022bed4e939d49679a50bd8326fa407ec9f1d39a",
         "type": "github"
       },
       "original": {
@@ -387,7 +387,6 @@
           "hackageNix"
         ],
         "hls-1.10": "hls-1.10",
-        "hls-2.0": "hls-2.0",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -400,17 +399,16 @@
         "nixpkgs-2111": "nixpkgs-2111",
         "nixpkgs-2205": "nixpkgs-2205",
         "nixpkgs-2211": "nixpkgs-2211",
-        "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1691714985,
-        "narHash": "sha256-EHQ2RnPTadPfhnoo3z3eYRvQXr2jHiX44bnO+XcinkY=",
+        "lastModified": 1684284676,
+        "narHash": "sha256-VhZiVvwXqHkWh8Tw81WL8vwMzGsAhag8SQCQWGXQBLs=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "2ae97270776e0ea43e665727d5b88bb4ec4d33c7",
+        "rev": "ec345f667f9f1596e3849b530fe4f1573fc07653",
         "type": "github"
       },
       "original": {
@@ -451,23 +449,6 @@
       "original": {
         "owner": "haskell",
         "ref": "1.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.0": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1687698105,
-        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "783905f211ac63edf982dd1889c671653327e441",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.0.0.1",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -559,11 +540,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1688517130,
-        "narHash": "sha256-hUqfxSlo+ffqVdkSZ1EDoB7/ILCL25eYkcCXW9/P3Wc=",
+        "lastModified": 1670983692,
+        "narHash": "sha256-avLo34JnI9HNyOuauK5R69usJm+GfW3MlyGlYxZhTgY=",
         "ref": "hkm/remote-iserv",
-        "rev": "9151db2a9a61d7f5fe52ff8836f18bbd0fd8933c",
-        "revCount": 13,
+        "rev": "50d0abb3317ac439a4e7495b185a64af9b7b9300",
+        "revCount": 10,
         "type": "git",
         "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       },
@@ -730,11 +711,11 @@
     },
     "nixpkgs-2205": {
       "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "lastModified": 1682600000,
+        "narHash": "sha256-ha4BehR1dh8EnXSoE1m/wyyYVvHI9txjW4w5/oxsW5Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "rev": "50fc86b75d2744e1ab3837ef74b53f103a9b55a0",
         "type": "github"
       },
       "original": {
@@ -746,32 +727,16 @@
     },
     "nixpkgs-2211": {
       "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "lastModified": 1682682915,
+        "narHash": "sha256-haR0u/j/nUvlMloYlaOYq1FMXTvkNHw+wGxc+0qXisM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "rev": "09f1b33fcc0f59263137e23e935c1bb03ec920e4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2305": {
-      "locked": {
-        "lastModified": 1690680713,
-        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -794,11 +759,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1690720142,
-        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
+        "lastModified": 1682656005,
+        "narHash": "sha256-fYplYo7so1O+rSQ2/aS+SbTPwLTeoUXk4ekKNtSl4P8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
+        "rev": "6806b63e824f84b0f0e60b6d660d4ae753de0477",
         "type": "github"
       },
       "original": {
@@ -1071,11 +1036,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1691712542,
-        "narHash": "sha256-0N7TJjUSP+Aq/OywFJgCElTSqN8/UOAlkLF1hfqh8AA=",
+        "lastModified": 1684282201,
+        "narHash": "sha256-QW1Xm2MC+Qx1ZYF1cFRsb73WJji8aq6m5RGHUk9WWFU=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "ed5a27143441eb4578276a3741a2ea1786fc93d8",
+        "rev": "39971b1a8a098dd5bbbd8d91ba35ff0bfc07ce22",
         "type": "github"
       },
       "original": {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -56,8 +56,8 @@ let
     src = ../.;
     # our current release compiler is 8107
     compiler-nix-name = lib.mkDefault "ghc8107";
-    # but we also build for 962.
-    flake.variants = lib.genAttrs ["ghc962"] (x: {compiler-nix-name = x;});
+    # but we also build for 927.
+    flake.variants = lib.genAttrs ["ghc927"] (x: {compiler-nix-name = x;});
 
     shell = {
       name = "cabal-dev-shell";


### PR DESCRIPTION
# Description

This change fixes the CI build failures, and [for now] removes `ghc962` from nix builds. We will continue to work to get GHC 9.6.2 supported.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
