### PR TITLE
Update GitHub CI to use actions/devx

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,143 +1,92 @@
 name: Haskell CI
 
-on: [push]
+on:
+  push:
+  pull_request:
+  schedule:
+    # Everyday at 4:00 AM UTC
+    - cron: "0 4 * * *"
 
 jobs:
   build:
+    name: build
+    defaults:
+      run:
+        shell: devx {0}
     runs-on: ${{ matrix.os }}
 
-
-    env:
-      # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-05-05"
-
     strategy:
-      fail-fast: false
       matrix:
-        cabal: ["3.10.1.0"]
-        ghc: ["8.10.7", "9.2.7", "9.6.2" ]
         os: [ubuntu-latest, macos-latest]
+        compiler-nix-name: [ghc8107]
 
     steps:
-    - name: Install Haskell
-      uses: input-output-hk/actions/haskell@latest
-      id: setup-haskell
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        cabal-version: ${{ matrix.cabal }}
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install GHC and Cabal
+        uses: input-output-hk/actions/devx@latest
+        with:
+          platform: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-linux' || 'x86_64-darwin' }}
+          target-platform: ""
+          compiler-nix-name: ${{ matrix.compiler-nix-name }}
+          minimal: false
+          # enable IOG flavour to bring in all the crypto libraries we need.
+          iog: true
+      - name: cabal update
+        run: cabal update
+      - name: cache cabal
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cabal-devx/packages
+            ~/.cabal-devx/store
+          key: ${{ runner.os }}-${{ matrix.compiler-nix-name }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.compiler-nix-name }}-
+      - name: cabal build dependencies
+        run: cabal build all -j --enable-tests --only-dependencies
+      - name: cabal build
+        run: cabal build all -j --enable-tests
+      - name: postgres init
+        run: |
+          # Set up environment
+          PG_DIR="$(mktemp -d)"
+          DB_DIR="${PG_DIR}/db"
+          PGPASSFILE="${PG_DIR}/pgpass-testing"
+          DBUSER=$(whoami)
+          DBNAME=$DBUSER
+          DBPASS=
 
-    - name: Install system dependencies
-      uses: input-output-hk/actions/base@latest
-      with:
-        use-sodium-vrf: false # default is true
+          # Initialise database
+          initdb --encoding=UTF8 --username=postgres "${DB_DIR}"
+          postgres -D "${DB_DIR}" -c listen_addresses="" -k "${PG_DIR}" &
 
-    - uses: actions/checkout@v3
+          # Verify Postgres is running
+          sleep 10
+          if (echo '\q' | psql -h ${PG_DIR} postgres postgres); then
+            echo "PostgreSQL server is verified to be started."
+          else
+            echo "Failed to connect to local PostgreSQL server."
+            exit 2
+          fi
 
-    - name: Select build directory
-      run: |
-        echo "$HOME/.cabal/bin"                 >> $GITHUB_PATH
+          # Create pgpass file
+          echo "${PG_DIR}:5432:$DBUSER:$DBUSER:*" > $PGPASSFILE
+          chmod 600 $PGPASSFILE
 
