### PR TITLE
Update to node 8.7

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,8 +10,8 @@ repository cardano-haskell-packages
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
 index-state:
-  , hackage.haskell.org 2023-09-01T22:19:16Z
-  , cardano-haskell-packages 2023-10-31T17:10:09Z
+  , hackage.haskell.org 2023-11-09T23:50:15Z
+  , cardano-haskell-packages 2023-11-17T22:33:04Z
 
 packages:
   cardano-db
@@ -71,8 +71,8 @@ package snap-server
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 735e6c97740c8def5d6e462bf5a29cbe6d323cfe
-  --sha256: sha256-Q4lhD+m5nvNu+dIHWB8WYVsWqi4/wmPPm+O/W6+HFJo=
+  tag: 34d89af65439db92293b88967c299c20692abc1c
+  --sha256: sha256-pVUWfzVnM4RvpFlJNH2ZmWPZzmkGT1Ty8B1p7NFh69M=
   subdir:
     cardano-git-rev
     cardano-node

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Alonzo/Scenarios.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Alonzo/Scenarios.hs
@@ -38,7 +38,7 @@ delegateAndSendBlocks n interpreter = do
   sendBlocks <- forM (chunksOf 500 addresses) $ \blockAddresses -> do
     blockTxs <- withAlonzoLedgerState interpreter $ \st ->
       forM (chunksOf 10 blockAddresses) $ \txAddresses ->
