### PR TITLE
Fix Hydra failures

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -102,14 +102,14 @@ let
       }
       {
         packages.cardano-db.components.tests.test-db = {
-            build-tools = [ pkgs.pkgsBuildBuild.postgresql ];
+            build-tools = [ pkgs.pkgsBuildBuild.postgresql_12 ];
             inherit preCheck;
             inherit postCheck;
           };
       }
       {
         packages.cardano-chain-gen.components.tests.cardano-chain-gen = {
-            build-tools = [ pkgs.pkgsBuildBuild.postgresql ];
+            build-tools = [ pkgs.pkgsBuildBuild.postgresql_12 ];
             inherit preCheck;
             inherit postCheck;
           };

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -102,14 +102,16 @@ let
       }
       {
         packages.cardano-db.components.tests.test-db = {
-            build-tools = [ pkgs.pkgsBuildBuild.postgresql_12 ];
+            # Postgres 12+ won't build with musl
+            build-tools = [ pkgs.pkgsBuildHost.postgresql_12 ];
             inherit preCheck;
             inherit postCheck;
           };
       }
       {
         packages.cardano-chain-gen.components.tests.cardano-chain-gen = {
-            build-tools = [ pkgs.pkgsBuildBuild.postgresql_12 ];
+            # Postgres 12+ won't build with musl
+            build-tools = [ pkgs.pkgsBuildHost.postgresql_12 ];
             inherit preCheck;
             inherit postCheck;
           };


### PR DESCRIPTION
# Description

As of commit 1437235b40f6e54af49e1ee06e8c1ea9616c9a29, migrations require PostgreSQL 12+. This change:

 * Runs tests with PostgreSQL 12
 * Runs tests with non-static PostgreSQL

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