-    - name: Install SystemD (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install libsystemd0 libsystemd-dev
+          # Create database
+          psql -h "${PG_DIR}" postgres postgres <<EOF
+            create role $DBUSER with createdb login password '$DBPASS';
+            alter user $DBUSER with superuser;
+            create database $DBNAME with owner = $DBUSER;
+            \\connect $DBNAME
+            ALTER SCHEMA public   OWNER TO $DBUSER;
+          EOF
 
-    - name: Install Postgres (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libpq-dev libpq5 net-tools postgresql
-
-    - name: Post Install Cleanup (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get -y remove --purge software-properties-common
-        sudo apt-get -y autoremove
-
-    - name: Install Postgres support (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install postgresql@14 libpq openssl@1.1 tree
-        tree /usr/local/opt/postgresql@14/lib/
-        echo "PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig:/usr/local/opt/postgresql@14/lib/postgresql@14/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH" | tee $GITHUB_ENV
-
-    - name: Start Postgresql service (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew services start postgresql
-        sudo mkdir -p /var/run/postgresql/
-        sudo ln -s /tmp/.s.PGSQL.5432 /var/run/postgresql/.s.PGSQL.5432
-
-    - name: Start Postgres service (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo pg_ctlcluster 14 main start
-
-    - name: Check if postgres is running
-      run: |
-        sleep 20
-        netstat -an
-        ls -al /var/run/postgresql/.s.PGSQL.5432 || true
-        ls -al || true
-
-    - name: Debug Pkgconfig
-      run: |
-        echo $PKG_CONFIG_PATH
-        pkg-config --list-all
-
-    - name: Haskell versions
-      run: |
-        ghc --version
-        cabal --version
-
-    - name: Cabal update
-      run: cabal update
-
-    - name: Cabal Configure
-      run: cabal configure --enable-tests --write-ghc-environment-files=always
-
-    - name: Configure to use libsodium
-      run: |
-        cat >> cabal.project.local <<EOF
-        package cardano-crypto-praos
-          flags: -external-libsodium-vrf
-        EOF
-
-    - name: Record dependencies
-      id: record-deps
-      run: |
-        cabal build all --dry-run --minimize-conflict-set
-        cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
-
-    - name: Cache Cabal store
-      uses: actions/cache@v3
-      with:
-        path: |
-          ${{ steps.setup-haskell.outputs.cabal-store }}
-          dist-newstyle
-        key: cache-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
-
-    - name: Build dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: cabal build all -j --ghc-option=-j4 --enable-tests --only-dependencies
-
-    - name: Build
-      run: cabal build all -j --ghc-option=-j4 --enable-tests
-
-    - name: Set up database user (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo -u postgres createuser --createdb --superuser runner
-
-    - name: Set up database
-      run: |
-        cardano_db_sync_exe="$(cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[] | select(."component-name" == "exe:cardano-db-sync") | ."bin-file"' | head)"
-
-        echo "Executable found at: $cardano_db_sync_exe"
-        chmod 600 config/pgpass-mainnet
-        chmod 600 cardano-chain-gen/test/testfiles/pgpass-testing
-
-        PGPASSFILE=config/pgpass-mainnet scripts/postgresql-setup.sh --createdb
-        PGPASSFILE=cardano-chain-gen/test/testfiles/pgpass-testing scripts/postgresql-setup.sh --createdb
-
-    - name: Run tests
-      run: cabal test all -j1
+          # Pass environment to subsequent steps
+          echo "PG_DIR=${PG_DIR}" >> "$GITHUB_ENV"
+          echo "PGPASSFILE=${PGPASSFILE}" >> "$GITHUB_ENV"
+      - name: cabal test
+        run: cabal test all -j1
+      - name: postgres shutdown
+        run: |
+          kill $(head ${DB_DIR}/postmaster.pid)

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -47,46 +47,36 @@ jobs:
       - name: cabal build
         run: cabal build all -j --enable-tests
       - name: postgres init
+        working-directory: 
         run: |
           # Set up environment
           PG_DIR="$(mktemp -d)"
           DB_DIR="${PG_DIR}/db"
-          PGPASSFILE="${PG_DIR}/pgpass-testing"
           DBUSER=$(whoami)
           DBNAME=$DBUSER
-          DBPASS=
-
-          # Initialise database
-          initdb --encoding=UTF8 --username=postgres "${DB_DIR}"
-          postgres -D "${DB_DIR}" -c listen_addresses="" -k "${PG_DIR}" &
-
-          # Verify Postgres is running
-          sleep 10
-          if (echo '\q' | psql -h ${PG_DIR} postgres postgres); then
-            echo "PostgreSQL server is verified to be started."
-          else
-            echo "Failed to connect to local PostgreSQL server."
-            exit 2
-          fi
-
-          # Create pgpass file
-          echo "${PG_DIR}:5432:$DBUSER:$DBUSER:*" > $PGPASSFILE
-          chmod 600 $PGPASSFILE
-
-          # Create database
-          psql -h "${PG_DIR}" postgres postgres <<EOF
-            create role $DBUSER with createdb login password '$DBPASS';
-            alter user $DBUSER with superuser;
-            create database $DBNAME with owner = $DBUSER;
-            \\connect $DBNAME
-            ALTER SCHEMA public   OWNER TO $DBUSER;
-          EOF
 
           # Pass environment to subsequent steps
           echo "PG_DIR=${PG_DIR}" >> "$GITHUB_ENV"
-          echo "PGPASSFILE=${PGPASSFILE}" >> "$GITHUB_ENV"
+          echo "DB_DIR=${DB_DIR}" >> "$GITHUB_ENV"
+          echo "DBUSER=${DBUSER}" >> "$GITHUB_ENV"
+
+          # Start postgres
+          ./scripts/postgresql-test.sh \
+            -s "$PG_DIR" \
+            -d "$DB_DIR" \
+            -u "$DBUSER" \
+            -n "$DBNAME" \
+            start
       - name: cabal test
-        run: cabal test all -j1
-      - name: postgres shutdown
         run: |
-          kill $(head ${DB_DIR}/postmaster.pid)
+          # Create pgpass file
+          export PGPASSFILE="${PG_DIR}/pgpass-testing"
+          echo "${PG_DIR}:5432:$DBUSER:$DBUSER:*" > $PGPASSFILE
+          chmod 600 $PGPASSFILE
+
+          # Run tests
+          cabal test all -j1
+      - name: postgres shutdown
+        if: ${{ always() }}
+        run: |
+          ./scripts/postgresql-test.sh -d "$DB_DIR" stop

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        compiler-nix-name: [ghc8107]
+        compiler-nix-name: [ghc8107, ghc928, ghc962]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         compiler-nix-name: [ghc8107]

--- a/scripts/postgresql-test.sh
+++ b/scripts/postgresql-test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+# Unoffiical bash strict mode.
+# See: http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -u
+set -o pipefail
+IFS=$'\n\t'
+
+progname="$0"
+
+function wait_for_postgres {
+    timeout 30 sh -c \
+        "until echo '\q' | psql -h $PG_DIR postgres postgres; do sleep 1; done"
+}
+
+function start_postgres {
+    mkdir -p "${PG_DIR}"
+    
+    # Initialise database
+    initdb --encoding=UTF8 --username=postgres "${DB_DIR}"
+    postgres -D "${DB_DIR}" -c listen_addresses="" -k "${PG_DIR}" &
+
+    # Verify Postgres is running
+    if wait_for_postgres; then
+        echo "PostgreSQL server is verified to be started."
+    else
+        echo "Failed to connect to local PostgreSQL server."
+        exit 2
+    fi
+
+    psql -h "${PG_DIR}" postgres postgres <<EOF
+        create role $DB_USER with createdb login password NULL;
+        alter user $DB_USER with superuser;
+        create database $DB_NAME with owner = $DB_USER;
+        \\connect $DB_NAME
+        ALTER SCHEMA public OWNER TO $DB_USER;
+EOF
+}
+
+function stop_postgres {
+    head -n 1 "${DB_DIR}/postmaster.pid" | xargs kill
+}
+
+
+function usage {
+    echo
+    echo "Usage:"
+    echo "    $progname [options] start    Initializes and starts a test database server"
+    echo "    $progname [options] stop     Stops the test database server"
+    echo
+    echo "  Creates a test database server"
+    echo
+    echo "Options:"
+    echo '  -d directory    Postgres data directory [default: db]'
+    echo '  -n db-name      Postgres database name [default: user]'
+    echo '  -s socket-dir   Directory of the unix-socket in [default: .]'
+    echo '  -u user         Postgres database user [default: current user]'
+ }
+
+set -e
+
+while getopts "d:n:s:u:h" arg; do
+    case "${arg}" in
+        d)
+            DB_DIR="${OPTARG}"
+            ;;
+        n)
+            DB_NAME="${OPTARG}"
+            ;;
+        s)
+            PG_DIR="${OPTARG}"
+            ;;
+        u)
+            DB_USER="${OPTARG}"
+            ;;
+        h)
+            echo "h"
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! ${DB_DIR+DEFINED} ]]; then
+    DB_DIR="$(pwd)/db"
+fi
+
+if [[ ! ${DB_USER+DEFINED} ]]; then
+    DB_USER="$(whoami)"
+fi
+
+if [[ ! ${DB_NAME+DEFINED} ]]; then
+    DB_NAME="$DB_USER"
+fi
+
+if [[ ! ${PG_DIR+DEFINED} ]]; then
+    PG_DIR="$(pwd)"
+fi
+
+DB_DIR=$(realpath "$DB_DIR")
+PG_DIR=$(realpath "$PG_DIR")
+
+COMMAND="${*:$OPTIND:1}"
+
+case $COMMAND in
+    "start")
+        start_postgres
+        ;;
+    "stop")
+        stop_postgres
+        ;;
+    *)
+        echo "A command must be specified!"
+        usage
+        exit 3
+        ;;
+esac


### PR DESCRIPTION
# Description

Why [input-output-hk/actions/devx-action](https://github.com/input-output-hk/actions#devx-action)? The devx action provides all the system dependencies with nix, but haskell dependencies from cabal. This makes builds easily reproducible from both CI and local development.

This means that if anything goes wrong in CI, you can enter the devx shell, then run the same commands CI runs, and the result should be the same.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