-        Alonzo.mkPaymentTx' utxoIndex (fmap (\addr -> (UTxOAddress addr, MaryValue 1 mempty)) txAddresses) st
+        Alonzo.mkPaymentTx' utxoIndex (fmap (\addr -> (UTxOAddress addr, MaryValue (Coin 1) mempty)) txAddresses) st
     forgeNextFindLeader interpreter (TxAlonzo <$> blockTxs)
   pure $ registerBlocks <> delegateBlocks <> sendBlocks
   where

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Alonzo/ScriptsExamples.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Alonzo/ScriptsExamples.hs
@@ -29,9 +29,7 @@ module Cardano.Mock.Forging.Tx.Alonzo.ScriptsExamples (
 
 import Cardano.Ledger.Address
 import Cardano.Ledger.Alonzo
-import Cardano.Ledger.Alonzo.Language
 import Cardano.Ledger.Alonzo.Scripts
-import Cardano.Ledger.Alonzo.Scripts.Data
 import Cardano.Ledger.BaseTypes
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential
@@ -39,6 +37,8 @@ import Cardano.Ledger.Crypto (StandardCrypto)
 import Cardano.Ledger.Era
 import Cardano.Ledger.Hashes
 import Cardano.Ledger.Mary.Value
+import Cardano.Ledger.Plutus.Data
+import Cardano.Ledger.Plutus.Language
 import Cardano.Prelude (panic)
 import Codec.CBOR.Write (toStrictByteString)
 import Codec.Serialise

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Babbage.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Babbage.hs
@@ -166,9 +166,9 @@ mkPaymentTx inputIndex outputIndex amount fees sta = do
   addr <- resolveAddress outputIndex sta
 
   let input = Set.singleton $ fst inputPair
-      output = BabbageTxOut addr (valueFromList (fromIntegral amount) []) NoDatum SNothing
+      output = BabbageTxOut addr (valueFromList (Coin amount) []) NoDatum SNothing
       BabbageTxOut addr' (MaryValue inputValue _) _ _ = snd inputPair
-      change = BabbageTxOut addr' (valueFromList (fromIntegral $ fromIntegral inputValue - amount - fees) []) NoDatum SNothing
+      change = BabbageTxOut addr' (valueFromList (Coin $ unCoin inputValue - amount - fees) []) NoDatum SNothing
   Right $ mkSimpleTx True $ consPaymentTxBody input mempty mempty (StrictSeq.fromList [output, change]) SNothing (Coin fees) mempty
 
 mkPaymentTx' ::
@@ -183,7 +183,7 @@ mkPaymentTx' inputIndex outputIndex sta = do
   let inps = Set.singleton $ fst inputPair
       BabbageTxOut addr' (MaryValue inputValue _) _ _ = snd inputPair
       outValue = sum (unCoin . coin . snd <$> outputIndex)
-      change = BabbageTxOut addr' (valueFromList (fromIntegral $ fromIntegral inputValue - outValue) []) NoDatum SNothing
+      change = BabbageTxOut addr' (valueFromList (Coin $ unCoin inputValue - outValue) []) NoDatum SNothing
   Right $ mkSimpleTx True $ consPaymentTxBody inps mempty mempty (StrictSeq.fromList $ outps ++ [change]) SNothing (Coin 0) mempty
   where
     mkOuts (outIx, vl) = do
@@ -224,7 +224,7 @@ mkLockByScriptTx inputIndex txOutTypes amount fees sta = do
   let input = Set.singleton $ fst inputPair
       outs = mkOutFromType amount <$> txOutTypes
       BabbageTxOut addr' (MaryValue inputValue _) _ _ = snd inputPair
-      change = BabbageTxOut addr' (valueFromList (fromIntegral $ fromIntegral inputValue - amount - fees) []) NoDatum SNothing
+      change = BabbageTxOut addr' (valueFromList (Coin $ unCoin inputValue - amount - fees) []) NoDatum SNothing
   -- No witnesses are necessary when the outputs is a script address. Only when it's consumed.
   Right $ mkSimpleTx True $ consPaymentTxBody input mempty mempty (StrictSeq.fromList $ outs <> [change]) SNothing (Coin fees) mempty
 
@@ -240,7 +240,7 @@ mkOutFromType amount txOutType =
         SNothing -> SNothing
         SJust True -> SJust alwaysSucceedsScript
         SJust False -> SJust alwaysFailsScript
-   in BabbageTxOut outAddress (valueFromList (fromIntegral amount) []) dt scpt
+   in BabbageTxOut outAddress (valueFromList (Coin amount) []) dt scpt
 
 mkUnlockScriptTx ::
   [BabbageUTxOIndex] ->
@@ -258,7 +258,7 @@ mkUnlockScriptTx inputIndex colInputIndex outputIndex succeeds amount fees sta =
 
   let inpts = Set.fromList $ fst <$> inputPairs
       colInput = Set.singleton $ fst colInputPair
-      output = BabbageTxOut addr (valueFromList (fromIntegral amount) []) NoDatum SNothing
+      output = BabbageTxOut addr (valueFromList (Coin amount) []) NoDatum SNothing
   Right
     $ mkScriptTx
       succeeds
@@ -286,7 +286,7 @@ mkUnlockScriptTxBabbage inputIndex colInputIndex outputIndex refInput compl succ
       colOut = maybeToStrictMaybe $ mkOutFromType amount <$> collTxOutType
       refInpts = Set.fromList $ fst <$> refInputPairs
       colInput = Set.singleton $ fst colInputPair
-      output = BabbageTxOut addr (valueFromList (fromIntegral amount) []) NoDatum SNothing
+      output = BabbageTxOut addr (valueFromList (Coin amount) []) NoDatum SNothing
   Right
     $ mkScriptTx
       succeeds
@@ -436,7 +436,7 @@ mkDepositTxPools inputIndex deposit sta = do
 
   let input = Set.singleton $ fst inputPair
       BabbageTxOut addr' (MaryValue inputValue _) _ _ = snd inputPair
-      change = BabbageTxOut addr' (valueFromList (fromIntegral $ fromIntegral inputValue - deposit) []) NoDatum SNothing
+      change = BabbageTxOut addr' (valueFromList (Coin $ unCoin inputValue - deposit) []) NoDatum SNothing
   Right $ mkSimpleTx True $ consTxBody input mempty mempty (StrictSeq.fromList [change]) SNothing (Coin 0) mempty (allPoolStakeCert sta) (Withdrawals mempty)
 
 mkDCertTxPools ::
@@ -555,7 +555,7 @@ mkFullTx n m sta = do
     policy0 = PolicyID alwaysMintScriptHash
     policy1 = PolicyID alwaysSucceedsScriptHash
     assets0 = Map.fromList [(Prelude.head assetNames, 5), (assetNames !! 1, 2)]
-    outValue0 = MaryValue 20 $ MultiAsset $ Map.fromList [(policy0, assets0), (policy1, assets0)]
+    outValue0 = MaryValue (Coin 20) $ MultiAsset $ Map.fromList [(policy0, assets0), (policy1, assets0)]
     addr0 = Addr Testnet (Prelude.head unregisteredAddresses) (StakeRefBase $ Prelude.head unregisteredStakeCredentials)
     addr2 = Addr Testnet (ScriptHashObj alwaysFailsScriptHash) (StakeRefBase $ unregisteredStakeCredentials !! 2)
     out0, out1, out2 :: BabbageTxOut StandardBabbage

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Babbage.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Babbage.hs
@@ -51,9 +51,7 @@ module Cardano.Mock.Forging.Tx.Babbage (
 import Cardano.Ledger.Address
 import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Alonzo.Core
-import Cardano.Ledger.Alonzo.Language
 import Cardano.Ledger.Alonzo.Scripts
-import qualified Cardano.Ledger.Alonzo.Scripts.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxAuxData as Alonzo
 import Cardano.Ledger.Alonzo.TxWits
 import Cardano.Ledger.Babbage.Collateral (collOuts)
@@ -67,6 +65,8 @@ import Cardano.Ledger.Credential
 import Cardano.Ledger.Crypto (ADDRHASH)
 import Cardano.Ledger.Keys
 import Cardano.Ledger.Mary.Value
+import qualified Cardano.Ledger.Plutus.Data as Alonzo
+import Cardano.Ledger.Plutus.Language
 import Cardano.Ledger.Shelley.PParams
 import Cardano.Ledger.Shelley.TxAuxData
 import Cardano.Ledger.Shelley.TxCert

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Babbage/Scenarios.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Babbage/Scenarios.hs
@@ -2,6 +2,7 @@ module Cardano.Mock.Forging.Tx.Babbage.Scenarios (
   delegateAndSendBlocks,
 ) where
 
+import Cardano.Ledger.Coin
 import Cardano.Ledger.Mary.Value
 import Cardano.Ledger.Shelley.API
 import Cardano.Ledger.Shelley.TxCert
@@ -39,7 +40,7 @@ delegateAndSendBlocks n interpreter = do
   sendBlocks <- forM (chunksOf 500 addresses) $ \blockAddresses -> do
     blockTxs <- withBabbageLedgerState interpreter $ \st ->
       forM (chunksOf 10 blockAddresses) $ \txAddresses ->
-        Babbage.mkPaymentTx' utxoIndex (fmap (\addr -> (UTxOAddress addr, MaryValue 1 mempty)) txAddresses) st
+        Babbage.mkPaymentTx' utxoIndex (fmap (\addr -> (UTxOAddress addr, MaryValue (Coin 1) mempty)) txAddresses) st
     forgeNextFindLeader interpreter (TxBabbage <$> blockTxs)
   pure $ registerBlocks <> delegateBlocks <> sendBlocks
   where

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Conway.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Conway.hs
@@ -125,7 +125,7 @@ mkPaymentTx ::
   Either ForgingError (AlonzoTx StandardConway)
 mkPaymentTx inputIndex outputIndex amount = mkPaymentTx' inputIndex outputIndices
   where
-    outputIndices = [(outputIndex, valueFromList amount [])]
+    outputIndices = [(outputIndex, valueFromList (Coin amount) [])]
 
 mkPaymentTx' ::
   ConwayUTxOIndex ->
@@ -143,7 +143,7 @@ mkPaymentTx' inputIndex outputIndices fees state' = do
       change =
         BabbageTxOut
           addr'
-          (valueFromList (fromIntegral $ fromIntegral inputValue - outValue - fees) [])
+          (valueFromList (Coin $ unCoin inputValue - outValue - fees) [])
           NoDatum
           SNothing
 
@@ -207,7 +207,7 @@ mkDepositTxPools inputIndex deposit state' = do
       change =
         BabbageTxOut
           addr'
-          (valueFromList (fromIntegral $ fromIntegral inputValue - deposit) [])
+          (valueFromList (Coin $ unCoin inputValue - deposit) [])
           NoDatum
           SNothing
 
@@ -343,7 +343,7 @@ mkFullTx n m state' = do
         (ScriptHashObj alwaysFailsScriptHash)
         (StakeRefBase $ unregisteredStakeCredentials !! 2)
     outValue0 =
-      MaryValue 20 $ MultiAsset $ Map.fromList [(policy0, assets0), (policy1, assets0)]
+      MaryValue (Coin 20) $ MultiAsset $ Map.fromList [(policy0, assets0), (policy1, assets0)]
     policy0 = PolicyID alwaysMintScriptHash
     policy1 = PolicyID alwaysSucceedsScriptHash
     assets0 = Map.fromList [(Prelude.head assetNames, 5), (assetNames !! 1, 2)]

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Conway.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Conway.hs
@@ -28,7 +28,6 @@ module Cardano.Mock.Forging.Tx.Conway (
 
 import Cardano.Ledger.Address (Addr (..), RewardAcnt (..), Withdrawals (..))
 import Cardano.Ledger.Allegra.Scripts (ValidityInterval (..))
-import Cardano.Ledger.Alonzo.Scripts.Data (Datum (..), hashData)
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..))
 import Cardano.Ledger.BaseTypes (EpochNo (..), Network (..))
@@ -43,8 +42,9 @@ import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (Credential (..), StakeCredential, StakeReference (..))
 import Cardano.Ledger.Crypto (ADDRHASH ())
 import Cardano.Ledger.Keys (KeyHash (..))
-import Cardano.Ledger.Language (Language (..))
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..), valueFromList)
+import Cardano.Ledger.Plutus.Data (Datum (..), hashData)
+import Cardano.Ledger.Plutus.Language (Language (..))
 import qualified Cardano.Ledger.Shelley.LedgerState as LedgerState
 import Cardano.Ledger.Shelley.TxAuxData (Metadatum (..))
 import Cardano.Ledger.TxIn (TxIn (..))

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Conway/Scenarios.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Conway/Scenarios.hs
@@ -6,6 +6,7 @@ module Cardano.Mock.Forging.Tx.Conway.Scenarios (
 
 import Cardano.Ledger.Address (Addr (..), Withdrawals (..))
 import Cardano.Ledger.BaseTypes (Network (..))
+import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway.TxCert (Delegatee (..))
 import Cardano.Ledger.Core (Tx ())
 import Cardano.Ledger.Credential (StakeCredential (), StakeReference (..))
@@ -67,7 +68,7 @@ mkPaymentBlocks utxoIx addresses interpreter =
   forgeBlocksChunked interpreter addresses $ \txAddrs ->
     Conway.mkPaymentTx' utxoIx (map mkUTxOAddress txAddrs) 0 . unState
   where
-    mkUTxOAddress addr = (UTxOAddress addr, MaryValue 1 mempty)
+    mkUTxOAddress addr = (UTxOAddress addr, MaryValue (Coin 1) mempty)
 
 -- | Forge blocks in chunks of 500 txs
 forgeBlocksChunked ::

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Plutus.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Plutus.hs
@@ -26,8 +26,8 @@ module Test.Cardano.Db.Mock.Unit.Alonzo.Plutus (
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Era.Shelley.Generic.Util (renderAddress)
-import Cardano.Ledger.Alonzo.Scripts.Data (hashData)
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..))
+import Cardano.Ledger.Plutus.Data (hashData)
 import Cardano.Ledger.SafeHash (extractHash)
 import Cardano.Ledger.Shelley.TxCert
 import Cardano.Mock.ChainSync.Server (IOManager)

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Plutus.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Alonzo/Plutus.hs
@@ -26,6 +26,7 @@ module Test.Cardano.Db.Mock.Unit.Alonzo.Plutus (
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Era.Shelley.Generic.Util (renderAddress)
+import Cardano.Ledger.Coin
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..))
 import Cardano.Ledger.Plutus.Data (hashData)
 import Cardano.Ledger.SafeHash (extractHash)
