### PR TITLE
Make core-tech-dbsync-maintainers code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,20 +1,2 @@
 # General reviewers per PR
-* @IntersectMBO/core-tech-dbsync
-
-# Specific reviewers for code pieces
-# NB - The last matching pattern takes precedence
-
-# /doc folder and README.* needs to be owned by @docs-access
-doc                          @input-output-hk/docs-access @IntersectMBO/core-tech-dbsync
-Readme.*                     @input-output-hk/docs-access @IntersectMBO/core-tech-dbsync
-CONTRIBUTING.rst             @input-output-hk/docs-access @IntersectMBO/core-tech-dbsync
-
-# DevOps
-.github                      @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
-/config                      @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
-nix                          @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
-*.nix                        @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
-flake.lock                   @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
-bors.toml                    @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
-docker-compose.yml           @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
-scripts/postgresql-setup.sh  @IntersectMBO/core-tech-devx @IntersectMBO/core-tech-release
+* @IntersectMBO/core-tech-dbsync-maintainers


### PR DESCRIPTION
# Description

Instead of having separate groups for certain files, core-tech-db-sync-maintainers owns all files in this repository. This will make getting reviews easier, as it involves the people most familiar with the code base.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
