### PR TITLE
docs: update instructions

### DIFF
--- a/doc/building-running.md
+++ b/doc/building-running.md
@@ -36,15 +36,15 @@ nix run .#mainnet/node
 ```
 
 More detailed instructions on GHC, Cabal, libraries and `cardano-node` setup can be found here:
-- [Installing Cardano Node from source](https://github.com/IntersectMBO/cardano-node/blob/master/doc/getting-started/install.md)
-- [Building Cardano Node with nix](https://github.com/IntersectMBO/cardano-node/blob/master/doc/getting-started/building-the-node-using-nix.md)
+- [Installing Cardano Node from source](https://developers.cardano.org/docs/get-started/cardano-node/installing-cardano-node/#building-from-source)
+- [Building Cardano Node with nix](https://developers.cardano.org/docs/get-started/cardano-node/installing-cardano-node/#building-via-nix)
 
 ### Set up and run the db-sync node
 
 - Install secp256k1 library as a prerequisite for building with cabal:
 
 ``` shell
-./scripts/secp256k1-setup.sh ac83be33d0956faf6b7f61a60ab524ef7d6a473a
+./scripts/secp256k1-setup.sh acf5c55ae6a94e5ca847e07def40427547876101
 # Check ./github/workflows/haskell.yml to validate the git sha above.
 
 # On Linux

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -12,7 +12,6 @@
   - `--fix-only`: Runs only the db-sync fix procedure for the wrong datum, redeemer_data, and plutus script bytes and exits.
   - `--disable-cache`: Disables the db-sync caches. Reduces memory usage but it takes longer to sync.
   - `--rollback-to-slot SLOTNO`: Force a rollback to the specified slot, if the given slot doesn't exist it will use the next greater slot.
-  - `--disable-in-out`: Disables the `tx_in` and `tx_out` table.
 
 - **Deprecated Options (for historical reference only):**
   - For more details, refer to [Configuration Documentation](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/configuration.md)
@@ -26,6 +25,7 @@
   - `--disable-plutus-extra`
   - `--disable-gov`
   - `--disable-offchain-pool-data`
+  - `--disable-in-out`
   - `--force-tx-in`
   - `--disable-all`
   - `--full`

--- a/doc/community-tools.md
+++ b/doc/community-tools.md
@@ -1,4 +1,4 @@
-#Community tools
+# Community tools
 
 This section provides a list of community-developed tools that integrate with cardano-db-sync. We appreciate the efforts of these developers in expanding the ecosystem. If you have a tool you'd like to add to this list, please open an issue or a pull request.
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -552,7 +552,7 @@ This will effect all governance related data/functionality.
 `remove_jsonb_from_schema`
 
 To improve inserting performance you can remove Jsonb data types in the schema. They can be reintroduced by using `disable` or by simply not using all together.
-A warning will logw if `remove_jsonb_from_schema` was previously set to `enable` and then either removed from the configuration file or set to `disabled`.
+A warning will log if `remove_jsonb_from_schema` was previously set to `enable` and then either removed from the configuration file or set to `disabled`.
 
 * Type: `string`
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -71,9 +71,6 @@ entrypoint. Possible values are:
  * mainnet
  * preprod
  * preview
- * private
- * sanchonet
- * shelley_qa
 
 #### `POSTGRES_HOST` (required)
 
@@ -202,9 +199,6 @@ entrypoint. Possible values are:
  * mainnet
  * preprod
  * preview
- * private
- * sanchonet
- * shelley_qa
 
 #### `POSTGRES_HOST` (required)
 