@@ -375,7 +376,7 @@ mintMultiAsset =
     startDBSync dbSync
     void $ withAlonzoFindLeaderAndSubmitTx interpreter mockServer $ \st -> do
       let val0 = MultiAsset $ Map.singleton (PolicyID alwaysMintScriptHash) (Map.singleton (head assetNames) 1)
-      Alonzo.mkMAssetsScriptTx [UTxOIndex 0] (UTxOIndex 1) [(UTxOAddressNew 0, MaryValue 10000 mempty)] val0 True 100 st
+      Alonzo.mkMAssetsScriptTx [UTxOIndex 0] (UTxOIndex 1) [(UTxOAddressNew 0, MaryValue (Coin 10000) mempty)] val0 True 100 st
 
     assertBlockNoBackoff dbSync 1
     assertAlonzoCounts dbSync (1, 1, 1, 1, 0, 0, 0, 0)
@@ -391,8 +392,8 @@ mintMultiAssets =
       let policy0 = PolicyID alwaysMintScriptHash
       let policy1 = PolicyID alwaysSucceedsScriptHash
       let val1 = MultiAsset $ Map.fromList [(policy0, assets0), (policy1, assets0)]
-      tx0 <- Alonzo.mkMAssetsScriptTx [UTxOIndex 0] (UTxOIndex 1) [(UTxOAddressNew 0, MaryValue 10000 mempty)] val1 True 100 st
-      tx1 <- Alonzo.mkMAssetsScriptTx [UTxOIndex 2] (UTxOIndex 3) [(UTxOAddressNew 0, MaryValue 10000 mempty)] val1 True 200 st
+      tx0 <- Alonzo.mkMAssetsScriptTx [UTxOIndex 0] (UTxOIndex 1) [(UTxOAddressNew 0, MaryValue (Coin 10000) mempty)] val1 True 100 st
+      tx1 <- Alonzo.mkMAssetsScriptTx [UTxOIndex 2] (UTxOIndex 3) [(UTxOAddressNew 0, MaryValue (Coin 10000) mempty)] val1 True 200 st
       pure [tx0, tx1]
 
     assertBlockNoBackoff dbSync 1
@@ -410,7 +411,7 @@ swapMultiAssets =
       let policy1 = PolicyID alwaysSucceedsScriptHash
       let mintValue0 = MultiAsset $ Map.fromList [(policy0, assetsMinted0), (policy1, assetsMinted0)]
       let assets0 = Map.fromList [(head assetNames, 5), (assetNames !! 1, 2)]
