### PR TITLE
prepareTxOut: force mSaId

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -894,7 +894,7 @@ insertDelegationVote ::
   DRep StandardCrypto ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) ()
 insertDelegationVote cache network txId idx cred drep = do
-  addrId <- liftLookupFail "insertDelegation" $ queryStakeAddrWithCache cache CacheNew network cred
+  addrId <- liftLookupFail "insertDelegationVote" $ queryStakeAddrWithCache cache CacheNew network cred
   drepId <- lift $ insertDrep drep
   void . lift . DB.insertDelegationVote $
     DB.DelegationVote

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -376,7 +376,7 @@ prepareTxOut ::
   Generic.TxOut ->
   ExceptT SyncNodeError (ReaderT SqlBackend m) (ExtendedTxOut, [MissingMaTxOut])
 prepareTxOut tracer cache iopts (txId, txHash) (Generic.TxOut index addr addrRaw value maMap mScript dt) = do
-  mSaId <- lift $ insertStakeAddressRefIfMissing tracer cache txId addr
+  !mSaId <- lift $ insertStakeAddressRefIfMissing tracer cache txId addr
   mDatumId <-
     whenFalseEmpty (ioPlutusExtra iopts) Nothing $
       Generic.whenInlineDatum dt $


### PR DESCRIPTION
# Description

Since `mSaId` doens't have a bang, the actual insert is not triggered at that
point causing `queryStakeAddrWithCache` used in `insertDelegationVote`
to fail.

In `insertTx`, `prepareTxOut` is called before `insertCertificate` which
calls `insertConwayDelegCert` followed by `insertDelegationVote` (that
can fail on not yet insterted `StakeCred` since it is still a thunk at
that point).

Closes #1540

Simplified reproducer:

```haskell
module LazyRepro where

import Debug.Trace

data ReproData = ReproData {
    a :: Int
  , b :: String
  }

prep :: IO ReproData
prep = do
  ma <- pure $ trace "tracer" undefined
  let !out = ReproData { a = ma, b = "yo" }
  pure out

main = prep
```

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
