### PR TITLE
Fix exe permissions in release distribution

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -413,7 +413,6 @@
                     # Copy exes to intermediate dir
                     cp \
                       --no-clobber \
-                      --no-preserve=mode \
                       --remove-destination \
                       --verbose \
                       ${lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exes} \


### PR DESCRIPTION
# Description

The binaries in the release archives (cardano-db-sync, cardano-smash-server, and so on) are missing the executable permission. This is the unintended consequence of respecting the default umask (introduced in #2023).

Fixes: #2026
See also: #2022

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
