### PR TITLE
Nix: Fix wrong git revision in version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,11 +65,12 @@
 
                 (final: prev:
                   let
-                    profiled = project.profiled.exes;
+                    profiled = builtins.mapAttrs (_: setGitRev) project.profiled.exes;
+                    exes = builtins.mapAttrs (_: setGitRev) project.exes;
                   in {
                     # The cardano-db-sync NixOS module (nix/nixos/cardano-db-sync-service.nix)
                     # expects these to be here
-                    inherit (project.exes)
+                    inherit (exes)
                       cardano-db-sync
                       cardano-db-tool
                       cardano-smash-server;
@@ -111,6 +112,8 @@
                 })
               ];
           };
+
+          setGitRev = nixpkgs.setGitRev (self.rev or "dirty");
 
           # Set up and start Postgres before running database tests
           preCheck = ''
@@ -523,7 +526,7 @@
                 cardano-smash-server-docker
                 project;
 
-              default = flake.packages."cardano-db-sync:exe:cardano-db-sync";
+              default = setGitRev flake.packages."cardano-db-sync:exe:cardano-db-sync";
             } // lib.optionalAttrs (system == "x86_64-darwin") {
               inherit cardano-db-sync-macos;
             } // {

--- a/flake.nix
+++ b/flake.nix
@@ -63,22 +63,18 @@
                   inherit (project.hsPkgs.cardano-cli.components.exes) cardano-cli;
                 })
 
-                (final: prev:
-                  let
-                    profiled = builtins.mapAttrs (_: setGitRev) project.profiled.exes;
-                    exes = builtins.mapAttrs (_: setGitRev) project.exes;
-                  in {
-                    # The cardano-db-sync NixOS module (nix/nixos/cardano-db-sync-service.nix)
-                    # expects these to be here
-                    inherit (exes)
-                      cardano-db-sync
-                      cardano-db-tool
-                      cardano-smash-server;
+                (final: prev: {
+                  # The cardano-db-sync NixOS module (nix/nixos/cardano-db-sync-service.nix)
+                  # expects these to be here
+                  inherit (exes)
+                    cardano-db-sync
+                    cardano-db-tool
+                    cardano-smash-server;
 
-                    cardano-db-sync-profiled = profiled.cardano-db-sync;
-                    cardano-smash-server-profiled = profiled.cardano-smash-server;
+                  cardano-db-sync-profiled = profiledExes.cardano-db-sync;
+                  cardano-smash-server-profiled = profiledExes.cardano-smash-server;
 
-                    schema = ./schema;
+                  schema = ./schema;
                   })
 
                 (final: prev: {
@@ -113,7 +109,6 @@
               ];
           };
 
-          setGitRev = nixpkgs.setGitRev (self.rev or "dirty");
 
           # Set up and start Postgres before running database tests
           preCheck = ''
@@ -383,6 +378,17 @@
             })
           ];
 
+          setGitRev = nixpkgs.setGitRev (self.rev or "dirty");
+
+          setGitRevs = exes: 
+            with nixpkgs.lib; pipe exes [
+              (filterAttrs (_: isDerivation))
+              (mapAttrs (_: setGitRev))
+            ];
+
+          exes = setGitRevs project.exes;
+          profiledExes = setGitRevs project.profiled.exes;
+
           staticChecks =
             let
               inherit (project.args) src compiler-nix-name;
@@ -398,10 +404,7 @@
           let
             mkDist = platform: project:
               let
-                exes = with lib; pipe project.exes [
-                  (collect isDerivation)
-                  (map setGitRev)
-                ];
+                exeVals = builtins.attrValues exes;
                 name = "cardano-db-sync-${version}-${platform}";
                 version = project.exes.cardano-db-sync.identifier.version;
                 env = {
@@ -418,7 +421,7 @@
                       --no-clobber \
                       --remove-destination \
                       --verbose \
-                      ${lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exes} \
+                      ${lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exeVals} \
                        ./bin
 
                     # Copy magrations to intermediate dir
@@ -436,7 +439,7 @@
                        (platform == "macos")
                        (lib.concatMapStrings
                          (exe: "rewrite-libs . ${exe}/bin/*")
-                         exes)}
+                         exeVals)}
 
                     # Package distribution
                     dist_file=${name}.tar.gz
@@ -484,8 +487,6 @@
               else
                 drv;
 
-            setGitRev = nixpkgs.setGitRev (self.rev or "dirty");
-
           in rec {
             checks = staticChecks;
 
@@ -526,7 +527,7 @@
                 cardano-smash-server-docker
                 project;
 
-              default = setGitRev flake.packages."cardano-db-sync:exe:cardano-db-sync";
+              default = exes.cardano-db-sync;
             } // lib.optionalAttrs (system == "x86_64-darwin") {
               inherit cardano-db-sync-macos;
             } // {


### PR DESCRIPTION
# Description

Fixes #1961. Setting the git revision generally works, but the following packages were missed:

 * cardano-db-sync, cardano-smash-server, cardano-db-tool (via legacyPackages)
 * packages.default (`nix build .\#`)

This change fixes them. In addition, I've tried to remove duplicated calls to `setGitRev` to prevent more of these from coming up.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
