### PR TITLE
Fix: Update "config" CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@ CONTRIBUTING.rst             @input-output-hk/docs-access @input-output-hk/core-
 # DevOps
 .buildkite                   @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
 .github                      @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
-config                       @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
+/config                      @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
 nix                          @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
 *.nix                        @input-output-hk/core-tech-devx @input-output-hk/core-tech-release
 flake.lock                   @input-output-hk/core-tech-devx @input-output-hk/core-tech-release


### PR DESCRIPTION
# Description

Only `config` in the top level should be maintained by core-tech-devx/core-tech-release. There are `config` subdirectories for tests that should be maintained by core-tech-dbsync

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
