### PR TITLE
Install blst on macos doc update

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -16,6 +16,10 @@ In addition, Cardano DB Sync requires the following software (instructions below
  * [libsodium-vrf](https://github.com/input-output-hk/libsodium)
  * [secp256k1](https://github.com/bitcoin-core/secp256k1)
  * [blst](https://github.com/supranational/blst)
+ 
+ macOS:
+ 
+* [x-code](https://developer.apple.com/xcode/resources/)
 
 Create a working directory for your builds:
 
@@ -157,7 +161,6 @@ Build it:
 ```bash
 ./build.sh
 ```
-
 Install it:
 
 ```bash
@@ -182,6 +185,29 @@ sudo chmod 644 \
   /usr/local/lib/libblst.* \
   /usr/local/include/{blst.*,blst_aux.h}
 ```
+
+#### MACOS:
+
+If you hit the following error on macOS:
+```bash
++ cc -O2 -fno-builtin -fPIC -Wall -Wextra -Werror -c ./src/server.c
+In file included from ./src/server.c:7:
+In file included from ./src/keygen.c:7:
+In file included from ./src/consts.h:8:
+./src/vect.h:402:11: fatal error: 'stdlib.h' file not found
+# include <stdlib.h>
+```
+
+check you have x-code command line tools installed or try install them by running:
+```bash
+xcode-select --install
+```
+
+if the error still arrises copy the content that x-code installs into `/usr/local/include/` making sure the folder is also on you `$PATH`:
+```bash
+sudo cp -R -a /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/* /usr/local/include/
+```
+
 
 ## Install Cardano DB Sync
 


### PR DESCRIPTION
# Description

This fixes https://github.com/input-output-hk/cardano-db-sync/issues/1512

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
