### PR TITLE
1966 - offchain image metadata

### DIFF
--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -352,7 +352,7 @@ test-suite test
                         Cardano.DbSync.Era.Shelley.Generic.ScriptDataTest
                         Cardano.DbSync.Era.Shelley.Generic.ScriptTest
                         Cardano.DbSync.Gen
-                        Cardano.DbSync.OffChain.VoteTest
+                        Cardano.DbSync.OffChain.Vote.TypesTest
                         Cardano.DbSync.Util.AddressTest
                         Cardano.DbSync.Util.Bech32Test
                         Cardano.DbSync.Util.CborTest

--- a/cardano-db-sync/src/Cardano/DbSync/OffChain/Vote/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/OffChain/Vote/Types.hs
@@ -284,8 +284,9 @@ instance FromJSON Image where
         | (_, tb) <- Text.break (== '/') ctb
         , Text.isPrefixOf "/" tb
         , (_, b) <- Text.break (== ';') tb
-        , Just imageData <- Text.stripPrefix ";base64," b ->
-            pure $ Image (TextValue imageData) Nothing
+        , Just _ <- Text.stripPrefix ";base64," b ->
+            -- Store the full data URI including prefix
+            pure $ Image curl Nothing
       _ -> fromImageUrl <$> parseJSON v
     where
       withObjectV v' s p = withObject s p v'

--- a/cardano-db-sync/test/Cardano/DbSync/OffChain/Vote/TypesTest.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/OffChain/Vote/TypesTest.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.DbSync.OffChain.Vote.TypesTest (tests) where
+
+import Cardano.DbSync.OffChain.Vote.Types
+import Cardano.Prelude
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text as Text
+import Hedgehog
+import qualified Hedgehog as H
+import Prelude ()
+
+tests :: IO Bool
+tests =
+  checkParallel $
+    Group
+      "Cardano.DbSync.OffChain.Vote.Types"
+      [ ("Image preserves data URI prefix", prop_image_preserves_data_uri_prefix)
+      , ("Image handles URL with hash", prop_image_handles_url_with_hash)
+      , ("Image preserves JPEG data URI", prop_image_preserves_jpeg_data_uri)
+      ]
+
+prop_image_preserves_data_uri_prefix :: Property
+prop_image_preserves_data_uri_prefix = property $ do
+  let jsonWithDataUri =
+        LBS.fromStrict $
+          encodeUtf8
+            "{ \"contentUrl\": \"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA\" }"
+
+  case Aeson.eitherDecode jsonWithDataUri of
+    Left err -> do
+      H.footnote $ "Parse failed: " <> err
+      H.failure
+    Right (img :: Image) -> do
+      let imgContent = textValue $ content img
+      H.assert $ "data:" `Text.isPrefixOf` imgContent
+      H.assert $ "image/png" `Text.isInfixOf` imgContent
+      H.assert $ "base64" `Text.isInfixOf` imgContent
+      imgContent === "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
+
+prop_image_handles_url_with_hash :: Property
+prop_image_handles_url_with_hash = property $ do
+  let jsonWithUrl =
+        LBS.fromStrict $
+          encodeUtf8
+            "{ \"contentUrl\": \"https://example.com/image.png\", \"sha256\": \"abc123\" }"
+
+  case Aeson.eitherDecode jsonWithUrl of
+    Left err -> do
+      H.footnote $ "Parse failed: " <> err
+      H.failure
+    Right (img :: Image) -> do
+      textValue (content img) === "https://example.com/image.png"
+      (textValue <$> msha256 img) === Just "abc123"
+
+prop_image_preserves_jpeg_data_uri :: Property
+prop_image_preserves_jpeg_data_uri = property $ do
+  let jsonWithJpeg =
+        LBS.fromStrict $
+          encodeUtf8
+            "{ \"contentUrl\": \"data:image/jpeg;base64,/9j/4AAQSkZJRg\" }"
+
+  case Aeson.eitherDecode jsonWithJpeg of
+    Left err -> do
+      H.footnote $ "Parse failed: " <> err
+      H.failure
+    Right (img :: Image) -> do
+      let imgContent = textValue $ content img
+      imgContent === "data:image/jpeg;base64,/9j/4AAQSkZJRg"

--- a/cardano-db-sync/test/Main.hs
+++ b/cardano-db-sync/test/Main.hs
@@ -4,7 +4,7 @@ import qualified Cardano.DbSync.ApiTest as Api
 import qualified Cardano.DbSync.Config.TypesTest as Types
 import qualified Cardano.DbSync.Era.Shelley.Generic.ScriptDataTest as ScriptData
 import qualified Cardano.DbSync.Era.Shelley.Generic.ScriptTest as Script
-import qualified Cardano.DbSync.OffChain.VoteTest as VoteTest
+import qualified Cardano.DbSync.OffChain.Vote.TypesTest as VoteTypes
 import qualified Cardano.DbSync.Util.AddressTest as Address
 import qualified Cardano.DbSync.Util.Bech32Test as Bech32
 import qualified Cardano.DbSync.Util.CborTest as Cbor
@@ -24,5 +24,5 @@ main =
     , DbSync.tests
     , Types.tests
     , Api.tests
-    , VoteTest.tests
+    , VoteTypes.tests
     ]

--- a/cardano-db/src/Cardano/Db/Statement/OffChain.hs
+++ b/cardano-db/src/Cardano/Db/Statement/OffChain.hs
@@ -507,7 +507,9 @@ insertBulkOffChainVoteData offChainVoteData = do
 
 insertBulkOffChainVoteDrepDataStmt :: HsqlStmt.Statement [SO.OffChainVoteDrepData] ()
 insertBulkOffChainVoteDrepDataStmt =
-  insertBulk
+  insertBulkWith
+    (ReplaceWithColumns ["off_chain_vote_data_id"])
+    False
     extractOffChainVoteDrepData
     SO.offChainVoteDrepDataBulkEncoder
     NoResultBulk


### PR DESCRIPTION
# Description

This fixes #1966 

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
