### PR TITLE
Nix: Add back required libpq static linking flags

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -244,11 +244,8 @@
                     # libpq static is pretty broken in nixpkgs. We can't rely on the
                     # pkg-config, so we have to add the correct libraries ourselves
                     #
-                    # TODO[sgillespie]: Are these still required? Review the
-                    # postgresql/nixpkgs packaging scripts
-                    #
-                    # "-optl-Wl,-lpgcommon"
-                    # "-optl-Wl,-lpgport"
+                    "-optl-Wl,-lpgcommon"
+                    "-optl-Wl,-lpgport"
                     "-optl-Wl,-lm"
 
                     # Since we aren't using pkg-config, it won't automatically include


### PR DESCRIPTION
# Description

Add back the following linker options:

 * -lpgcommon
 * -lpgport

These got removed at some point to test if they were still needed (they are), but for some reason never got added back.

# Checklist

- [X] Commit sequence broadly makes sense
- [X] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [X] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