-      let outValue0 = MaryValue 20 $ MultiAsset $ Map.fromList [(policy0, assets0), (policy1, assets0)]
+      let outValue0 = MaryValue (Coin 20) $ MultiAsset $ Map.fromList [(policy0, assets0), (policy1, assets0)]
 
       tx0 <-
         Alonzo.mkMAssetsScriptTx

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/InlineAndReference.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/InlineAndReference.hs
@@ -16,6 +16,7 @@ module Test.Cardano.Db.Mock.Unit.Babbage.InlineAndReference (
   referenceDelegation,
 ) where
 
+import Cardano.Ledger.Coin
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..))
 import Cardano.Mock.ChainSync.Server (IOManager)
 import Cardano.Mock.Forging.Interpreter (withBabbageLedgerState)
@@ -376,7 +377,7 @@ referenceMintingScript =
         Babbage.mkMAssetsScriptTx
           [UTxOIndex 0]
           (UTxOIndex 1)
-          [(UTxOAddressNew 0, MaryValue 10000 mempty)]
+          [(UTxOAddressNew 0, MaryValue (Coin 10000) mempty)]
           [UTxOPair utxo0]
           val0
           True
@@ -413,7 +414,7 @@ referenceDelegation =
         Babbage.mkMAssetsScriptTx
           [UTxOIndex 0]
           (UTxOIndex 1)
-          [(UTxOAddressNew 0, MaryValue 10000 mempty)]
+          [(UTxOAddressNew 0, MaryValue (Coin 10000) mempty)]
           [UTxOPair utxo0]
           val0
           True

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Plutus.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Plutus.hs
@@ -28,8 +28,8 @@ module Test.Cardano.Db.Mock.Unit.Babbage.Plutus (
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Era.Shelley.Generic.Util (renderAddress)
-import Cardano.Ledger.Alonzo.Scripts.Data (hashData)
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..))
+import Cardano.Ledger.Plutus.Data (hashData)
 import Cardano.Ledger.SafeHash (extractHash)
 import Cardano.Ledger.Shelley.TxCert
 import Cardano.Mock.ChainSync.Server (IOManager)

--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Plutus.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Babbage/Plutus.hs
@@ -28,6 +28,7 @@ module Test.Cardano.Db.Mock.Unit.Babbage.Plutus (
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Era.Shelley.Generic.Util (renderAddress)
+import Cardano.Ledger.Coin
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..))
 import Cardano.Ledger.Plutus.Data (hashData)
 import Cardano.Ledger.SafeHash (extractHash)
@@ -411,7 +412,7 @@ mintMultiAsset =
     startDBSync dbSync
     void $ withBabbageFindLeaderAndSubmitTx interpreter mockServer $ \st -> do
       let val0 = MultiAsset $ Map.singleton (PolicyID alwaysMintScriptHash) (Map.singleton (head assetNames) 1)
-      Babbage.mkMAssetsScriptTx [UTxOIndex 0] (UTxOIndex 1) [(UTxOAddressNew 0, MaryValue 10000 mempty)] [] val0 True 100 st
+      Babbage.mkMAssetsScriptTx [UTxOIndex 0] (UTxOIndex 1) [(UTxOAddressNew 0, MaryValue (Coin 10000) mempty)] [] val0 True 100 st
 
     assertBlockNoBackoff dbSync 1
     assertAlonzoCounts dbSync (1, 1, 1, 1, 0, 0, 0, 0)
@@ -427,8 +428,8 @@ mintMultiAssets =
       let policy0 = PolicyID alwaysMintScriptHash
       let policy1 = PolicyID alwaysSucceedsScriptHash
       let val1 = MultiAsset $ Map.fromList [(policy0, assets0), (policy1, assets0)]
-      tx0 <- Babbage.mkMAssetsScriptTx [UTxOIndex 0] (UTxOIndex 1) [(UTxOAddressNew 0, MaryValue 10000 mempty)] [] val1 True 100 st
-      tx1 <- Babbage.mkMAssetsScriptTx [UTxOIndex 2] (UTxOIndex 3) [(UTxOAddressNew 0, MaryValue 10000 mempty)] [] val1 True 200 st
+      tx0 <- Babbage.mkMAssetsScriptTx [UTxOIndex 0] (UTxOIndex 1) [(UTxOAddressNew 0, MaryValue (Coin 10000) mempty)] [] val1 True 100 st
+      tx1 <- Babbage.mkMAssetsScriptTx [UTxOIndex 2] (UTxOIndex 3) [(UTxOAddressNew 0, MaryValue (Coin 10000) mempty)] [] val1 True 200 st
       pure [tx0, tx1]
 
     assertBlockNoBackoff dbSync 1
@@ -446,7 +447,7 @@ swapMultiAssets =
       let policy1 = PolicyID alwaysSucceedsScriptHash
       let mintValue0 = MultiAsset $ Map.fromList [(policy0, assetsMinted0), (policy1, assetsMinted0)]
       let assets0 = Map.fromList [(head assetNames, 5), (assetNames !! 1, 2)]
-      let outValue0 = MaryValue 20 $ MultiAsset $ Map.fromList [(policy0, assets0), (policy1, assets0)]
+      let outValue0 = MaryValue (Coin 20) $ MultiAsset $ Map.fromList [(policy0, assets0), (policy1, assets0)]
 
       tx0 <-
         Babbage.mkMAssetsScriptTx

--- a/cardano-db-sync/CHANGELOG.md
+++ b/cardano-db-sync/CHANGELOG.md
@@ -18,6 +18,11 @@ Some useful links (adjust the numbers to the correct tag):
 
 In the schema docs, you can search for `13.2` or `Conway` for schema changes from the previous official release.
 
+### sancho-2.3.0
+- is compatible with node 8.7-pre
+- introduces flag `--only-gov` which allows db-sync to sync only the governance related data.
+- disable swagger in smash server temporarily
+
 ### sancho-2.2.0
 - is compatible with node 8.6-pre
 - `governance_action.ratified_epoch` is now populated

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -209,7 +209,6 @@ library
                       , sop-core
                       , strict-sop-core
                       , strict-stm
-                      , swagger2
                       , text
                       , time
                       , transformers
