### PR TITLE
Fix GHC 9.6 build

### DIFF
--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -331,7 +331,7 @@ test-suite test
                         Cardano.DbSync.Util.Bech32Test
                         Cardano.DbSync.Util.CborTest
 
-  build-depends:        base                            >= 4.14         && < 4.17
+  build-depends:        base
                       , aeson
                       , base16-bytestring
                       , bytestring

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Script.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Script.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.DbSync.Era.Shelley.Generic.Script (
   MultiSigScript (..),
@@ -27,6 +29,9 @@ import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Parser ())
 import Data.Sequence.Strict (fromList)
+#if __GLASGOW_HASKELL__ >= 906
+import Data.Type.Equality (type (~))
+#endif
 import Text.Show (Show (..))
 import Prelude ()
 


### PR DESCRIPTION
# Description

This fixes builds on GHC 9.6, where `base` is `4.18`. This is a copy/paste error from `cardano-db-sync:lib:cardano-db-sync`

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
