### PR TITLE
fix(nix): Add cardano-smash-server with basic-auth disabled

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -307,6 +307,9 @@
             cardano-db-sync-docker = callPackage ./nix/docker.nix {
               inherit (inputs.iohkNix.lib) evalService;
             };
+            cardano-smash-server-no-basic-auth = (project.appendModule {
+              modules = [{packages.cardano-smash-server.flags.disable-basic-auth = true;}];
+            }).exes.cardano-smash-server;
 
             # TODO: macOS builders are resource-constrained and cannot run the detabase
             # integration tests. Add these back when we get beefier builders.
@@ -331,6 +334,7 @@
             } // lib.optionalAttrs (system == "x86_64-darwin") {
               inherit cardano-db-sync-macos;
             } // {
+              inherit cardano-smash-server-no-basic-auth;
               checks = staticChecks;
             };
 
@@ -338,10 +342,11 @@
 
             packages = lib.optionalAttrs (system == "x86_64-linux") {
               inherit cardano-db-sync-linux cardano-db-sync-docker;
-
               default = flake.packages."cardano-db-sync:exe:cardano-db-sync";
             } // lib.optionalAttrs (system == "x86_64-darwin") {
               inherit cardano-db-sync-macos;
+            } // {
+              inherit cardano-smash-server-no-basic-auth;
             };
           }));
 


### PR DESCRIPTION
# Description

Add back a variant of cardano-smash-server with basic-auth flag disabled..

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
