### PR TITLE
Fix macOS devShell builds (exclude liburing)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -243,8 +243,9 @@
               buildInputs = with nixpkgs.pkgsBuildBuild; [
                 git
                 protobuf
-                liburing
                 snappy
+              ] ++ lib.optionals (system == "x86_64-linux") [
+                liburing # io_uring is linux-only
               ];
 
               withHoogle = true;


### PR DESCRIPTION
# Description

The io_uring library is linux-kernel specific, so only include it as a buildInput for linux devShells.

This will fix the following problem build error in CI:
```
include/liburing.h:15:10: fatal error: 'linux/swab.h' file not found
   15 | #include <linux/swab.h>
      |          ^~~~~~~~~~~~~~
1 error generated.
```

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
