### PR TITLE
Fixes for Sancho 2-3-0 migrations

### DIFF
--- a/schema/migration-2-0030-20231017.sql
+++ b/schema/migration-2-0030-20231017.sql
@@ -7,10 +7,12 @@ BEGIN
   SELECT stage_two + 1 INTO next_version FROM schema_version ;
   IF next_version = 30 THEN
     EXECUTE 'ALTER TABLE "pool_offline_data" RENAME TO "off_chain_pool_data"' ;
+    EXECUTE 'ALTER SEQUENCE "pool_offline_data_id_seq" RENAME TO "off_chain_pool_data_id_seq"' ;
     EXECUTE 'ALTER TABLE "off_chain_pool_data" RENAME CONSTRAINT "unique_pool_offline_data" TO "unique_off_chain_pool_data"' ;
     EXECUTE 'ALTER TABLE "off_chain_pool_data" RENAME CONSTRAINT "pool_offline_data_pkey" TO "off_chain_pool_data_pkey"' ;
 
     EXECUTE 'ALTER TABLE "pool_offline_fetch_error" RENAME TO "off_chain_pool_fetch_error"' ;
+    EXECUTE 'ALTER SEQUENCE "pool_offline_fetch_error_id_seq" RENAME TO "off_chain_pool_fetch_error_id_seq"' ;
     EXECUTE 'ALTER TABLE "off_chain_pool_fetch_error" RENAME CONSTRAINT "unique_pool_offline_fetch_error" TO "unique_off_chain_pool_fetch_error"' ;
     EXECUTE 'ALTER TABLE "off_chain_pool_fetch_error" RENAME CONSTRAINT "pool_offline_fetch_error_pkey" TO "off_chain_pool_fetch_error_pkey"' ;
 

--- a/schema/migration-2-0032-20231107.sql
+++ b/schema/migration-2-0032-20231107.sql
@@ -6,8 +6,7 @@ DECLARE
 BEGIN
   SELECT stage_two + 1 INTO next_version FROM schema_version ;
   IF next_version = 32 THEN
-    EXECUTE 'ALTER TABLE "committee_de_registration" ADD COLUMN "cold_key" bytea NOT NULL' ;
-    EXECUTE 'ALTER TABLE "committee_de_registration" DROP COLUMN "hot_key"' ;
+    EXECUTE 'ALTER TABLE "committee_de_registration" RENAME COLUMN "cold_key" TO "hot_key"' ;
     EXECUTE 'CREATe TABLE "off_chain_anchor_data"("id" SERIAL8  PRIMARY KEY UNIQUE,"voting_anchor_id" INT8 NOT NULL,"hash" BYTEA NOT NULL,"json" jsonb NOT NULL,"bytes" bytea NOT NULL)' ;
     EXECUTE 'CREATe TABLE "off_chain_anchor_fetch_error"("id" SERIAL8  PRIMARY KEY UNIQUE,"voting_anchor_id" INT8 NOT NULL,"fetch_error" VARCHAR NOT NULL,"retry_count" word31type NOT NULL)' ;
     -- Hand written SQL statements can be added here.


### PR DESCRIPTION
The `cold_key` to `hot_key` otherwise fails on populated table.

Second one is just a sequence renaming to match table renaming.