### PR TITLE
Fix GitHub release workflows

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Nix with good defaults
-        uses: input-output-hk/install-nix-action@v21
+        uses: input-output-hk/install-nix-action@v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
@@ -21,9 +21,6 @@ jobs:
             allow-import-from-derivation = true
             accept-flake-config = true
           nix_path: nixpkgs=channel:nixos-unstable
-          # cardano-parts requires nix >= 2.17.0; We can remove this after the next release
-          # to install-nix-action (v23)
-          install_url: https://releases.nixos.org/nix/nix-2.17.0/install
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Nix with good defaults
-        uses: input-output-hk/install-nix-action@v21
+        uses: input-output-hk/install-nix-action@v31
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
@@ -27,9 +27,6 @@ jobs:
             allow-import-from-derivation = true
             accept-flake-config = true
           nix_path: nixpkgs=channel:nixos-unstable
-          # cardano-parts requires nix >= 2.17.0; We can remove this after the next release
-          # to install-nix-action (v23)
-          install_url: https://releases.nixos.org/nix/nix-2.17.0/install
 
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

In GitHub workflows where we use cachix/install-nix-action, we are getting the following failure:

    This version of Nixpkgs requires an implementation of Nix with the
    following features:
      - `builtins.nixVersion` reports at least 2.18

This is because we previously fixed the version to 2.17, due to previous incompatibilities. Those have now been resolved by cachix/install-nix-action, so we don't need to fix the version anymore.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
