### PR TITLE
doc: Fix typo in doc/running.md

### DIFF
--- a/doc/running.md
+++ b/doc/running.md
@@ -26,7 +26,7 @@ curl --remote-name-all --output-dir mainnet \
     https://book.world.dev.cardano.org/environments/mainnet/config.json \
     https://book.world.dev.cardano.org/environments/mainnet/db-sync-config.json \
     https://book.world.dev.cardano.org/environments/mainnet/submit-api-config.json \
-    https://book.world.dev.cardano.org/environments/mainnet/topology.json
+    https://book.world.dev.cardano.org/environments/mainnet/topology.json \
     https://book.world.dev.cardano.org/environments/mainnet/byron-genesis.json \
     https://book.world.dev.cardano.org/environments/mainnet/shelley-genesis.json \
     https://book.world.dev.cardano.org/environments/mainnet/alonzo-genesis.json \


### PR DESCRIPTION
# Description

Fix typo in running instructions

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
