### PR TITLE
fix(docker): change node healthcheck from EKG to Prometheus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     healthcheck:
       # Ping the EKG port to see if it responds.
       # Assuming if EKG isn't up then the rest of cardano-node isn't either.
-      test: ["CMD-SHELL", "curl -f 127.0.0.1:12788 || exit 1"]
+      test: ["CMD-SHELL", "curl -f 127.0.0.1:12798/metrics || exit 1"]
       interval: 60s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
Fixes #2097 

The legacy EKG port (12788) is not exposed by default in recent trace-dispatcher configurations. Switching to 12798/metrics ensures db-sync can verify node readiness.

**Problem**
The `cardano-db-sync` service is stuck in a permanent "Waiting"  loop because the `cardano-node` healthcheck consistently fails. 

The current healthcheck in `docker-compose.yml` attempts to ping the EKG service on port `12788`, but this service is inactive in the current `trace-dispatcher` configuration used by the `ghcr.io/intersectmbo/cardano-node:10.7.x` images.

**Root Cause Analysis**
* **Port Mismatch:** The node configuration (generated via Nix in the container) uses the new tracing system. Examination of `TraceOptions` confirms that only `PrometheusSimple` is explicitly bound to a port (`12798`).

```sh
docker exec preview-cardano-node-1 cat /nix/store/xg336a45l8pp14i0164s4q538vwk0w3l-config-0-0.json | jq '.TraceOptions[""]'
{
  "backends": [
    "EKGBackend",
    "Forwarder",
    "PrometheusSimple suffix 127.0.0.1 12798",
    "Stdout HumanFormatColoured"
  ],
  "detail": "DNormal",
  "severity": "Notice"
}
```
* **EKG Behavior:** The `EKGBackend` is present in the config but lacks the legacy `hasEKG` listener mapping, resulting in a `Connection Refused` on port `12788`.
* **Path Validation:** Direct testing via `curl` on the Prometheus port returns a `404` at the root but a valid `200 OK` at `/metrics`.

**Proposed Solution**


Update the `docker-compose.yml` healthcheck to target the verified Prometheus metrics endpoint.

```yaml
healthcheck:
  test: ["CMD-SHELL", "curl -f 127.0.0.1:12798/metrics || exit 1"]
  interval: 30s
  timeout: 10s
  retries: 10
  start_period: 2m
```


# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
