### PR TITLE
Speed up prune migrations

### DIFF
--- a/cardano-db/src/Cardano/Db/Error.hs
+++ b/cardano-db/src/Cardano/Db/Error.hs
@@ -33,6 +33,7 @@ data LookupFail
   | DbMetaMultipleRows
   | DBMultipleGenesis
   | DBExtraMigration !String
+  | DBPruneConsumed !String
   deriving (Eq, Generic)
 
 instance Exception LookupFail
@@ -52,6 +53,7 @@ instance Show LookupFail where
       DbMetaMultipleRows -> "Multiple rows in Meta table which should only contain one"
       DBMultipleGenesis -> "Multiple Genesis blocks found. These are blocks without an EpochNo"
       DBExtraMigration e -> "DBExtraMigration : " <> e
+      DBPruneConsumed e -> "DBExtraMigration" <> e
 
 base16encode :: ByteString -> Text
 base16encode = Text.decodeUtf8 . Base16.encode

--- a/cardano-db/src/Cardano/Db/Multiplex.hs
+++ b/cardano-db/src/Cardano/Db/Multiplex.hs
@@ -105,7 +105,6 @@ runExtraMigrations trce blockNoDiff PruneConsumeMigration {..} = do
           ExtraCons.migrateTxOut (Just trce)
         (False, _, True) -> do
           shouldInsertToMigrationTable
-          liftIO $ logInfo trce "Now Running extra migration prune tx_out"
           ExtraCons.deleteAndUpdateConsumedTxOut trce blockNoDiff
         (True, _, True) -> do
           shouldInsertToMigrationTable

--- a/cardano-db/src/Cardano/Db/Multiplex.hs
+++ b/cardano-db/src/Cardano/Db/Multiplex.hs
@@ -106,7 +106,7 @@ runExtraMigrations trce blockNoDiff PruneConsumeMigration {..} = do
         (False, _, True) -> do
           shouldInsertToMigrationTable
           liftIO $ logInfo trce "Now Running extra migration prune tx_out"
-          ExtraCons.deleteAndUpdateConsumedTxOut trce hasConsumedField blockNoDiff
+          ExtraCons.deleteAndUpdateConsumedTxOut trce blockNoDiff
         (True, _, True) -> do
           shouldInsertToMigrationTable
           liftIO $ logInfo trce "Running extra migration prune tx_out"

--- a/cardano-db/src/Cardano/Db/Multiplex.hs
+++ b/cardano-db/src/Cardano/Db/Multiplex.hs
@@ -105,10 +105,11 @@ runExtraMigrations trce blockNoDiff PruneConsumeMigration {..} = do
           ExtraCons.migrateTxOut (Just trce)
         (False, _, True) -> do
           shouldInsertToMigrationTable
+          liftIO $ logInfo trce "Now Running extra migration prune tx_out"
+          ExtraCons.deleteAndUpdateConsumedTxOut trce blockNoDiff
+
           liftIO $ logInfo trce "Running extra migrations consumed_tx_out and prune tx_out"
           ExtraCons.migrateTxOut (Just trce)
-          liftIO $ logInfo trce "Now Running extra migration prune tx_out"
-          ExtraCons.deleteConsumedTxOut trce blockNoDiff
         (True, _, True) -> do
           shouldInsertToMigrationTable
           liftIO $ logInfo trce "Running extra migration prune tx_out"

--- a/cardano-db/src/Cardano/Db/Multiplex.hs
+++ b/cardano-db/src/Cardano/Db/Multiplex.hs
@@ -106,10 +106,7 @@ runExtraMigrations trce blockNoDiff PruneConsumeMigration {..} = do
         (False, _, True) -> do
           shouldInsertToMigrationTable
           liftIO $ logInfo trce "Now Running extra migration prune tx_out"
-          ExtraCons.deleteAndUpdateConsumedTxOut trce blockNoDiff
-
-          liftIO $ logInfo trce "Running extra migrations consumed_tx_out and prune tx_out"
-          ExtraCons.migrateTxOut (Just trce)
+          ExtraCons.deleteAndUpdateConsumedTxOut trce hasConsumedField blockNoDiff
         (True, _, True) -> do
           shouldInsertToMigrationTable
           liftIO $ logInfo trce "Running extra migration prune tx_out"


### PR DESCRIPTION
# Description

This fixes #1511 

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
