### PR TITLE
Unit test speedup by not always dropping whole DB

### DIFF
--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Property/Property.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Property/Property.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-deferred-out-of-scope-variables #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Db.Mock.Property.Property (
@@ -273,4 +274,4 @@ prop_empty_blocks iom knownMigrations = withMaxSuccess 20 $ noShrinking $ forAll
   prettyCommands smSymbolic hist (checkCommandNames cmds (res === Ok))
   where
     smSymbolic = sm (error "inter") (error "mockServer") (error "dbSync")
-    runAction action = withFullConfig' False False initCommandLineArgs "config" "qsm" action iom knownMigrations
+    runAction action = withFullConfig' (WithConfigArgs False False False) initCommandLineArgs "config" "qsm" action iom knownMigrations

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Plutus.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Plutus.hs
@@ -52,7 +52,7 @@ import Control.Monad (void)
 import qualified Data.Map as Map
 import Data.Text (Text)
 import Ouroboros.Consensus.Cardano.Block (StandardAlonzo)
-import Test.Cardano.Db.Mock.Config (alonzoConfigDir, startDBSync, withFullConfig)
+import Test.Cardano.Db.Mock.Config (alonzoConfigDir, startDBSync, withFullConfig, withFullConfigAndDropDB)
 import Test.Cardano.Db.Mock.UnifiedApi (
   fillUntilNextEpoch,
   forgeNextAndSubmit,
@@ -73,7 +73,7 @@ import Test.Tasty.HUnit (Assertion)
 ----------------------------------------------------------------------------------------------------------
 simpleScript :: IOManager -> [(Text, Text)] -> Assertion
 simpleScript =
-  withFullConfig alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
     void $ registerAllStakeCreds interpreter mockServer
 
@@ -248,7 +248,7 @@ multipleScriptsFailedSameBlock =
 
 registrationScriptTx :: IOManager -> [(Text, Text)] -> Assertion
 registrationScriptTx =
-  withFullConfig alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
 
     void $
@@ -371,7 +371,7 @@ deregistrationsScriptTx'' =
 
 mintMultiAsset :: IOManager -> [(Text, Text)] -> Assertion
 mintMultiAsset =
-  withFullConfig alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
     void $ withAlonzoFindLeaderAndSubmitTx interpreter mockServer $ \st -> do
       let val0 = MultiAsset $ Map.singleton (PolicyID alwaysMintScriptHash) (Map.singleton (head assetNames) 1)

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/PoolAndSmash.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/PoolAndSmash.hs
@@ -28,6 +28,7 @@ import Test.Cardano.Db.Mock.Config (
   getPoolLayer,
   startDBSync,
   withFullConfig,
+  withFullConfigAndDropDB,
  )
 import Test.Cardano.Db.Mock.UnifiedApi (
   fillUntilNextEpoch,
@@ -48,7 +49,7 @@ import Test.Tasty.HUnit (Assertion, assertEqual)
 
 poolReg :: IOManager -> [(Text, Text)] -> Assertion
 poolReg =
-  withFullConfig alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
 
     void $ forgeNextFindLeaderAndSubmit interpreter mockServer []

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Reward.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Reward.hs
@@ -39,6 +39,7 @@ import Test.Cardano.Db.Mock.Config (
   startDBSync,
   stopDBSync,
   withFullConfig,
+  withFullConfigAndDropDB,
  )
 import Test.Cardano.Db.Mock.UnifiedApi (
   fillEpochPercentage,
@@ -56,7 +57,7 @@ import Test.Tasty.HUnit (Assertion)
 
 simpleRewards :: IOManager -> [(Text, Text)] -> Assertion
 simpleRewards =
-  withFullConfig alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
     void $ registerAllStakeCreds interpreter mockServer
 

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Simple.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Simple.hs
@@ -12,7 +12,7 @@ import Control.Concurrent.Class.MonadSTM.Strict (MonadSTM (atomically))
 import Control.Monad (void)
 import Data.Text (Text)
 import Ouroboros.Network.Block (blockNo)
-import Test.Cardano.Db.Mock.Config (alonzoConfigDir, startDBSync, stopDBSync, withFullConfig)
+import Test.Cardano.Db.Mock.Config (alonzoConfigDir, startDBSync, stopDBSync, withFullConfig, withFullConfigAndDropDB)
 import Test.Cardano.Db.Mock.Examples (mockBlock0, mockBlock1, mockBlock2)
 import Test.Cardano.Db.Mock.UnifiedApi (forgeNextAndSubmit)
 import Test.Cardano.Db.Mock.Validate (assertBlockNoBackoff)
@@ -20,7 +20,7 @@ import Test.Tasty.HUnit (Assertion, assertBool)
 
 forgeBlocks :: IOManager -> [(Text, Text)] -> Assertion
 forgeBlocks = do
-  withFullConfig alonzoConfigDir testLabel $ \interpreter _mockServer _dbSync -> do
+  withFullConfigAndDropDB alonzoConfigDir testLabel $ \interpreter _mockServer _dbSync -> do
     _block0 <- forgeNext interpreter mockBlock0
     _block1 <- forgeNext interpreter mockBlock1
     block2 <- forgeNext interpreter mockBlock2

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Stake.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Stake.hs
@@ -27,7 +27,7 @@ import Control.Concurrent.Class.MonadSTM.Strict (MonadSTM (atomically))
 import Control.Monad (forM_, replicateM_, void)
 import Data.Text (Text)
 import Ouroboros.Network.Block (blockSlot)
-import Test.Cardano.Db.Mock.Config (alonzoConfigDir, startDBSync, withFullConfig)
+import Test.Cardano.Db.Mock.Config (alonzoConfigDir, startDBSync, withFullConfig, withFullConfigAndDropDB)
 import Test.Cardano.Db.Mock.UnifiedApi (
   fillEpochs,
   fillUntilNextEpoch,
@@ -54,7 +54,7 @@ import Test.Tasty.HUnit (Assertion)
 
 registrationTx :: IOManager -> [(Text, Text)] -> Assertion
 registrationTx =
-  withFullConfig alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
 
     void $
@@ -213,7 +213,7 @@ stakeAddressPtrUseBefore =
 
 stakeDistGenesis :: IOManager -> [(Text, Text)] -> Assertion
 stakeDistGenesis =
-  withFullConfig alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
     a <- fillUntilNextEpoch interpreter mockServer
     assertBlockNoBackoff dbSync (fromIntegral $ length a)

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Tx.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Tx.hs
@@ -12,6 +12,7 @@ import Test.Cardano.Db.Mock.Config (
   alonzoConfigDir,
   startDBSync,
   withFullConfig,
+  withFullConfigAndDropDB,
  )
 import Test.Cardano.Db.Mock.UnifiedApi (
   withAlonzoFindLeaderAndSubmit,
@@ -22,7 +23,7 @@ import Test.Tasty.HUnit (Assertion)
 
 addSimpleTx :: IOManager -> [(Text, Text)] -> Assertion
 addSimpleTx =
-  withFullConfig alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB alonzoConfigDir testLabel $ \interpreter mockServer dbSync -> do
     -- translate the block to a real Cardano block.
     void $
       withAlonzoFindLeaderAndSubmitTx interpreter mockServer $

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/EpochDisabled.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/EpochDisabled.hs
@@ -10,7 +10,7 @@ import qualified Cardano.Mock.Forging.Tx.Babbage as Babbage
 import Cardano.Mock.Forging.Types (UTxOIndex (..))
 import Control.Monad (void)
 import Data.Text (Text)
-import Test.Cardano.Db.Mock.Config (CommandLineArgs (..), babbageConfigDir, initCommandLineArgs, startDBSync, withCustomConfig)
+import Test.Cardano.Db.Mock.Config (CommandLineArgs (..), babbageConfigDir, initCommandLineArgs, startDBSync, withCustomConfig, withCustomConfigAndDropDB)
 import Test.Cardano.Db.Mock.UnifiedApi (forgeAndSubmitBlocks, withBabbageFindLeaderAndSubmitTx)
 import Test.Cardano.Db.Mock.Validate (assertBlockNoBackoff, assertEqQuery)
 import Test.Tasty.HUnit (Assertion)
@@ -21,7 +21,7 @@ mkCommandLineArgs epochDisabled = initCommandLineArgs {claEpochDisabled = epochD
 -- this test fails as incorrect configuration file given
 checkEpochDisabledArg :: IOManager -> [(Text, Text)] -> Assertion
 checkEpochDisabledArg =
-  withCustomConfig (mkCommandLineArgs True) babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfigAndDropDB (mkCommandLineArgs True) babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     startDBSync dbSyncEnv
     b1 <- forgeAndSubmitBlocks interpreter mockServer 50
     -- add 2 blocks with tx

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/ForceIndex.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/ForceIndex.hs
@@ -10,7 +10,7 @@ import qualified Cardano.Db as DB
 import Cardano.Mock.ChainSync.Server (IOManager)
 import Data.Text (Text)
 import GHC.Conc.IO (threadDelay)
-import Test.Cardano.Db.Mock.Config (CommandLineArgs (..), babbageConfigDir, initCommandLineArgs, startDBSync, withCustomConfig)
+import Test.Cardano.Db.Mock.Config (CommandLineArgs (..), babbageConfigDir, initCommandLineArgs, startDBSync, withCustomConfig, withCustomConfigAndDropDB)
 import Test.Cardano.Db.Mock.Validate (assertEqQuery)
 import Test.Tasty.HUnit (Assertion)
 
@@ -29,7 +29,7 @@ checkForceIndexesArg =
 
 checkNoForceIndexesArg :: IOManager -> [(Text, Text)] -> Assertion
 checkNoForceIndexesArg =
-  withCustomConfig commandLineNoForceIndexArgs babbageConfigDir testLabel $ \_ _ dbSyncEnv -> do
+  withCustomConfigAndDropDB commandLineNoForceIndexArgs babbageConfigDir testLabel $ \_ _ dbSyncEnv -> do
     startDBSync dbSyncEnv
     threadDelay 3_000_000
     assertEqQuery dbSyncEnv DB.queryPgIndexesCount 93 "there wasn't the correct number of indexes"

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/MigrateConsumedPruneTxOut.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/CommandLineArg/MigrateConsumedPruneTxOut.hs
@@ -34,6 +34,7 @@ import Test.Cardano.Db.Mock.Config (
   startDBSync,
   stopDBSync,
   withCustomConfig,
+  withCustomConfigAndDropDB,
  )
 import Test.Cardano.Db.Mock.Examples (mockBlock0, mockBlock1)
 import Test.Cardano.Db.Mock.UnifiedApi (
@@ -49,7 +50,7 @@ import Test.Tasty.HUnit (Assertion)
 
 commandLineArgCheck :: IOManager -> [(Text, Text)] -> Assertion
 commandLineArgCheck = do
-  withCustomConfig cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
+  withCustomConfigAndDropDB cmdLineArgs babbageConfigDir testLabel $ \interpreter mockServer dbSyncEnv -> do
     void $
       withBabbageFindLeaderAndSubmitTx interpreter mockServer $
         Babbage.mkPaymentTx (UTxOIndex 0) (UTxOIndex 1) 10000 500

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/InlineAndReference.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/InlineAndReference.hs
@@ -37,7 +37,7 @@ import qualified Data.ByteString.Short as SBS
 import qualified Data.Map as Map
 import Data.Text (Text)
 import Ouroboros.Network.Block (blockPoint)
-import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, withFullConfig)
+import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, withFullConfig, withFullConfigAndDropDB)
 import Test.Cardano.Db.Mock.UnifiedApi (
   forgeNextAndSubmit,
   forgeNextFindLeaderAndSubmit,
@@ -50,7 +50,7 @@ import Test.Tasty.HUnit (Assertion)
 
 unlockDatumOutput :: IOManager -> [(Text, Text)] -> Assertion
 unlockDatumOutput =
-  withFullConfig babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
     void $ registerAllStakeCreds interpreter mockServer
 

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Other.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Other.hs
@@ -43,7 +43,7 @@ import Control.Monad (forM_, void)
 import Data.Text (Text)
 import Ouroboros.Consensus.Cardano.Block (StandardBabbage, StandardCrypto)
 import Ouroboros.Network.Block (blockPoint)
-import Test.Cardano.Db.Mock.Config (babbageConfigDir, getPoolLayer, startDBSync, stopDBSync, withFullConfig)
+import Test.Cardano.Db.Mock.Config (babbageConfigDir, getPoolLayer, startDBSync, stopDBSync, withFullConfig, withFullConfigAndDropDB)
 import Test.Cardano.Db.Mock.Examples (mockBlock0)
 import Test.Cardano.Db.Mock.UnifiedApi (
   fillEpochPercentage,
@@ -122,7 +122,7 @@ configNoStakes =
 
 poolReg :: IOManager -> [(Text, Text)] -> Assertion
 poolReg =
-  withFullConfig babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
 
     void $ forgeNextFindLeaderAndSubmit interpreter mockServer []
@@ -350,7 +350,7 @@ poolDelist =
 
 forkFixedEpoch :: IOManager -> [(Text, Text)] -> Assertion
 forkFixedEpoch =
-  withFullConfig "config-hf-epoch1" testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB "config-hf-epoch1" testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
     void $
       withAlonzoFindLeaderAndSubmitTx interpreter mockServer $

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Plutus.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Plutus.hs
@@ -55,7 +55,7 @@ import qualified Data.Map as Map
 import Data.Text (Text)
 import Ouroboros.Consensus.Cardano.Block (StandardBabbage)
 import Ouroboros.Network.Block (genesisPoint)
-import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, withFullConfig)
+import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, withFullConfig, withFullConfigAndDropDB)
 import Test.Cardano.Db.Mock.UnifiedApi (
   fillUntilNextEpoch,
   forgeNextAndSubmit,
@@ -80,7 +80,7 @@ import Test.Tasty.HUnit (Assertion)
 
 simpleScript :: IOManager -> [(Text, Text)] -> Assertion
 simpleScript =
-  withFullConfig babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
     void $ registerAllStakeCreds interpreter mockServer
 
@@ -284,7 +284,7 @@ multipleScriptsFailedSameBlock =
 
 registrationScriptTx :: IOManager -> [(Text, Text)] -> Assertion
 registrationScriptTx =
-  withFullConfig babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
 
     void $
@@ -407,7 +407,7 @@ deregistrationsScriptTx'' =
 
 mintMultiAsset :: IOManager -> [(Text, Text)] -> Assertion
 mintMultiAsset =
-  withFullConfig babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
     void $ withBabbageFindLeaderAndSubmitTx interpreter mockServer $ \st -> do
       let val0 = MultiAsset $ Map.singleton (PolicyID alwaysMintScriptHash) (Map.singleton (head assetNames) 1)

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Reward.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Reward.hs
@@ -34,7 +34,7 @@ import Control.Monad (forM_, void)
 import qualified Data.Map as Map
 import Data.Text (Text)
 import Ouroboros.Network.Block (blockPoint)
-import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, stopDBSync, withFullConfig)
+import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, stopDBSync, withFullConfig, withFullConfigAndDropDB)
 import Test.Cardano.Db.Mock.UnifiedApi (
   fillEpochPercentage,
   fillEpochs,
@@ -58,7 +58,7 @@ import Test.Tasty.HUnit (Assertion)
 
 simpleRewards :: IOManager -> [(Text, Text)] -> Assertion
 simpleRewards =
-  withFullConfig babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
     void $ registerAllStakeCreds interpreter mockServer
 

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Rollback.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Rollback.hs
@@ -23,7 +23,7 @@ import Control.Concurrent.Class.MonadSTM.Strict (atomically)
 import Control.Monad (forM, forM_, void)
 import Data.Text (Text)
 import Ouroboros.Network.Block (blockPoint)
-import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, stopDBSync, withFullConfig)
+import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, stopDBSync, withFullConfig, withFullConfigAndDropDB)
 import Test.Cardano.Db.Mock.Examples (mockBlock0, mockBlock1, mockBlock2)
 import Test.Cardano.Db.Mock.UnifiedApi (forgeAndSubmitBlocks, forgeNextAndSubmit, forgeNextFindLeaderAndSubmit, getBabbageLedgerState, rollbackTo, withBabbageFindLeaderAndSubmit, withBabbageFindLeaderAndSubmitTx)
 import Test.Cardano.Db.Mock.Validate (assertBlockNoBackoff, assertTxCount)
@@ -31,7 +31,7 @@ import Test.Tasty.HUnit (Assertion)
 
 simpleRollback :: IOManager -> [(Text, Text)] -> Assertion
 simpleRollback = do
-  withFullConfig babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
     blk0 <- forgeNext interpreter mockBlock0
     blk1 <- forgeNext interpreter mockBlock1
     blk2 <- forgeNext interpreter mockBlock2

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Simple.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Simple.hs
@@ -14,7 +14,7 @@ import Control.Concurrent.Class.MonadSTM.Strict (atomically)
 import Control.Monad (void)
 import Data.Text (Text)
 import Ouroboros.Network.Block (blockNo)
-import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, stopDBSync, withFullConfig)
+import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, stopDBSync, withFullConfig, withFullConfigAndDropDB)
 import Test.Cardano.Db.Mock.Examples (mockBlock0, mockBlock1, mockBlock2)
 import Test.Cardano.Db.Mock.UnifiedApi (fillUntilNextEpoch, forgeAndSubmitBlocks, forgeNextAndSubmit)
 import Test.Cardano.Db.Mock.Validate (assertBlockNoBackoff)
@@ -22,7 +22,7 @@ import Test.Tasty.HUnit (Assertion, assertBool)
 
 forgeBlocks :: IOManager -> [(Text, Text)] -> Assertion
 forgeBlocks = do
-  withFullConfig babbageConfigDir testLabel $ \interpreter _mockServer _dbSync -> do
+  withFullConfigAndDropDB babbageConfigDir testLabel $ \interpreter _mockServer _dbSync -> do
     _block0 <- forgeNext interpreter mockBlock0
     _block1 <- forgeNext interpreter mockBlock1
     block2 <- forgeNext interpreter mockBlock2

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Stake.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Stake.hs
@@ -28,7 +28,7 @@ import Control.Concurrent.Class.MonadSTM.Strict (MonadSTM (..))
 import Control.Monad (forM_, replicateM_, void)
 import Data.Text (Text)
 import Ouroboros.Network.Block (blockSlot)
-import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, withFullConfig)
+import Test.Cardano.Db.Mock.Config (babbageConfigDir, startDBSync, withFullConfig, withFullConfigAndDropDB)
 import Test.Cardano.Db.Mock.UnifiedApi (
   fillEpochs,
   fillUntilNextEpoch,
@@ -55,7 +55,7 @@ import Test.Tasty.HUnit (Assertion)
 
 registrationTx :: IOManager -> [(Text, Text)] -> Assertion
 registrationTx =
-  withFullConfig babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
 
     void $
@@ -213,7 +213,7 @@ stakeAddressPtrUseBefore =
 ----------------------------------------------------------------------------------------------------------
 stakeDistGenesis :: IOManager -> [(Text, Text)] -> Assertion
 stakeDistGenesis =
-  withFullConfig babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
+  withFullConfigAndDropDB babbageConfigDir testLabel $ \interpreter mockServer dbSync -> do
     startDBSync dbSync
     a <- fillUntilNextEpoch interpreter mockServer
     assertBlockNoBackoff dbSync (fromIntegral $ length a)


### PR DESCRIPTION
# Description

This fixes #1384 instead of dropping the whole DB and re running the schema on every test we now do it only on the ones that need to drop the whole DB prior to starting the test. This save a couple of seconds off every test!!

locally -
before: All 150 tests passed (450.35s)
after : All 150 tests passed (387.74s)



# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
