### PR TITLE
Nix: Fix release dist to include static binaries

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -483,7 +483,7 @@
           let
             mkDist = platform: project:
               let
-                exeVals = builtins.attrValues exes;
+                exeVals = builtins.attrValues (setGitRevs project.exes);
                 name = "cardano-db-sync-${version}-${platform}";
                 version = project.exes.cardano-db-sync.identifier.version;
                 env = {


### PR DESCRIPTION
# Description

Previously, the release distributions included the dynamic (rather than statically-built) binaries. There was a subtle bug that caused the static haskell.nix project to be ignored and use the default (dynamic).

It was introduced by b6a024ce7bd1a54efa7c8e5741e40e82fbdd2736.

Fixes: #2108
See also: PR #1962

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