@@ -349,7 +348,7 @@ test-suite test
                       , cardano-ledger-binary
                       , cardano-ledger-core:testlib
                       , cardano-ledger-allegra:{cardano-ledger-allegra,testlib}
-                      , cardano-ledger-alonzo:{cardano-ledger-alonzo,testlib}
+                      , cardano-ledger-alonzo:{testlib}
                       , cardano-ledger-shelley:{cardano-ledger-shelley,testlib}
                       , cardano-db-sync
                       , cardano-ledger-core

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ParamProposal.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ParamProposal.hs
@@ -14,13 +14,13 @@ module Cardano.DbSync.Era.Shelley.Generic.ParamProposal (
 import Cardano.DbSync.Era.Shelley.Generic.Util (unKeyHashRaw)
 import Cardano.DbSync.Era.Shelley.Generic.Witness (Witness (..))
 import Cardano.Ledger.Alonzo.Core
-import Cardano.Ledger.Alonzo.Language (Language)
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import Cardano.Ledger.BaseTypes (UnitInterval, strictMaybeToMaybe)
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import Cardano.Ledger.Coin (Coin, unCoin)
 import Cardano.Ledger.Crypto
 import qualified Cardano.Ledger.Keys as Ledger
+import Cardano.Ledger.Plutus.Language (Language)
 import qualified Cardano.Ledger.Shelley.PParams as Shelley
 import Cardano.Prelude
 import Cardano.Slotting.Slot (EpochNo (..))
@@ -69,7 +69,7 @@ data ParamProposal = ParamProposal
     pppPoolVotingThresholds :: !(Maybe PoolVotingThresholds)
   , pppDRepVotingThresholds :: !(Maybe DRepVotingThresholds)
   , pppCommitteeMinSize :: !(Maybe Natural)
-  , pppCommitteeMaxTermLength :: !(Maybe Natural)
+  , pppCommitteeMaxTermLength :: !(Maybe Word64)
   , pppGovActionLifetime :: !(Maybe EpochNo)
   , pppGovActionDeposit :: !(Maybe Natural)
   , pppDRepDeposit :: !(Maybe Natural)
@@ -138,7 +138,7 @@ convertConwayParamProposal pmap =
       pppPoolVotingThresholds = strictMaybeToMaybe (pmap ^. ppuPoolVotingThresholdsL)
     , pppDRepVotingThresholds = strictMaybeToMaybe (pmap ^. ppuDRepVotingThresholdsL)
     , pppCommitteeMinSize = strictMaybeToMaybe (pmap ^. ppuCommitteeMinSizeL)
-    , pppCommitteeMaxTermLength = strictMaybeToMaybe (pmap ^. ppuCommitteeMaxTermLengthL)
+    , pppCommitteeMaxTermLength = unEpochNo <$> strictMaybeToMaybe (pmap ^. ppuCommitteeMaxTermLengthL)
     , pppGovActionLifetime = strictMaybeToMaybe (pmap ^. ppuGovActionLifetimeL)
     , pppGovActionDeposit = fromIntegral . unCoin <$> strictMaybeToMaybe (pmap ^. ppuGovActionDepositL)
     , pppDRepDeposit = fromIntegral . unCoin <$> strictMaybeToMaybe (pmap ^. ppuDRepDepositL)

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ProtoParams.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ProtoParams.hs
@@ -10,13 +10,13 @@ module Cardano.DbSync.Era.Shelley.Generic.ProtoParams (
 
 import Cardano.DbSync.Types
 import Cardano.Ledger.Alonzo.Core
-import Cardano.Ledger.Alonzo.Language (Language)
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import Cardano.Ledger.BaseTypes (UnitInterval)
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.PParams hiding (params)
+import Cardano.Ledger.Plutus.Language (Language)
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Prelude
 import Cardano.Slotting.Slot (EpochNo (..))
@@ -61,7 +61,7 @@ data ProtoParams = ProtoParams
     ppPoolVotingThresholds :: !(Maybe PoolVotingThresholds)
   , ppDRepVotingThresholds :: !(Maybe DRepVotingThresholds)
   , ppCommitteeMinSize :: !(Maybe Natural)
-  , ppCommitteeMaxTermLength :: !(Maybe Natural)
+  , ppCommitteeMaxTermLength :: !(Maybe Word64)
   , ppGovActionLifetime :: !(Maybe EpochNo)
   , ppGovActionDeposit :: !(Maybe Natural)
   , ppDRepDeposit :: !(Maybe Natural)
@@ -121,7 +121,7 @@ fromConwayParams params =
     , ppPoolVotingThresholds = Just $ params ^. ppPoolVotingThresholdsL
     , ppDRepVotingThresholds = Just $ params ^. ppDRepVotingThresholdsL
     , ppCommitteeMinSize = Just $ params ^. ppCommitteeMinSizeL
-    , ppCommitteeMaxTermLength = Just $ params ^. ppCommitteeMaxTermLengthL
+    , ppCommitteeMaxTermLength = Just . unEpochNo $ params ^. ppCommitteeMaxTermLengthL
     , ppGovActionLifetime = Just $ params ^. ppGovActionLifetimeL
     , ppGovActionDeposit = Just . fromIntegral . unCoin $ params ^. ppGovActionDepositL
     , ppDRepDeposit = Just . fromIntegral . unCoin $ params ^. ppDRepDepositL

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ScriptData.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/ScriptData.hs
@@ -8,10 +8,10 @@ module Cardano.DbSync.Era.Shelley.Generic.ScriptData (
   ScriptData (..),
 ) where
 
-import Cardano.Ledger.Alonzo.Scripts.Data (Data (..), getPlutusData)
 import Cardano.Ledger.Binary (Annotator (..), DecCBOR (..), ToCBOR (..), fromPlainDecoder)
 import Cardano.Ledger.Binary.Encoding (EncCBOR (..))
 import Cardano.Ledger.Era (Era (..))
+import Cardano.Ledger.Plutus.Data (Data (..), getPlutusData)
 import Cardano.Prelude hiding (show)
 import Codec.Serialise (Serialise (..))
 import Control.Monad (fail)

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Tx/Alonzo.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Tx/Alonzo.hs
@@ -36,7 +36,6 @@ import Cardano.DbSync.Era.Shelley.Generic.Util
 import Cardano.DbSync.Era.Shelley.Generic.Witness
 import Cardano.DbSync.Types (DataHash)
 import qualified Cardano.Ledger.Address as Ledger
-import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..), txscriptfee, unBinaryPlutus)
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
@@ -50,6 +49,7 @@ import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), policyID)
+import qualified Cardano.Ledger.Plutus.Language as Alonzo
 import qualified Cardano.Ledger.SafeHash as Ledger
 import Cardano.Ledger.Shelley.Scripts (ScriptHash)
 import qualified Cardano.Ledger.Shelley.Tx as ShelleyTx
