### PR TITLE
Respect default umask in distribution archive

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -406,6 +406,7 @@
                     # Copy exes to intermediate dir
                     cp \
                       --no-clobber \
+                      --no-preserve=mode \
                       --remove-destination \
                       --verbose \
                       ${lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exes} \
@@ -414,6 +415,7 @@
                     # Copy magrations to intermediate dir
                     cp \
                       --no-clobber \
+                      --no-preserve=mode \
                       --remove-destination \
                       --verbose \
                       --recursive \


### PR DESCRIPTION
# Description

When copying files from the nix store to the intermediate directory, ignore the source file permissions. These are coming from the nix store, so they will not be writable.

Without this change, this will result in unexpected `Permission denied` when manipulating extracted files.

Fixes: #2022

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.10.1.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
