### PR TITLE
2086 - fix manual rollbacks

### DIFF
--- a/cardano-db/src/Cardano/Db/Statement/Base.hs
+++ b/cardano-db/src/Cardano/Db/Statement/Base.hs
@@ -857,17 +857,41 @@ deleteBlocksSlotNo ::
   Bool ->
   DbM Bool
 deleteBlocksSlotNo trce txOutVariantType (SlotNo slotNo) isConsumedTxOut = do
-  blockEpochE <- queryNearestBlockSlotNo slotNo
-  case blockEpochE of
-    Nothing -> pure False
-    (Just (blockId, epochN)) -> do
-      -- Delete the block and return whether it was successful
-      deleteCount <- deleteBlocksBlockId trce txOutVariantType blockId epochN isConsumedTxOut
-      if deleteCount > 0
-        then pure True
-        else do
-          liftIO $ logWarning trce $ "deleteBlocksSlotNo: No blocks found for slot: " <> Text.pack (show slotNo)
+  mBlock <- queryNearestBlockSlotNo slotNo
+  case mBlock of
+    Nothing -> do
+      liftIO $ logWarning trce $ "deleteBlocksSlotNo: No block found at or after slot: " <> textShow slotNo
+      pure False
+    Just (blockId, blockNo) -> do
+      -- Get the correct epoch number (same approach as rollbackFromBlockNo)
+      mBlockAndEpoch <- queryBlockNoAndEpoch blockNo
+      case mBlockAndEpoch of
+        Nothing -> do
+          liftIO $ logWarning trce $ "deleteBlocksSlotNo: Block not found for block_no: " <> textShow blockNo
           pure False
+        Just (_, epochNo) -> do
+          nBlocks <- queryBlockCountAfterBlockNo blockNo True
+          liftIO $
+            logInfo trce $
+              "Rollback: Deleting "
+                <> textShow nBlocks
+                <> " blocks with block_no >= "
+                <> textShow blockNo
+                <> " (slot >= "
+                <> textShow slotNo
+                <> ", epoch "
+                <> textShow epochNo
+                <> ")"
+
+          deleteCount <- deleteBlocksBlockId trce txOutVariantType blockId epochNo isConsumedTxOut
+
+          if deleteCount > 0
+            then do
+              liftIO $ logInfo trce $ "Rollback: Successfully deleted " <> textShow deleteCount <> " blocks"
+              pure True
+            else do
+              liftIO $ logWarning trce $ "deleteBlocksSlotNo: No blocks were deleted for slot: " <> textShow slotNo
+              pure False
 
 --------------------------------------------------------------------------------
 deleteBlocksSlotNoNoTrace :: TxOutVariantType -> SlotNo -> DbM Bool

--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -32,18 +32,20 @@ This directory contains various documentation files for setting up, configuring,
 
 14. [Syncing and Rollbacks](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/syncing-and-rollbacks.md) - Details on the syncing procedure and handling rollbacks, explaining how the node syncs with the blockchain and manages rollbacks in case of errors or inconsistencies.
 
-15. [Community Tools](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/community-tools.md) - Information on various community tools like Koios and Blockfrost, providing an overview of these tools, their features, and how they can be used to interact with Cardano DB Sync.
+15. [Manual Rollbacks](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/manual-rollbacks.md) - Guide to performing manual rollbacks using cardano-db-sync or cardano-db-tool, including use cases, step-by-step instructions, and best practices for rolling back the database to fix incorrect data or recover from issues.
 
-16. [Interesting Queries](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/interesting-queries.md) - A collection of useful SQL queries for interacting with the database, including examples of queries for retrieving data, analyzing transactions, and generating reports.
+16. [Community Tools](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/community-tools.md) - Information on various community tools like Koios and Blockfrost, providing an overview of these tools, their features, and how they can be used to interact with Cardano DB Sync.
 
-17. [Troubleshooting](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/troubleshooting.md) - Common issues and troubleshooting steps for Cardano DB Sync, providing solutions for various problems that users may encounter while running the node.
+17. [Interesting Queries](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/interesting-queries.md) - A collection of useful SQL queries for interacting with the database, including examples of queries for retrieving data, analyzing transactions, and generating reports.
 