@@ -64,7 +64,7 @@ import qualified Data.Set as Set
 #if __GLASGOW_HASKELL__ >= 906
 import Data.Type.Equality (type (~))
 #endif
-import Cardano.Ledger.Language (Plutus (..))
+import Cardano.Ledger.Plutus.Language (Plutus (..))
 import Lens.Micro
 import Ouroboros.Consensus.Cardano.Block (EraCrypto, StandardAlonzo, StandardCrypto)
 
@@ -123,7 +123,7 @@ fromAlonzoTx ioExtraPlutus mprices (blkIndex, tx) =
         { txOutIndex = index
         , txOutAddress = txOut ^. Core.addrTxOutL
         , txOutAddressRaw = SBS.fromShort bs
-        , txOutAdaValue = Coin ada
+        , txOutAdaValue = ada
         , txOutMaValue = maMap
         , txOutScript = Nothing
         , txOutDatum = getMaybeDatumHash $ strictMaybeToMaybe mDataHash

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Tx/Babbage.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Tx/Babbage.hs
@@ -21,16 +21,15 @@ import Cardano.DbSync.Era.Shelley.Generic.Tx.Types
 import Cardano.DbSync.Era.Shelley.Generic.Witness
 import qualified Cardano.Ledger.Address as Ledger
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
-import qualified Cardano.Ledger.Alonzo.Scripts.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import Cardano.Ledger.Babbage.Core as Core hiding (Tx, TxOut)
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut)
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as Ledger
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..))
+import qualified Cardano.Ledger.Plutus.Data as Alonzo
 import Cardano.Prelude
 import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map
@@ -128,7 +127,7 @@ fromTxOut index txOut =
     { txOutIndex = index
     , txOutAddress = txOut ^. Core.addrTxOutL
     , txOutAddressRaw = SBS.fromShort bs
-    , txOutAdaValue = Coin ada
+    , txOutAdaValue = ada
     , txOutMaValue = maMap
     , txOutScript = fromScript <$> strictMaybeToMaybe mScript
     , txOutDatum = fromDatum datum

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Tx/Mary.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Generic/Tx/Mary.hs
@@ -12,7 +12,6 @@ import Cardano.DbSync.Era.Shelley.Generic.Tx.Shelley
 import Cardano.DbSync.Era.Shelley.Generic.Tx.Types
 import Cardano.DbSync.Era.Shelley.Generic.Witness
 import qualified Cardano.Ledger.Address as Ledger
-import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Mary.TxBody
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..))
@@ -65,7 +64,7 @@ fromMaryTx (blkIndex, tx) =
         { txOutIndex = index
         , txOutAddress = txOut ^. Core.addrTxOutL
         , txOutAddressRaw = SBS.fromShort bs
-        , txOutAdaValue = Coin ada
+        , txOutAdaValue = ada
         , txOutMaValue = maMap
         , txOutScript = Nothing
         , txOutDatum = NoDatum -- Mary does not support plutus data

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Insert.hs
@@ -61,7 +61,6 @@ import Cardano.DbSync.Util
 import Cardano.DbSync.Util.Bech32
 import Cardano.DbSync.Util.Cbor (serialiseTxMetadataToCbor)
 import qualified Cardano.Ledger.Address as Ledger
-import Cardano.Ledger.Alonzo.Language (Language)
 import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
 import Cardano.Ledger.BaseTypes (getVersion, strictMaybeToMaybe)
 import qualified Cardano.Ledger.BaseTypes as Ledger
@@ -76,6 +75,7 @@ import Cardano.Ledger.DRep
 import Cardano.Ledger.Keys
 import qualified Cardano.Ledger.Keys as Ledger
 import Cardano.Ledger.Mary.Value (AssetName (..), MultiAsset (..), PolicyID (..))
+import Cardano.Ledger.Plutus.Language (Language)
 import qualified Cardano.Ledger.Shelley.API.Wallet as Shelley
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 import Cardano.Ledger.Shelley.TxCert

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/OffChain/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/OffChain/Types.hs
@@ -14,21 +14,16 @@ import Cardano.Prelude
 import Control.Monad.Fail (fail)
 import Data.Aeson (FromJSON (..), Object, ToJSON (..), object, withObject, (.:), (.=))
 import Data.Aeson.Types (Parser)
-import Data.Swagger (ToSchema (..))
 
 newtype PoolDescription = PoolDescription
   { unPoolDescription :: Text
   }
   deriving (Eq, Show, Ord, Generic)
 
-instance ToSchema PoolDescription
-
 newtype PoolHomepage = PoolHomepage
   { unPoolHomepage :: Text
   }
   deriving (Eq, Show, Ord, Generic)
-
-instance ToSchema PoolHomepage
 
 -- | The bit of the pool data off the chain.
 data PoolOffChainMetadata = PoolOffChainMetadata
@@ -44,14 +39,10 @@ newtype PoolName = PoolName
   }
   deriving (Eq, Show, Ord, Generic)
 
-instance ToSchema PoolName
-
 newtype PoolTicker = PoolTicker
   { unPoolTicker :: Text
   }
   deriving (Eq, Show, Ord, Generic)
-
-instance ToSchema PoolTicker
 
 instance FromJSON PoolOffChainMetadata where
   parseJSON =
@@ -71,8 +62,6 @@ instance ToJSON PoolOffChainMetadata where
       , "ticker" .= unPoolTicker ticker'
       , "homepage" .= unPoolHomepage homepage'
       ]
-
-instance ToSchema PoolOffChainMetadata
 
 -- -------------------------------------------------------------------------------------------------
 