--- a/doc/installing-with-nix.md
+++ b/doc/installing-with-nix.md
@@ -9,7 +9,7 @@ build Cardano DB Sync.
 This guide assumes you have the following tools:
 
  * [Nix](https://nixos.org/download.html)
- * [Cardano Node](https://github.com/IntersectMBO/cardano-node/blob/master/doc/getting-started/building-the-node-using-nix.md)
+ * [Cardano Node](https://developers.cardano.org/docs/get-started/cardano-node/installing-cardano-node/)
 
 Nix will handle all other dependencies.
 

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -5,15 +5,15 @@
 This guide assumes you have the following tools:
 
  * [Git](https://git-scm.com/download)
- * [Cardano Node](https://github.com/IntersectMBO/cardano-node/blob/master/doc/getting-started/install.md)
+ * [Cardano Node](https://developers.cardano.org/docs/get-started/cardano-node/installing-cardano-node/)
  * [Postgres Development Libraries (libpq)](https://www.postgresql.org/download/)
  * [ICU Development Libraries (libicu-dev)](https://unicode-org.github.io/icu/download/)
  * [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
 
 In addition, Cardano DB Sync requires the following software (instructions below):
 
- * [GHC](https://www.haskell.org/ghcup/install/) >= 8.10.7
- * [Cabal](https://www.haskell.org/ghcup/install/) >= 3.10.1.0
+ * [GHC](https://www.haskell.org/ghcup/install/) >= 9.6.7
+ * [Cabal](https://www.haskell.org/ghcup/install/) >= 3.10.2.0
  * [libsodium-vrf](https://github.com/IntersectMBO/libsodium)
  * [secp256k1](https://github.com/bitcoin-core/secp256k1)
  * [blst](https://github.com/supranational/blst)
@@ -42,10 +42,10 @@ dependencies.
 Once GHCup is installed, open a new terminal (to get an updated environment) and run:
 
 ```bash
-ghcup install ghc 8.10.7
-ghcup install cabal 3.10.1.0
-ghcup set ghc 8.10.7
-ghcup set cabal 3.10.1.0
+ghcup install ghc 9.6.7
+ghcup install cabal 3.10.2.0
+ghcup set ghc 9.6.7
+ghcup set cabal 3.10.2.0
 ```
 
 Check that you will use the GHCup tools (and not any other installation on the system):
@@ -236,7 +236,7 @@ Explicitly set the GHC version that we installed earlier. This avoids defaulting
 system version of GHC that might be different than the one you have installed.
 
 ```bash
-echo "with-compiler: ghc-8.10.7" >> cabal.project.local
+echo "with-compiler: ghc-9.6.7" >> cabal.project.local
 ```
 
 macOS installs OpenSSL in a different location than expected by default. If you have

--- a/doc/running.md
+++ b/doc/running.md
@@ -5,7 +5,7 @@
 This guide assumes you have the following tools:
 
  * [Git](https://git-scm.com/download)
- * [Cardano Node](https://github.com/input-output-hk/cardano-node-wiki/blob/main/docs/getting-started/install.md)
+ * [Cardano Node](https://developers.cardano.org/docs/get-started/cardano-node/installing-cardano-node/)
  * [Cardano DB Sync](installing.md)
 
 ## Download Configuration Files
@@ -13,7 +13,7 @@ This guide assumes you have the following tools:
 Create a directory to store configs
 
 ```bash
-mkdir -p ~/src/cardano-environments/{mainnet,preprod,preview,sanchonet}
+mkdir -p ~/src/cardano-environments/{mainnet,preprod,preview}
 cd ~/src/cardano-environments
 ```
 
@@ -39,7 +39,7 @@ cardano-node run \
     --config ~/src/cardano-environments/config.json
     --topology ~/src/cardano-environments/topology.json \
     --database-path ~/src/cardano-environments/mainnet/db \
-    --socket-path node.socket \
+    --socket-path ~/src/cardano-environments/mainnet/node.socket \
     --host-addr 0.0.0.0 
 ```
 

--- a/doc/schema-management.md
+++ b/doc/schema-management.md
@@ -32,7 +32,7 @@ where the `1` denotes "stage 1" of the SQL migration, the `0000` is the migratio
 last number is the date. Listing the directory containing the schema and sorting the list will
 order them in the correct order for applying to the database.
 
-Since the introduction of `use_address_table` [config](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/configuration.md#tx-out). The file `migration-4-001-*` when indexing will not be ran when the this configuration is active.
+Since the introduction of `use_address_table` [config](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/configuration.md#address-table), the `migration-4-001-*` file will not be executed during indexing when this configuration is active.
 
 There is also a flag you can use in cardano-db-tool `--use-tx-out-address` which handles the alternate variation of the schema, one might be using.
 

--- a/doc/smash.md
+++ b/doc/smash.md
@@ -14,7 +14,7 @@ The first generation of SMASH server has been deployed by Input Output Global (I
 
 Exchanges, for example, can use the same functionality to keep track of stake pool metadata. SMASH will allow an exchange to fetch stake pool metadata and verify its content against the on-chain registered hash. The exchange can then check existing metadata for correctness (size limits, content), create new stake pools manually, and reserve their ticker names. In case there is a stake pool with a duplicated ticker name, counterfeit or offensive content, it will be possible to delist this pool.
 
-## SMASH Characteristics**
+## SMASH Characteristics
 
 There are two main parts of SMASH:
 
@@ -70,7 +70,7 @@ SMASH records and serves the following subset of information:
 
 More information about the pool metadata (the `PoolMetaData` record) can be found [here](https://github.com/IntersectMBO/cardano-ledger/blob/4458fdba7e2211f63e7f28ecd3f9b55b02eee071/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs#L62)
 
-Stake pool metadata information can be also found in [The mainnet metadata Design Specification for Delegation and Incentives in Cardano](https://hydra.iohk.io/build/790053/download/1/delegation_design_spec.pdf) section 4.2 Stake Pool Metadata, p.30.
+Stake pool metadata information can be also found in [The mainnet metadata Design Specification for Delegation and Incentives in Cardano](https://github.com/intersectmbo/cardano-ledger/releases/latest/download/shelley-delegation.pdf) section 4.2 Stake Pool Metadata, p.30.
 
 
 ## Installation

--- a/doc/syncing-and-rollbacks.md
+++ b/doc/syncing-and-rollbacks.md
@@ -26,7 +26,7 @@ argument to `db-sync`. This ledger state directory must persist across machine r
 Each ledger state is valid only for a specific block. It is not valid for any block before
 or any block after the block it is valid for.
 
-The option `--state-dir` can be ommited when one doesn't want to use local ledger, for the omittion to work a `--disable-ledger` flag should be used, more information on what this flag does can be found [here](./configuration.md#--disable-ledger).
+The option `--state-dir` can be ommited when one doesn't want to use local ledger, for the omittion to work a `--disable-ledger` flag should be used, more information on what this flag does can be found [here](./configuration.md#ledger).
 
 
 ## Concurrency


### PR DESCRIPTION
- Remove old links that return 404
- For `secp256k1` we use `v0.3.2` https://github.com/input-output-hk/iohk-nix/blob/master/flake.nix
```sh
secp256k1 = { url = "github:bitcoin-core/secp256k1?ref=v0.3.2"; flake = false; };
```
which has different revison: https://github.com/bitcoin-core/secp256k1/releases/tag/v0.3.2

```sh
secp256k1$ git co v0.3.2
HEAD is now at acf5c55 Merge bitcoin-core/secp256k1#1312: release: Prepare for 0.3.2

secp256k1$ git last
commit acf5c55ae6a94e5ca847e07def40427547876101 (HEAD, tag: v0.3.2)
Merge: 3e3d125 d490ca2
Author: Tim Ruffing <crypto@timruffing.de>
Date:   Sat May 13 19:38:26 2023 +0200

    Merge bitcoin-core/secp256k1#1312: release: Prepare for 0.3.2

```

- Remove not existing anymore environments: `sanchonet`, `private`
- Fix typos, wrong anchors
- Update `ghc` to `9.6.7` and `cabal` to `3.10.2.0` - the same versions as in official node instruction