-18. [Release Process](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/release-process.md) - Detailed process for releasing new versions of Cardano DB Sync, covering the steps required to prepare, test, and publish a new release.
+18. [Troubleshooting](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/troubleshooting.md) - Common issues and troubleshooting steps for Cardano DB Sync, providing solutions for various problems that users may encounter while running the node.
 
-19. [State Snapshot](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/state-snapshot.md) - Guide to creating and restoring state snapshots, explaining how to take snapshots of the database state and restore them when needed.
+19. [Release Process](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/release-process.md) - Detailed process for releasing new versions of Cardano DB Sync, covering the steps required to prepare, test, and publish a new release.
 
-20. [Pool OffChain Data](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/pool-offchain-data.md) - Handling off-chain data for staking pools, providing details on managing off-chain data and integrating it with the Cardano DB Sync Node.
+20. [State Snapshot](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/state-snapshot.md) - Guide to creating and restoring state snapshots, explaining how to take snapshots of the database state and restore them when needed.
 
-21. [SMASH](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/smash.md) - Information on the Stakepool Metadata Aggregation Server (SMASH), explaining the purpose of SMASH, how it works, and how to set it up.
+21. [Pool OffChain Data](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/pool-offchain-data.md) - Handling off-chain data for staking pools, providing details on managing off-chain data and integrating it with the Cardano DB Sync Node.
 
-22. [HLint and Stylish Haskell](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/hlint-stylish-haskell.md) - Setting up `hlint` and `stylish-haskell` for code linting and formatting, providing instructions on configuring these tools to maintain code quality and consistency.
+22. [SMASH](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/smash.md) - Information on the Stakepool Metadata Aggregation Server (SMASH), explaining the purpose of SMASH, how it works, and how to set it up.
+
+23. [HLint and Stylish Haskell](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/hlint-stylish-haskell.md) - Setting up `hlint` and `stylish-haskell` for code linting and formatting, providing instructions on configuring these tools to maintain code quality and consistency.

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -11,7 +11,7 @@
   - `--force-indexes`: Forces the Index creation at the start of db-sync. Normally they're created later.
   - `--fix-only`: Runs only the db-sync fix procedure for the wrong datum, redeemer_data, and plutus script bytes and exits.
   - `--disable-cache`: Disables the db-sync caches. Reduces memory usage but it takes longer to sync.
-  - `--rollback-to-slot SLOTNO`: Force a rollback to the specified slot, if the given slot doesn't exist it will use the next greater slot.
+  - `--rollback-to-slot SLOTNO`: Force a rollback to the specified slot, if the given slot doesn't exist it will use the next greater slot. See [Manual Rollbacks](manual-rollbacks.md) for details.
   - `--disable-in-out`: Disables the `tx_in` and `tx_out` table.
 
 - **Deprecated Options (for historical reference only):**

--- a/doc/syncing-and-rollbacks.md
+++ b/doc/syncing-and-rollbacks.md
@@ -85,3 +85,12 @@ all the blocks that needs deletion, we found only the oldest one and delete with
 every transaction after it. We use the property that fields like `tx.block_id` are non-decreasing,
 meaning newer entries will have bigger values. So if we simply find the oldest transaction that
 needs to be deleted, it's easy to delete everything with a single query.
+
+### Manual Rollbacks
+
+In addition to automatic rollbacks that occur during normal chain-sync operations, you can perform
+manual rollbacks using either `cardano-db-sync --rollback-to-slot` or `cardano-db-tool rollback`.
+These are useful for testing, fixing incorrect data after bug fixes, or recovering from corrupted
+database states.
+
+For detailed information on performing manual rollbacks, see [Manual Rollbacks](manual-rollbacks.md).


### PR DESCRIPTION
# Description

This is an addition to #2086 

When performing a slot-based rollback using either `cardano-db-sync --rollback-to-slot` or `cardano-db-tool rollback --slot`, the function incorrectly uses block_no (block height/number, e.g., 27,000,000) instead of epoch_no (epoch number, e.g., 619) when deleting epoch-related data.

### Fix
Add a second query step to get the correct epoch number, matching the pattern used in production:
This uses the same `queryBlockNoAndEpoch` logic that production rollbacks use, which correctly returns the previous block's epoch_no to handle epoch boundary rollbacks properly.


# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
