### PR TITLE
Fix verbose logs when creating constraints

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Util/Constraint.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Util/Constraint.hs
@@ -22,9 +22,9 @@ import Cardano.Prelude (MonadIO (..), Proxy (..), ReaderT (runReaderT), atomical
 import Control.Concurrent.Class.MonadSTM.Strict (readTVarIO, writeTVar)
 import Control.Monad (unless)
 import Control.Monad.Trans.Control (MonadBaseControl)
-import Data.Text (Text, pack)
+import Data.Text (Text)
 import Database.Persist.EntityDef.Internal (EntityDef (..))
-import Database.Persist.Names (ConstraintNameDB (..), FieldNameDB (..))
+import Database.Persist.Names (ConstraintNameDB (..), EntityNameDB (..), FieldNameDB (..))
 import Database.Persist.Postgresql (PersistEntity (..), SqlBackend)
 
 constraintNameEpochStake :: ConstraintNameDB
@@ -107,9 +107,9 @@ logNewConstraint ::
   EntityDef ->
   Text ->
   IO ()
-logNewConstraint trce tableName constraintName =
+logNewConstraint trce table constraintName =
   logInfo trce $
     "The table "
-      <> pack (show tableName)
+      <> unEntityNameDB (entityDB table)
       <> " was given a new unique constraint called "
       <> constraintName


### PR DESCRIPTION
# Description

There was an error with the logs when adding new constraints which was only meant to log the table name!

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