--- a/cardano-db-sync/src/Cardano/DbSync/Fix/PlutusDataBytes.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Fix/PlutusDataBytes.hs
@@ -20,12 +20,12 @@ import Cardano.DbSync.Era.Shelley.Generic.Tx.Alonzo
 import Cardano.DbSync.Era.Shelley.Generic.Tx.Types
 import Cardano.DbSync.Error (bsBase16Encode)
 import Cardano.DbSync.Types
-import qualified Cardano.Ledger.Alonzo.Scripts.Data as Alonzo
 import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxWits as Alonzo
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Era as Ledger
+import qualified Cardano.Ledger.Plutus.Data as Alonzo
 import Cardano.Prelude (mapMaybe)
 import Cardano.Slotting.Slot (SlotNo (..))
 import Control.Monad (filterM, when)

--- a/cardano-db-sync/src/Cardano/DbSync/Fix/PlutusScripts.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Fix/PlutusScripts.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.Alonzo.Scripts
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import qualified Cardano.Ledger.Core as Ledger
-import qualified Cardano.Ledger.Language as Ledger
+import qualified Cardano.Ledger.Plutus.Language as Ledger
 
 import Cardano.Db (ScriptType (..), maybeToEither)
 import qualified Cardano.Db.Old.V13_0 as DB_V_13_0
