### PR TITLE
CI: Increase timeout to 6 seconds on restart tests

### DIFF
--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Config/MigrateConsumedPruneTxOut.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway/Config/MigrateConsumedPruneTxOut.hs
@@ -406,7 +406,7 @@ migrateAndPruneRestart =
     newEnv <- replaceConfigFile "test-db-sync-config.json" dbSync
     startDBSync newEnv
     -- There is a slight delay before the flag is checked
-    threadDelay 3_000_000
+    threadDelay 6_000_000
     -- Expected to fail
     checkStillRuns dbSync
   where
@@ -432,7 +432,7 @@ pruneRestartMissingFlag =
     newEnv <- replaceConfigFile "test-db-sync-config.json" dbSync
     startDBSync newEnv
     -- There is a slight delay before the flag is checked
-    threadDelay 3_000_000
+    threadDelay 6_000_000
     -- Expected to fail
     checkStillRuns dbSync
   where
@@ -458,7 +458,7 @@ bootstrapRestartMissingFlag =
     newEnv <- replaceConfigFile "test-db-sync-config.json" dbSync
     startDBSync newEnv
     -- There is a slight delay befor the flag is checked
-    threadDelay 3_000_000
+    threadDelay 6_000_000
     -- Expected to fail
     checkStillRuns dbSync
   where


### PR DESCRIPTION
# Description

When fingerprints are missing, it takes much longer to run these tests, and 3 seconds may not be long enough to exit on slower runners

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/cardano-db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
