### PR TITLE
doc: correct Full preset description

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -75,7 +75,8 @@ Below is a sample `insert_options` section that shows the recommended defaults:
 ## Preset
 
 Preset is an aggregate setting that overrides all other properties. For example, setting
-preset to `"full"` will enable all insert options except `"tx_cbor"`.
+preset to `"full"` will enable all insert options except `"tx_cbor"`, `"offchain_pool_data"`,
+and `"offchain_vote_data"` (the last two default to `"disable"` since 13.7.0.1).
 
 `preset`
 
@@ -85,14 +86,43 @@ preset to `"full"` will enable all insert options except `"tx_cbor"`.
 
 | Value           | Explanation                                                  |
 | :-----------    | :----------------------------------------------------------- |
-| ["full"](#Full)             | Enable all options                                           |
+| ["full"](#Full)             | Enable all options except `tx_cbor`, `offchain_pool_data`, and `offchain_vote_data` |
 | ["only_utxo"](#only-utxo)   | Only load `block`, `tx`, `tx_out` and `ma_tx_out`.            |
 | ["only_governance"](#only-governance)     | Disable most data except governance data.                    |
 | ["disable_all"](#disable-all) | Only load `block`, `tx` and data related to the ledger state |
 
 ### Full
 
-This is equivalent to enabling all other settings.
+This is equivalent to setting:
+
+```
+"tx_cbor": "disable",
+"tx_out": {
+  "value": "enable",
+  "use_address_table": false
+},
+"ledger": "enable",
+"shelley": {
+  "enable": true
+},
+"multi_asset": {
+  "enable": true
+},
+"metadata": {
+  "enable": true
+},
+"plutus": {
+  "enable": true
+},
+"governance": "enable",
+"offchain_pool_data": "disable",
+"offchain_vote_data": "disable",
+"pool_stat": "enable",
+"json_type": "text"
+```
+
+`offchain_pool_data` and `offchain_vote_data` default to `"disable"` since 13.7.0.1 - set
+them to `"enable"` explicitly if you need offchain metadata fetching.
 
 ### Only UTxO
 


### PR DESCRIPTION
The configuration doc claimed the `full` preset enables every option, but since 13.7.0.1 it leaves `offchain_pool_data` and `offchain_vote_data` disabled by default.

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
