### PR TITLE
Fix resolveTxInputs bug

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Grouped.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert/Grouped.hs
@@ -149,9 +149,9 @@ resolveTxInputs hasConsumed needsValue groupedOutputs txIn =
   liftLookupFail ("resolveTxInputs " <> textShow txIn <> " ") $ do
     qres <-
       case (hasConsumed, needsValue) of
+        (_, True) -> fmap convertFoundAll <$> resolveInputTxOutIdValue txIn
         (False, _) -> fmap convertnotFound <$> resolveInputTxId txIn
         (True, False) -> fmap convertFoundTxOutId <$> resolveInputTxOutId txIn
-        (True, True) -> fmap convertFoundAll <$> resolveInputTxOutIdValue txIn
     case qres of
       Right ret -> pure $ Right ret
       Left err ->


### PR DESCRIPTION
It now returns the output value when needed

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
