### PR TITLE
CI / add input-output-hk dependencies

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -47,6 +47,11 @@ jobs:
           minimal: false
           # enable IOG-full flavour to bring in all the crypto libraries we need.
           iog-full: true
+      # TODO: remove when input-output-hk/devx is fixed
+      - name: Install system dependencies
+        uses: input-output-hk/actions/base@latest
+        with:
+          use-sodium-vrf: true
       - name: cache cabal
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
# Description

Just copied what cardano-node does for their dependencies https://github.com/IntersectMBO/cardano-node/blob/master/.github/workflows/haskell.yml#L95-L98

This fixes the lmdb missing in CI.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
