### PR TITLE
2051 - Era aware pointer addresses

### DIFF
--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Unit/Conway.hs
@@ -156,6 +156,7 @@ unitTests iom knownMigrations =
         , test "stake address pointers" Stake.stakeAddressPtr
         , test "stake address pointers deregistration" Stake.stakeAddressPtrDereg
         , test "stake address pointers. Use before registering." Stake.stakeAddressPtrUseBefore
+        , test "stake address pointers have NULL stake_address_id in Conway" Stake.stakeAddressPtrNullInConway
         , test "register stake creds" Stake.registerStakeCreds
         , test "register stake creds with shelley disabled" Stake.registerStakeCredsNoShelley
         ]

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Shelley/Genesis.hs
@@ -26,6 +26,7 @@ import Cardano.DbSync.Era.Universal.Insert.Certificate (insertDelegation, insert
 import Cardano.DbSync.Era.Universal.Insert.Other (insertStakeAddressRefIfMissing)
 import Cardano.DbSync.Era.Universal.Insert.Pool (insertPoolRegister)
 import Cardano.DbSync.Error
+import Cardano.DbSync.Types (BlockEra (..))
 import Cardano.DbSync.Util
 import Cardano.Ledger.Address (serialiseAddr)
 import qualified Cardano.Ledger.Coin as Ledger
@@ -269,7 +270,7 @@ insertTxOuts syncEnv blkId (TxIn txInId _, txOut) = do
           }
 
   tryUpdateCacheTx (envCache syncEnv) txInId txId
-  _ <- insertStakeAddressRefIfMissing (withNoCache syncEnv) (txOut ^. Core.addrTxOutL)
+  _ <- insertStakeAddressRefIfMissing (withNoCache syncEnv) (txOut ^. Core.addrTxOutL) Shelley
   case ioTxOutVariantType . soptInsertOptions $ envOptions syncEnv of
     DB.TxOutVariantCore ->
       void

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Block.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Block.hs
@@ -97,7 +97,7 @@ insertBlockUniversal syncEnv shouldLog withinTwoMins withinHalfHour blk details 
 
     let zippedTx = zip [0 ..] (Generic.blkTxs blk)
     let txInserter = insertTx syncEnv isMember blkId (sdEpochNo details) (Generic.blkSlotNo blk) applyResult
-    blockGroupedData <- foldM (\gp (idx, tx) -> txInserter idx tx gp) mempty zippedTx
+    blockGroupedData <- foldM (\gp (idx, tx) -> txInserter idx tx gp (Generic.blkEra blk)) mempty zippedTx
 
     minIds <- insertBlockGroupedData syncEnv blockGroupedData
 

--- a/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Other.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Era/Universal/Insert/Other.hs
@@ -26,6 +26,7 @@ import qualified Cardano.DbSync.Era.Shelley.Generic as Generic
 import Cardano.DbSync.Era.Universal.Insert.Grouped
 import Cardano.DbSync.Era.Util (safeDecodeToJson)
 import Cardano.DbSync.Error (SyncNodeError)
+import Cardano.DbSync.Types (BlockEra (..))
 import Cardano.DbSync.Util
 import qualified Cardano.Ledger.Address as Ledger
 import qualified Cardano.Ledger.BaseTypes as Ledger
@@ -136,16 +137,21 @@ insertWithdrawals syncEnv txId redeemers txWdrl = do
 insertStakeAddressRefIfMissing ::
   SyncEnv ->
   Ledger.Addr ->
+  BlockEra ->
   ExceptT SyncNodeError DB.DbM (Maybe DB.StakeAddressId)
-insertStakeAddressRefIfMissing syncEnv addr =
+insertStakeAddressRefIfMissing syncEnv addr era =
   case addr of
     Ledger.AddrBootstrap {} -> pure Nothing
     Ledger.Addr nw _pcred sref ->
       case sref of
         Ledger.StakeRefBase cred -> do
           Just <$> queryOrInsertStakeAddress syncEnv UpdateCache nw cred
-        Ledger.StakeRefPtr ptr -> do
-          lift $ DB.queryStakeRefPtr ptr
+        Ledger.StakeRefPtr ptr ->
+          -- In Conway era onwards, Pointer addresses are treated as Enterprise addresses
+          case era of
+            Conway -> pure Nothing
+            Dijkstra -> pure Nothing
+            _ -> lift $ DB.queryStakeRefPtr ptr
         Ledger.StakeRefNull -> pure Nothing
 
 insertMultiAsset ::


### PR DESCRIPTION
# Description

This fixes #2051 

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