@@ -49,7 +49,7 @@ import Ouroboros.Consensus.Cardano.Block (HardForkBlock (BlockAllegra, BlockAlon
 import Ouroboros.Consensus.Shelley.Eras
 
 import Cardano.DbSync.Fix.PlutusDataBytes
-import Cardano.Ledger.Language (Plutus (..))
+import Cardano.Ledger.Plutus.Language (Plutus (..))
 
 newtype FixPlutusScripts = FixPlutusScripts {scriptsInfo :: [FixPlutusInfo]}
 

--- a/cardano-db-sync/test/Cardano/DbSync/Era/Shelley/Generic/ScriptDataTest.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/Era/Shelley/Generic/ScriptDataTest.hs
@@ -4,10 +4,10 @@
 module Cardano.DbSync.Era.Shelley.Generic.ScriptDataTest (tests) where
 
 import Cardano.DbSync.Era.Shelley.Generic.ScriptData
-import Cardano.Ledger.Alonzo.Scripts.Data (Data (..))
-import qualified Cardano.Ledger.Alonzo.Scripts.Data as Ledger
 import Cardano.Ledger.Api (Shelley ())
 import Cardano.Ledger.Binary.Decoding
+import Cardano.Ledger.Plutus.Data (Data (..))
+import qualified Cardano.Ledger.Plutus.Data as Ledger
 import Cardano.Prelude
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Base16 as Base16

--- a/cardano-db-tool/cardano-db-tool.cabal
+++ b/cardano-db-tool/cardano-db-tool.cabal
@@ -58,7 +58,7 @@ library
                       , base16-bytestring
                       , bytestring
                       , ansi-terminal
-                      , cardano-api
+                      , cardano-api ^>=8.33
                       , cardano-db
                       , cardano-db-sync
                       , cardano-ledger-alonzo

--- a/cardano-smash-server/cardano-smash-server.cabal
+++ b/cardano-smash-server/cardano-smash-server.cabal
@@ -72,8 +72,6 @@ library
                       , quiet
                       , resource-pool
                       , servant-server
-                      , servant-swagger
-                      , swagger2
                       , text
                       , time
                       , transformers-except

--- a/cardano-smash-server/src/Cardano/SMASH/Server/Api.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/Api.hs
@@ -19,7 +19,6 @@ module Cardano.SMASH.Server.Api (
 import Cardano.Prelude
 import Cardano.SMASH.Server.Types
 import Data.Aeson (FromJSON, ToJSON (..), eitherDecode, encode, object, (.=))
-import Data.Swagger (Swagger (..))
 import Network.Wai (Request, lazyRequestBody)
 import Servant (
   BasicAuth,
@@ -42,7 +41,6 @@ import Servant.Server.Internal (
   errBody,
   withRequest,
  )
-import Servant.Swagger (HasSwagger (..))
 import Prelude (String)
 
 -- Showing errors as JSON. To be reused when we need more general error handling.
@@ -136,11 +134,7 @@ type SmashAPI =
     :<|> AddTickerAPI
     :<|> FetchPoliciesAPI
 
--- | API for serving @swagger.json@.
-type SwaggerAPI = "swagger.json" :> Get '[JSON] Swagger
-
--- | Combined API of a Todo service with Swagger documentation.
-type API = SwaggerAPI :<|> SmashAPI
+type API = SmashAPI
 
 fullAPI :: Proxy API
 fullAPI = Proxy
@@ -148,11 +142,3 @@ fullAPI = Proxy
 -- | Just the @Proxy@ for the API type.
 smashApi :: Proxy SmashAPI
 smashApi = Proxy
-
--- For now, we just ignore the @Body@ definition.
-instance HasSwagger api => HasSwagger (Body name :> api) where
-  toSwagger _ = toSwagger (Proxy :: Proxy api)
-
--- For now, we just ignore the @BasicAuth@ definition.
-instance HasSwagger api => HasSwagger (BasicAuth name typo :> api) where
-  toSwagger _ = toSwagger (Proxy :: Proxy api)

--- a/cardano-smash-server/src/Cardano/SMASH/Server/Impl.hs
+++ b/cardano-smash-server/src/Cardano/SMASH/Server/Impl.hs
@@ -15,24 +15,20 @@ import Cardano.SMASH.Server.PoolDataLayer
 import Cardano.SMASH.Server.Types
 import Data.Aeson (encode)
 import qualified Data.ByteString.Lazy as LBS
-import Data.Swagger (Contact (..), Info (..), License (..), Swagger (..), URL (..))
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Data.Version (showVersion)
 import Paths_cardano_smash_server (version)
 import Servant (Handler (..), Server, err400, err403, err404, errBody, (:<|>) (..))
-import Servant.Swagger (toSwagger)
 
 data ServerEnv = ServerEnv
   { seTrace :: Trace IO Text
   , seDataLayer :: PoolDataLayer
   }
 
--- | Combined server of a Smash service with Swagger documentation.
 server :: ServerEnv -> Server API
 server serverEnv =
-  pure todoSwagger
-    :<|> getOffChainPoolMetadata serverEnv
+  getOffChainPoolMetadata serverEnv
     :<|> getHealthStatus
     :<|> getReservedTickers serverEnv
     :<|> getDelistedPools serverEnv
@@ -43,37 +39,6 @@ server serverEnv =
     :<|> checkPool serverEnv
     :<|> addTicker serverEnv
     :<|> fetchPolicies serverEnv
-
--- | Swagger spec for Todo API.
-todoSwagger :: Swagger
-todoSwagger =
-  let swaggerDefinition = toSwagger smashApi
-   in swaggerDefinition {_swaggerInfo = swaggerInfo}
-  where
-    smashVersion :: Text
-    smashVersion = toS $ showVersion version
-
-    swaggerInfo :: Info
-    swaggerInfo =
-      Info
-        { _infoTitle = "Smash"
-        , _infoDescription = Just "Stakepool Metadata Aggregation Server"
-        , _infoTermsOfService = Nothing
-        , _infoContact =
-            Just $
-              Contact
-                { _contactName = Just "IOHK"
-                , _contactUrl = Just $ URL "https://iohk.io/"
-                , _contactEmail = Just "operations@iohk.io"
-                }
-        , _infoLicense =
-            Just $
-              License
-                { _licenseName = "APACHE2"
-                , _licenseUrl = Just $ URL "https://github.com/input-output-hk/cardano-db-sync/blob/master/LICENSE"
-                }
-        , _infoVersion = smashVersion
-        }
 
 -- 403 if it is delisted
 -- 404 if it is not available (e.g. it could not be downloaded, or was invalid)

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -1,5 +1,8 @@
 # Schema Documentation for cardano-db-sync
 
+Schema version: 13.2.0.0 (from branch **kderme/update-node-8-7** which may not accurately reflect the version number)
+**Note:** This file is auto-generated from the documentation in cardano-db/src/Cardano/Db/Schema.hs by the command `cabal run -- gen-schema-docs doc/schema.md`. This document should only be updated during the release process and updated on the release branch.
+
 ### `schema_version`
 
 The version of the database schema. Schema versioning is split into three stages as detailed below. This table should only ever have a single row.
@@ -801,7 +804,7 @@ A table for every committee key de-registration. New in 13.2-Conway.
 | `id` | integer (64) |  |
 | `tx_id` | integer (64) | The Tx table index of the tx that includes this certificate. |
 | `cert_index` | integer (32) | The index of this deregistration within the certificates of this transaction. |
-| `hot_key` | bytea | The deregistered hot key hash |
+| `cold_key` | bytea | The deregistered cold key hash |
 | `voting_anchor_id` | integer (64) | The Voting anchor reference id |
 
 ### `drep_registration`

--- a/doc/smash.md
+++ b/doc/smash.md
@@ -165,6 +165,7 @@ Interacting with a server via a regular HTTP protocol is unsafe since it is usin
 ## How to get the Swagger/OpenAPI info?
 
 First, run the application. Then, go to the localhost and copy the content into an [editor](https://editor.swagger.io/).
+TODO: Swagger has been disabled in recent releases.
 
 ## Delisting feature
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1698829226,
-        "narHash": "sha256-OBUn6pmiCBdufRguopaEcX4P17+lCUDRvkPWe+Zw85Q=",
+        "lastModified": 1701085773,
+        "narHash": "sha256-R4931htVMyz67VAOrnucHwJqg9pg7ugQ6Us2gIpeD8A=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "ed556064d76437dffe96852b5635958df469fdb5",
+        "rev": "cb16e4a295c594cd1d5f02008e4dd03eb6061d25",
         "type": "github"
       },
       "original": {
@@ -918,11 +918,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1698798436,
-        "narHash": "sha256-Ifn2zipHCxfptZZk6spjD/ftJkj369hfG4+wU0RmyD0=",
+        "lastModified": 1701044613,
+        "narHash": "sha256-OdiZwE4on2vev78bykz4pm9zsapWrzdPcxvrAki48vI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "868e67700a89b0fdda60695fe129afffa048e4a5",
+        "rev": "7fa495d9f3beec14b32ea20f3388516aa2e64481",
         "type": "github"
       },
       "original": {
@@ -1016,11 +1016,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1697451482,
-        "narHash": "sha256-KAuNGPVBgk+VL930ADRNr9D/obdRTsUDBlaTlUdIAqo=",
+        "lastModified": 1701053834,
+        "narHash": "sha256-4sH4//POARjeKJv1mu8aU4W4A28GYqrj9KB3PqusHis=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e22ee1836c855c0a0a4862ad8b92c3a405c8b55c",
+        "rev": "7c491c55157208575c70c7b8434e9d4a1cf173a6",
         "type": "github"
       },
       "original": {
@@ -1317,11 +1317,11 @@
         "sodium": "sodium_3"
       },
       "locked": {
-        "lastModified": 1698746924,
-        "narHash": "sha256-8og+vqQPEoB2KLUtN5esGMDymT+2bT/rCHZt1NAe7y0=",
+        "lastModified": 1698999258,
+        "narHash": "sha256-42D1BMbdyZD+lT+pWUzb5zDQyasNbMJtH/7stuPuPfE=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "af551ca93d969d9715fa9bf86691d9a0a19e89d9",
+        "rev": "73dc2bb45af6f20cfe1d962f1334eed5e84ae764",
         "type": "github"
       },
       "original": {
@@ -2266,11 +2266,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1697414975,
-        "narHash": "sha256-LWi7J8UZBUTJQ1C6B3J3wSBMO16QLu3BGEZX63R8Efo=",
+        "lastModified": 1701043780,
+        "narHash": "sha256-d5CYT7WGEaL6IFNmUg4JUb+onxI/tO1qgHs/TCIKB3A=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "0dc5411664dde81964454397944824a86c5b1c98",
+        "rev": "cb49435b81adf0549589c51f39b5b38b4369f106",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

2 issues with this pr
- [x]  nix build -v .#cardano-db-sync -o db-sync-node
returns 
```
error: flake 'git+file:///home/kostas/programming/cardano-db-sync' does not provide attribute 'packages.x86_64-linux.cardano-db-sync', 'legacyPackages.x86_64-linux.cardano-db-sync' or 'cardano-db-sync'
```

- [x] swagger2 hash aeson < 2.2 and ledger has aeson > 2.2
So temporarily we have disabled smash. Tests also don't build.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
