### PR TITLE
fix: CI add missing lmdb dependency to devx shell

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -52,6 +52,14 @@ jobs:
         uses: input-output-hk/actions/base@latest
         with:
           use-sodium-vrf: true
+      - name: Add LMDB to Nix environment
+        run: |
+          nix-env -f '<nixpkgs>' -iA lmdb
+          LMDB_STORE=$(find /nix/store -maxdepth 1 -name '*lmdb*-dev' -type d | head -1)
+          if [ -n "$LMDB_STORE" ]; then
+            echo "LMDB_PKGCONFIG=${LMDB_STORE}/lib/pkgconfig" >> $GITHUB_ENV
+          fi
+        shell: devx {0}
       - name: cache cabal
         uses: actions/cache@v3
         with:
@@ -61,11 +69,17 @@ jobs:
           key: ${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
           restore-keys: ${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.compiler-nix-name }}-
       - name: cabal update
-        run: cabal update
+        run: |
+          export PKG_CONFIG_PATH_FOR_TARGET=${{ env.LMDB_PKGCONFIG }}:${PKG_CONFIG_PATH_FOR_TARGET:-}
+          cabal update
       - name: cabal build dependencies
-        run: cabal build all -j --enable-tests --only-dependencies
+        run: |
+          export PKG_CONFIG_PATH_FOR_TARGET=${{ env.LMDB_PKGCONFIG }}:${PKG_CONFIG_PATH_FOR_TARGET:-}
+          cabal build all -j --enable-tests --only-dependencies
       - name: cabal build
-        run: cabal build all -j --enable-tests
+        run: |
+          export PKG_CONFIG_PATH_FOR_TARGET=${{ env.LMDB_PKGCONFIG }}:${PKG_CONFIG_PATH_FOR_TARGET:-}
+          cabal build all -j --enable-tests
       - name: postgres init
         working-directory:
         run: |
@@ -89,6 +103,7 @@ jobs:
             start
       - name: cabal test
         run: |
+          export PKG_CONFIG_PATH_FOR_TARGET=${{ env.LMDB_PKGCONFIG }}:${PKG_CONFIG_PATH_FOR_TARGET:-}
           # Create pgpass file
           export PGPASSFILE="${PG_DIR}/pgpass-testing"
           echo "${PG_DIR}:5432:$DBUSER:$DBUSER:*" > $PGPASSFILE


### PR DESCRIPTION
# Description

The CI cabal builds are failing due to missing dependency of lmdb and it being accessible to the devx nix shell.

There is a PR in devx https://github.com/input-output-hk/devx/pull/221 which also fixes this but we're unable to merge that due to the uploader being broken and this has been the case for 6 months.
 

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
