### PR TITLE
cardano-db: Expose Cardano.Db.Types module

### DIFF
--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -35,6 +35,7 @@ library
                         Cardano.Db.Schema.Variants
                         Cardano.Db.Schema.Variants.TxOutAddress
                         Cardano.Db.Schema.Variants.TxOutCore
+                        Cardano.Db.Types
 
   other-modules:        Cardano.Db.Error
                         Cardano.Db.Git.RevFromGit
@@ -76,7 +77,6 @@ library
                         Cardano.Db.Statement.StakeDelegation
                         Cardano.Db.Statement.Types
                         Cardano.Db.Statement.Variants.TxOut
-                        Cardano.Db.Types
 
   build-depends:        aeson
                       , base                            >= 4.14         && < 5


### PR DESCRIPTION
# Description

Anybody that wants to build Haskell code on top of `db-sync` and write `Hasql` queries will need at least the `DbM` type exposed and probably other stuff in that module.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
