### PR TITLE
fix: correct swapped min_pool_cost / coins_per_utxo_size

### DIFF
--- a/cardano-db/src/Cardano/Db/Schema/Core/GovernanceAndVoting.hs
+++ b/cardano-db/src/Cardano/Db/Schema/Core/GovernanceAndVoting.hs
@@ -547,7 +547,7 @@ paramProposalEncoder =
     , paramProposalProtocolMajor >$< E.param (E.nullable $ fromIntegral >$< E.int2)
     , paramProposalProtocolMinor >$< E.param (E.nullable $ fromIntegral >$< E.int2)
     , paramProposalMinUtxoValue >$< maybeDbLovelaceEncoder
-    , paramProposalCoinsPerUtxoSize >$< maybeDbLovelaceEncoder
+    , paramProposalMinPoolCost >$< maybeDbLovelaceEncoder
     , paramProposalCostModelId >$< Id.maybeIdEncoder Id.getCostModelId
     , paramProposalPriceMem >$< E.param (E.nullable E.float8)
     , paramProposalPriceStep >$< E.param (E.nullable E.float8)
@@ -559,7 +559,7 @@ paramProposalEncoder =
     , paramProposalCollateralPercent >$< E.param (E.nullable $ fromIntegral >$< E.int2)
     , paramProposalMaxCollateralInputs >$< E.param (E.nullable $ fromIntegral >$< E.int2)
     , paramProposalRegisteredTxId >$< Id.idEncoder Id.getTxId
-    , paramProposalMinPoolCost >$< maybeDbLovelaceEncoder
+    , paramProposalCoinsPerUtxoSize >$< maybeDbLovelaceEncoder
     , paramProposalPvtMotionNoConfidence >$< E.param (E.nullable E.float8)
     , paramProposalPvtCommitteeNormal >$< E.param (E.nullable E.float8)
     , paramProposalPvtCommitteeNoConfidence >$< E.param (E.nullable E.float8)


### PR DESCRIPTION
# Description

The `paramProposalEncoder` in `cardano-db/src/Cardano/Db/Schema/Core/GovernanceAndVoting.hs` emits field values in an order that does not match the `ParamProposal` record definition (and the matching decoder). As a result, values written to the `min_pool_cost` and `coins_per_utxo_size` columns are swapped for every row inserted into `param_proposal`.

## Details

The `ParamProposal` record (and `DbInfo` / `paramProposalDecoder`) define the field order as:

```
... paramProposalMinUtxoValue
    paramProposalMinPoolCost          -- position 20
    paramProposalCostModelId
    ...
    paramProposalRegisteredTxId
    paramProposalCoinsPerUtxoSize     -- position 32
    ...
```

The generated `INSERT` column list follows this same order. However, `paramProposalEncoder` supplies values in a different order:

```
... paramProposalMinUtxoValue
    paramProposalCoinsPerUtxoSize     -- supplied at position 20
    paramProposalCostModelId
    ...
    paramProposalRegisteredTxId
    paramProposalMinPoolCost          -- supplied at position 32
    ...
```

This means the `CoinsPerUtxoSize` Haskell value is written into the `min_pool_cost` SQL column, and the `MinPoolCost` Haskell value is written into the `coins_per_utxo_size` SQL column.

The bug was caught by the system-level E2E [cardano-node-tests](https://github.com/IntersectMBO/cardano-node-tests/blob/master/cardano_node_tests/tests/tests_conway/test_pparam_update.py) suite by `test_pparam_update` test, which proposes `minPoolCost` in 0–10 range and `utxoCostPerByte` in 4311–4400. The db-sync row consistently shows `min_pool_cost` in the 4311–4400 range and `coins_per_utxo_size` in the 0–10 range - i.e. outside each column's legitimate range.

## Fix

Swap the two encoder lines so the encoder order matches the record definition and the decoder.

Only `paramProposalEncoder` is changed. The record, `DbInfo` instance, and `paramProposalDecoder` already had the correct order.

Existing rows written by affected versions remain swapped on disk and need a resync (or one-off column-swap migration) to correct.

The fix was verified by the `test_pparam_update` test.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically