### PR TITLE
update blst macos install docs

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -203,11 +203,10 @@ check you have x-code command line tools installed or try install them by runnin
 xcode-select --install
 ```
 
-if the error still arrises copy the content that x-code installs into `/usr/local/include/` making sure the folder is also on you `$PATH`:
+If you are using homebrew you might need to unistall `llvm@13` as this clashes with x-code:
 ```bash
-sudo cp -R -a /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/* /usr/local/include/
+brew uninstall llvm@13
 ```
-
 
 ## Install Cardano DB Sync
 


### PR DESCRIPTION
# Description

There was actually an easier fix with macos blst installation error. Turns out that having x-code command line tool is needed but if any other installations of llvm say via homebrew where present it would cause errors. 

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
