### PR TITLE
Drop use of partial List functions

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/Ledger/State.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Ledger/State.hs
@@ -705,7 +705,7 @@ listMemorySnapshots env = do
       case AS.toNewestFirst $ ledgerDbCheckpoints ldb of
         [] -> []
         [a] -> [a]
-        ls -> [List.head ls, List.last ls]
+        (h : ls) -> catMaybes [Just h, lastMay ls]
     notGenesis GenesisPoint = False
     notGenesis (BlockPoint _ _) = True
 


### PR DESCRIPTION
# Description

Ghc-9.10 and later warn about use of partial functions like `List.head`.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
