### PR TITLE
2118-epoch out_sum/fees corruption from numeric decoders

### DIFF
--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -143,6 +143,7 @@ test-suite test
                       , cardano-ledger-core
                       , cardano-ledger-mary
                       , hedgehog
+                      , scientific
                       , wide-word
 
 test-suite test-db
@@ -151,7 +152,8 @@ test-suite test-db
   main-is:              test-db.hs
   hs-source-dirs:       test
 
-  other-modules:        Test.IO.Cardano.Db.Insert
+  other-modules:        Test.IO.Cardano.Db.EpochCalc
+                        Test.IO.Cardano.Db.Insert
                         Test.IO.Cardano.Db.Migration
                         Test.IO.Cardano.Db.Rollback
                         Test.IO.Cardano.Db.TotalSupply
@@ -179,6 +181,7 @@ test-suite test-db
                       , tasty-hunit
                       , text
                       , time
+                      , wide-word
 
 -- test-suite schema-rollback
 --   default-language:     Haskell2010

--- a/cardano-db/src/Cardano/Db/Schema/Core/Base.hs
+++ b/cardano-db/src/Cardano/Db/Schema/Core/Base.hs
@@ -247,6 +247,12 @@ instance DbInfo TxIn where
     , ("redeemer_id", "bigint[]")
     ]
 
+entityTxInDecoder :: D.Row (Entity TxIn)
+entityTxInDecoder =
+  Entity
+    <$> idDecoder TxInId
+    <*> txInDecoder
+
 txInDecoder :: D.Row TxIn
 txInDecoder =
   TxIn
@@ -620,6 +626,12 @@ data Withdrawal = Withdrawal
 
 type instance Key Withdrawal = WithdrawalId
 instance DbInfo Withdrawal
+
+entityWithdrawalDecoder :: D.Row (Entity Withdrawal)
+entityWithdrawalDecoder =
+  Entity
+    <$> idDecoder WithdrawalId
+    <*> withdrawalDecoder
 
 withdrawalDecoder :: D.Row Withdrawal
 withdrawalDecoder =

--- a/cardano-db/src/Cardano/Db/Schema/Core/EpochAndProtocol.hs
+++ b/cardano-db/src/Cardano/Db/Schema/Core/EpochAndProtocol.hs
@@ -70,6 +70,12 @@ type instance Key Epoch = EpochId
 instance DbInfo Epoch where
   uniqueFields _ = ["no"]
 
+entityEpochDecoder :: D.Row (Entity Epoch)
+entityEpochDecoder =
+  Entity
+    <$> idDecoder EpochId
+    <*> epochDecoder
+
 epochDecoder :: D.Row Epoch
 epochDecoder =
   Epoch

--- a/cardano-db/src/Cardano/Db/Schema/Core/StakeDelegation.hs
+++ b/cardano-db/src/Cardano/Db/Schema/Core/StakeDelegation.hs
@@ -16,7 +16,7 @@ import Hasql.Encoders as E
 import Cardano.Db.Schema.Ids
 import Cardano.Db.Schema.Types (textDecoder)
 import Cardano.Db.Statement.Function.Core (bulkEncoder)
-import Cardano.Db.Statement.Types (DbInfo (..), Key)
+import Cardano.Db.Statement.Types (DbInfo (..), Entity (..), Key)
 import Cardano.Db.Types (
   DbLovelace (..),
   RewardSource,
@@ -44,6 +44,12 @@ data StakeAddress = StakeAddress -- Can be an address of a script hash
 type instance Key StakeAddress = StakeAddressId
 instance DbInfo StakeAddress where
   uniqueFields _ = ["hash_raw"]
+
+entityStakeAddressDecoder :: D.Row (Entity StakeAddress)
+entityStakeAddressDecoder =
+  Entity
+    <$> idDecoder StakeAddressId
+    <*> stakeAddressDecoder
 
 stakeAddressDecoder :: D.Row StakeAddress
 stakeAddressDecoder =
@@ -141,6 +147,12 @@ data Delegation = Delegation
 
 type instance Key Delegation = DelegationId
 instance DbInfo Delegation
+
+entityDelegationDecoder :: D.Row (Entity Delegation)
+entityDelegationDecoder =
+  Entity
+    <$> idDecoder DelegationId
+    <*> delegationDecoder
 
 delegationDecoder :: D.Row Delegation
 delegationDecoder =

--- a/cardano-db/src/Cardano/Db/Statement/Base.hs
+++ b/cardano-db/src/Cardano/Db/Statement/Base.hs
@@ -1414,7 +1414,7 @@ queryTxInRedeemerStmt =
           , " FROM " <> tableN
           , " WHERE redeemer_id IS NOT NULL"
           ]
-    decoder = HsqlD.rowList SCB.txInDecoder
+    decoder = HsqlD.rowList (entityVal <$> SCB.entityTxInDecoder)
 
 queryTxInRedeemer :: HasCallStack => DbM [SCB.TxIn]
 queryTxInRedeemer =
@@ -1438,7 +1438,7 @@ queryTxInFailedTxStmt =
           , " ON tx_in.tx_in_id = tx.id"
           , " WHERE tx.valid_contract = FALSE"
           ]
-    decoder = HsqlD.rowList SCB.txInDecoder
+    decoder = HsqlD.rowList (entityVal <$> SCB.entityTxInDecoder)
 
 queryTxInFailedTx :: HasCallStack => DbM [SCB.TxIn]
 queryTxInFailedTx = runSession mkDbCallStack $ HsqlSes.statement () queryTxInFailedTxStmt
@@ -1469,7 +1469,7 @@ queryWithdrawalScriptStmt =
           , " FROM " <> tableN
           , " WHERE redeemer_id IS NOT NULL"
           ]
-    decoder = HsqlD.rowList SCB.withdrawalDecoder
+    decoder = HsqlD.rowList (entityVal <$> SCB.entityWithdrawalDecoder)
 
 queryWithdrawalScript :: HasCallStack => DbM [SCB.Withdrawal]
 queryWithdrawalScript = runSession mkDbCallStack $ HsqlSes.statement () queryWithdrawalScriptStmt

--- a/cardano-db/src/Cardano/Db/Statement/ChainGen.hs
+++ b/cardano-db/src/Cardano/Db/Statement/ChainGen.hs
@@ -32,7 +32,7 @@ import qualified Cardano.Db.Schema.Variants.TxOutCore as SVC
 import Cardano.Db.Statement.Function.Core (runSession, runSessionEntity)
 import Cardano.Db.Statement.Function.Query (countAll, countWhere, parameterisedCountWhere)
 import Cardano.Db.Statement.Types (DbInfo (..), Entity (..), tableName)
-import Cardano.Db.Types (Ada, DbM, RewardSource, rewardSourceDecoder, word64ToAda)
+import Cardano.Db.Types (Ada, DbM, RewardSource, rewardSourceDecoder, scientificToWord64, word64ToAda)
 
 queryEpochParamWithEpochNoStmt :: HsqlStmt.Statement Word64 (Maybe (Entity SCE.EpochParam))
 queryEpochParamWithEpochNoStmt =
@@ -311,7 +311,7 @@ queryTreasuryDonationsStmt =
           , " FROM " <> txTableN
           ]
 
-    decoder = HsqlD.singleRow (HsqlD.column $ HsqlD.nonNullable $ fromIntegral <$> HsqlD.int8)
+    decoder = HsqlD.singleRow (HsqlD.column $ HsqlD.nonNullable $ scientificToWord64 <$> HsqlD.numeric)
 
 queryTreasuryDonations :: DbM Word64
 queryTreasuryDonations =
@@ -477,7 +477,7 @@ queryTxFeeDepositStmt =
           ]
     encoder = fromIntegral >$< HsqlE.param (HsqlE.nonNullable HsqlE.int8)
     decoder = HsqlD.rowMaybe $ do
-      fee <- HsqlD.column (HsqlD.nonNullable $ fromIntegral <$> HsqlD.int8)
+      fee <- HsqlD.column (HsqlD.nonNullable $ scientificToWord64 <$> HsqlD.numeric)
       deposit <- HsqlD.column (HsqlD.nullable HsqlD.int8)
       pure (word64ToAda fee, fromMaybe 0 deposit)
 
@@ -618,7 +618,7 @@ queryTxWithdrawalStmt =
 
     encoder = fromIntegral >$< HsqlE.param (HsqlE.nonNullable HsqlE.int8)
     decoder = HsqlD.singleRow $ do
-      amount <- HsqlD.column (HsqlD.nonNullable $ fromIntegral <$> HsqlD.int8)
+      amount <- HsqlD.column (HsqlD.nonNullable $ scientificToWord64 <$> HsqlD.numeric)
       pure $ word64ToAda amount
 
 -- | It is probably not possible to have two withdrawals in a single Tx.

--- a/cardano-db/src/Cardano/Db/Statement/EpochAndProtocol.hs
+++ b/cardano-db/src/Cardano/Db/Statement/EpochAndProtocol.hs
@@ -9,7 +9,6 @@ import Data.Functor.Contravariant ((>$<))
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEnc
 import Data.Time (UTCTime)
-import Data.WideWord (Word128 (..))
 import qualified Hasql.Decoders as HsqlD
 import qualified Hasql.Encoders as HsqlE
 import qualified Hasql.Session as HsqlSes
@@ -23,7 +22,7 @@ import Cardano.Db.Statement.Function.Core (ResultType (..), runSession, runSessi
 import Cardano.Db.Statement.Function.Insert (insert, insertCheckUnique, insertReplace)
 import Cardano.Db.Statement.Function.Query (countAll, replace, selectByFieldFirst)
 import Cardano.Db.Statement.Types (Entity (..), tableName)
-import Cardano.Db.Types (DbLovelace (..), DbM)
+import Cardano.Db.Types (DbLovelace (..), DbM, scientificToWord128, scientificToWord64)
 
 --------------------------------------------------------------------------------
 -- CostModel
@@ -129,7 +128,7 @@ queryEpochEntryStmt =
   HsqlStmt.Statement sql encoder decoder True
   where
     encoder = HsqlE.param (HsqlE.nonNullable $ fromIntegral >$< HsqlE.int8)
-    decoder = HsqlD.rowMaybe SEnP.epochDecoder
+    decoder = HsqlD.rowMaybe (entityVal <$> SEnP.entityEpochDecoder)
     sql =
       TextEnc.encodeUtf8 $
         Text.concat
@@ -185,8 +184,8 @@ queryCalcEpochEntryStmt =
       blockCount <- HsqlD.column (HsqlD.nonNullable $ fromIntegral <$> HsqlD.int8)
       minTime <- HsqlD.column (HsqlD.nullable utcTimeAsTimestampDecoder)
       maxTime <- HsqlD.column (HsqlD.nullable utcTimeAsTimestampDecoder)
-      outSum <- HsqlD.column (HsqlD.nonNullable HsqlD.int8) -- Decode as single int8
-      feeSum <- HsqlD.column (HsqlD.nonNullable HsqlD.int8)
+      outSum <- HsqlD.column (HsqlD.nonNullable (scientificToWord128 <$> HsqlD.numeric))
+      feeSum <- HsqlD.column (HsqlD.nonNullable (scientificToWord64 <$> HsqlD.numeric))
       txCount <- HsqlD.column (HsqlD.nonNullable $ fromIntegral <$> HsqlD.int8)
 
       pure $ case (blockCount, minTime, maxTime) of
@@ -196,8 +195,8 @@ queryCalcEpochEntryStmt =
             then convertBlk epochNo (blockCount, Just start, Just end)
             else
               SEnP.Epoch
-                { SEnP.epochOutSum = Word128 0 (fromIntegral outSum) -- Construct Word128 from single value
-                , SEnP.epochFees = DbLovelace $ fromIntegral feeSum
+                { SEnP.epochOutSum = outSum
+                , SEnP.epochFees = DbLovelace feeSum
                 , SEnP.epochTxCount = txCount
                 , SEnP.epochBlkCount = blockCount
                 , SEnP.epochNo = epochNo
@@ -269,7 +268,7 @@ queryLatestEpochStmt =
           , " WHERE no = (SELECT MAX(no) FROM epoch)"
           ]
 
-    decoder = HsqlD.rowMaybe SEnP.epochDecoder
+    decoder = HsqlD.rowMaybe (entityVal <$> SEnP.entityEpochDecoder)
 
 -- | Get the most recent epoch in the Epoch DB table.
 queryLatestEpoch :: DbM (Maybe SEnP.Epoch)

--- a/cardano-db/src/Cardano/Db/Statement/Function/Query.hs
+++ b/cardano-db/src/Cardano/Db/Statement/Function/Query.hs
@@ -253,16 +253,14 @@ queryStatementCacheSize :: HasCallStack => DbM Int
 queryStatementCacheSize =
   runSession mkDbCallStack $ HsqlSes.statement () queryStatementCacheStmt
 
--- Decoder for Ada amounts from database int8 values
 adaDecoder :: HsqlD.Row Ada
 adaDecoder = do
   amount <- HsqlD.column (HsqlD.nonNullable HsqlD.int8)
   pure $ lovelaceToAda (fromIntegral amount)
 
--- Decoder for summed Ada amounts with null handling
 adaSumDecoder :: HsqlD.Row Ada
 adaSumDecoder = do
-  amount <- HsqlD.column (HsqlD.nullable HsqlD.int8)
+  amount <- HsqlD.column (HsqlD.nullable HsqlD.numeric)
   case amount of
-    Just value -> pure $ lovelaceToAda (fromIntegral value)
+    Just value -> pure $ lovelaceToAda (floor value)
     Nothing -> pure $ Ada 0

--- a/cardano-db/src/Cardano/Db/Statement/StakeDelegation.hs
+++ b/cardano-db/src/Cardano/Db/Statement/StakeDelegation.hs
@@ -28,7 +28,7 @@ import Cardano.Db.Statement.Function.Core (ResultType (..), ResultTypeBulk (..),
 import Cardano.Db.Statement.Function.Insert (insert, insertCheckUnique)
 import Cardano.Db.Statement.Function.InsertBulk (insertBulk, insertBulkMaybeIgnore, insertBulkMaybeIgnoreWithConstraint)
 import Cardano.Db.Statement.Function.Query (adaSumDecoder, countAll)
-import Cardano.Db.Statement.Types (DbInfo (..))
+import Cardano.Db.Statement.Types (DbInfo (..), Entity (..))
 import Cardano.Db.Types (Ada, DbLovelace, DbM, RewardSource, dbLovelaceDecoder, rewardSourceDecoder, rewardSourceEncoder)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Credential (Ptr (..), SlotNo32 (..))
@@ -61,7 +61,7 @@ queryDelegationScriptStmt =
           , " FROM " <> tableN
           , " WHERE redeemer_id IS NOT NULL"
           ]
-    decoder = HsqlD.rowList SS.delegationDecoder
+    decoder = HsqlD.rowList (entityVal <$> SS.entityDelegationDecoder)
 
 queryDelegationScript :: DbM [SS.Delegation]
 queryDelegationScript =
@@ -486,7 +486,7 @@ queryStakeAddressScriptStmt =
           , " FROM " <> tableN
           , " WHERE script_hash IS NOT NULL"
           ]
-    decoder = HsqlD.rowList SS.stakeAddressDecoder
+    decoder = HsqlD.rowList (entityVal <$> SS.entityStakeAddressDecoder)
 
 queryStakeAddressScript :: DbM [SS.StakeAddress]
 queryStakeAddressScript =

--- a/cardano-db/src/Cardano/Db/Types.hs
+++ b/cardano-db/src/Cardano/Db/Types.hs
@@ -28,7 +28,7 @@ import Data.Fixed (Micro, showFixed)
 import Data.Functor.Contravariant ((>$<))
 import Data.Int (Int64)
 import Data.Pool (Pool)
-import Data.Scientific (Scientific (..), coefficient, scientific, toBoundedInteger)
+import Data.Scientific (Scientific (..), scientific, toBoundedInteger)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.WideWord (Word128 (..))
@@ -176,12 +176,10 @@ newtype DbWord64 = DbWord64 {unDbWord64 :: Word64}
   deriving (Eq, Generic, Num)
   deriving (Read, Show) via (Quiet DbWord64)
 
--- Helper to replicate the original Persistent fromPersistValue behavior for DbWord64
--- This matches the PersistRational case: fromIntegral $ numerator r
 scientificToWord64 :: Scientific -> Word64
 scientificToWord64 s = case toBoundedInteger @Word64 s of
   Just w64 -> w64
-  Nothing -> fromIntegral $ coefficient s -- Fallback to coefficient for out-of-bounds values
+  Nothing -> fromInteger (floor s)
 
 -- Value encoder for DbWord64 using numeric (matches word64type domain)
 dbWord64ValueEncoder :: HsqlE.Value DbWord64
@@ -530,10 +528,28 @@ integerToDbInt65 i
   | otherwise = toDbInt65 (fromIntegral i)
 
 word128Encoder :: HsqlE.Value Word128
-word128Encoder = fromInteger . toInteger >$< HsqlE.numeric
+word128Encoder = word128ToScientific >$< HsqlE.numeric
 
 word128Decoder :: HsqlD.Value Word128
-word128Decoder = fromInteger . fromIntegral . coefficient <$> HsqlD.numeric
+word128Decoder = scientificToWord128 <$> HsqlD.numeric
+
+-- | Convert a 'Word128' to a 'Scientific' for storage in a PostgreSQL @numeric@ column.
+-- This is exposed for testing the encoder/decoder pair without a database connection.
+word128ToScientific :: Word128 -> Scientific
+word128ToScientific = fromInteger . toInteger
+
+-- | Convert a 'Scientific' read from a PostgreSQL @numeric@ column back to a 'Word128'.
+--
+-- PostgreSQL strips trailing zeros in its binary @numeric@ representation, so a
+-- value like @380_000_000_000_000_000@ may come back as @Scientific 38 16@
+-- (coefficient @38@, @base10Exponent = 16@). 'coefficient' alone would drop
+-- the exponent, so we use 'floor' on the full 'Scientific' which is exact for
+-- non-negative integral values - the only shape we ever encode here, since
+-- 'Word128' is non-negative and stored in @numeric(39,0)@.
+--
+-- This is exposed for testing the encoder/decoder pair without a database connection.
+scientificToWord128 :: Scientific -> Word128
+scientificToWord128 = fromInteger . floor
 
 lovelaceToAda :: Integer -> Ada
 lovelaceToAda ll =

--- a/cardano-db/test/Test/IO/Cardano/Db/EpochCalc.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/EpochCalc.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Database integration tests covering the encoding/decoding of large numeric
+-- values in the @epoch@ table and the SUM-based 'queryCalcEpochEntry' fallback.
+--
+-- These tests exist because of a regression introduced by the Persistent ->
+-- Hasql migration where:
+--
+-- * 'word128Decoder' was reading the @coefficient@ of the 'Scientific' returned
+--   by Hasql's @numeric@ decoder without honouring @base10Exponent@. PostgreSQL
+--   strips trailing zeros in its binary @numeric@ representation, so a value
+--   like @380_000_000_000_000_000@ comes back as @Scientific 38 16@ and was
+--   being decoded as @38@.
+--
+-- * 'queryCalcEpochEntryStmt' was decoding @SUM(tx.out_sum)@ and @SUM(tx.fee)@
+--   (both @numeric@) as @int8@ and packing the result into the low 64 bits of
+--   a 'Word128' via @Word128 0 (fromIntegral outSum)@.
+module Test.IO.Cardano.Db.EpochCalc (
+  tests,
+) where
+
+import Cardano.Db
+import Control.Monad (void)
+import Data.WideWord.Word128 (Word128)
+import Data.Word (Word64)
+import Test.IO.Cardano.Db.Util
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
+
+tests :: TestTree
+tests =
+  testGroup
+    "EpochCalc"
+    [ testCase "Word128 round-trip with trailing zeros" word128RoundTripWithTrailingZerosTest
+    , testCase "queryCalcEpochEntry handles realistic large sums" queryCalcEpochEntryLargeSumsTest
+    ]
+
+-- | Insert an 'Epoch' row whose @out_sum@ has many trailing zeros - the kind of
+-- value PostgreSQL is most likely to return in normalised form. Round-trip
+-- through 'queryEpochEntry' must preserve the exact value.
+word128RoundTripWithTrailingZerosTest :: IO ()
+word128RoundTripWithTrailingZerosTest =
+  runDbStandaloneSilent $ do
+    deleteAllBlocks
+    -- The bug shows up most visibly with values that have many trailing zeros,
+    -- because PostgreSQL stores them with a non-zero base10 exponent.
+    let originalEpoch =
+          Epoch
+            { epochOutSum = 380_000_000_000_000_000 -- ~38B ADA in lovelace
+            , epochFees = DbLovelace 36_000_000_000 -- ~36k ADA in lovelace
+            , epochTxCount = 100
+            , epochBlkCount = 21600
+            , epochNo = 999_999 -- Use a high epoch number unlikely to clash
+            , epochStartTime = dummyUTCTime
+            , epochEndTime = dummyUTCTime
+            }
+    void $ insertEpoch originalEpoch
+
+    result <- queryEpochEntry (epochNo originalEpoch)
+    decoded <- extractDbResult result
+    assertBool
+      ( "epoch round-trip mismatch:\n  expected: "
+          ++ show originalEpoch
+          ++ "\n  got:      "
+          ++ show decoded
+      )
+      (decoded == originalEpoch)
+
+-- | Insert a block plus several txs whose @out_sum@ and @fee@ totals are big
+-- (but realistic for a busy epoch), then call 'queryCalcEpochEntry' and verify
+-- the SUM is decoded correctly.
+--
+-- This exercises the cold-cache fallback that 'cardano-db-sync' uses when the
+-- in-memory epoch cache is empty (server restart, rollback, @--disable-cache@,
+-- or first epoch boundary after upgrade).
+queryCalcEpochEntryLargeSumsTest :: IO ()
+queryCalcEpochEntryLargeSumsTest =
+  runDbStandaloneSilent $ do
+    deleteAllBlocks
+    slid <- insertSlotLeader testSlotLeader
+    bid <- insertBlock (mkBlock 0 slid)
+
+    -- Insert 10 txs with realistic large per-tx values. Per-tx out_sum of
+    -- 1e15 lovelace (1M ADA) summed across 10 txs gives 1e16 lovelace - well
+    -- above Int32 range, exercising the SUM path properly without straining
+    -- Word64 limits.
+    let perTxOutSum :: Word64
+        perTxOutSum = 1_000_000_000_000_000 -- 1e15 lovelace = 1M ADA
+        perTxFee :: Word64
+        perTxFee = 3_600_000_000 -- 3,600 ADA
+        nTxs :: Word64
+        nTxs = 10
+        expectedOutSum :: Word128
+        expectedOutSum = fromIntegral (perTxOutSum * nTxs)
+        expectedFees :: DbLovelace
+        expectedFees = DbLovelace (perTxFee * nTxs)
+
+    let bigTx i =
+          Tx
+            { txHash = mkTxHash bid i
+            , txBlockId = bid
+            , txBlockIndex = fromIntegral i
+            , txOutSum = DbLovelace perTxOutSum
+            , txFee = DbLovelace perTxFee
+            , txDeposit = Just 0
+            , txSize = 12
+            , txInvalidHereafter = Nothing
+            , txInvalidBefore = Nothing
+            , txValidContract = True
+            , txScriptSize = 0
+            , txTreasuryDonation = DbLovelace 0
+            }
+    mapM_ (\i -> void . insertTx $ bigTx i) [0 .. nTxs - 1]
+
+    -- mkBlock hard-codes epoch_no = 0
+    calcEpoch <- queryCalcEpochEntry 0
+
+    assertBool
+      ( "epochOutSum mismatch:\n  expected: "
+          ++ show expectedOutSum
+          ++ "\n  got:      "
+          ++ show (epochOutSum calcEpoch)
+      )
+      (epochOutSum calcEpoch == expectedOutSum)
+    assertBool
+      ( "epochFees mismatch:\n  expected: "
+          ++ show expectedFees
+          ++ "\n  got:      "
+          ++ show (epochFees calcEpoch)
+      )
+      (epochFees calcEpoch == expectedFees)
+    assertBool
+      ( "epochTxCount mismatch:\n  expected: "
+          ++ show nTxs
+          ++ "\n  got:      "
+          ++ show (epochTxCount calcEpoch)
+      )
+      (epochTxCount calcEpoch == nTxs)

--- a/cardano-db/test/Test/Property/Cardano/Db/Types.hs
+++ b/cardano-db/test/Test/Property/Cardano/Db/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
@@ -19,6 +20,7 @@ import qualified Data.ByteString.Short as SBS
 import Data.Either (fromRight)
 import Data.Int (Int64)
 import Data.Maybe (fromMaybe)
+import Data.Scientific (normalize, scientific)
 import Data.WideWord.Word128 (Word128 (..))
 import Data.Word (Word64)
 import Hedgehog (Gen, Property, discover, (===))
@@ -145,18 +147,59 @@ prop_roundtrip_DbWord64 =
   where
     genWord64Range = Gen.word64 (Range.linear 0 (fromIntegral (maxBound :: Int64)))
 
--- Test Word128 roundtrip through components
-prop_roundtrip_Word128 :: Property
-prop_roundtrip_Word128 =
-  H.withTests 5000 . H.property $ do
-    w128 <- H.forAll genWord128Limited
+-- | Targeted regression test for the Word128 decoder.
+--
+-- PostgreSQL strips trailing zeros in its binary @numeric@ representation, so a
+-- value like @380_000_000_000_000_000@ may come back from Hasql as
+-- @Scientific 38 16@ (coefficient @38@, @base10Exponent = 16@). The decoder
+-- must honour the exponent.
+prop_word128_decoder_handles_normalised_scientific :: Property
+prop_word128_decoder_handles_normalised_scientific = H.withTests 1 . H.property $ do
+  -- 38 * 10^16 = 380_000_000_000_000_000
+  let sci = scientific 38 16
+      expected = 380_000_000_000_000_000 :: Word128
+  scientificToWord128 sci === expected
 
-    runWord128Roundtrip w128 === w128
+-- | Round-trip property: encode a 'Word128' to 'Scientific' (via the same logic
+-- as 'word128Encoder'), simulate PostgreSQL normalising it (which strips
+-- trailing zeros from the coefficient), then decode (via the same logic as
+-- 'word128Decoder'). The result must equal the original.
+prop_word128_roundtrip_via_normalised_scientific :: Property
+prop_word128_roundtrip_via_normalised_scientific =
+  H.withTests 5000 . H.property $ do
+    w <- H.forAll genWord128
+    let encoded = word128ToScientific w
+        -- Simulate what PostgreSQL does on the wire: drop trailing zeros from
+        -- the coefficient and bump the exponent. Hasql's numeric decoder
+        -- returns this normalised form for us.
+        normalised = normalize encoded
+        decoded = scientificToWord128 normalised
+    decoded === w
+
+-- | Round-trip property over a curated set of values that are particularly
+-- likely to expose exponent-handling bugs: powers of ten, and values composed
+-- mostly of trailing zeros (typical of round lovelace amounts in production).
+prop_word128_roundtrip_trailing_zeros :: Property
+prop_word128_roundtrip_trailing_zeros =
+  H.withTests 1 . H.property $
+    mapM_
+      ( \w ->
+          scientificToWord128 (normalize (word128ToScientific w)) === w
+      )
+      problemValues
   where
-    genWord128Limited = do
-      hi <- Gen.word64 (Range.linear 0 (fromIntegral (maxBound :: Int64)))
-      lo <- Gen.word64 (Range.linear 0 (fromIntegral (maxBound :: Int64)))
-      pure $ Word128 hi lo
+    problemValues :: [Word128]
+    problemValues =
+      [ 0
+      , 1
+      , 10
+      , 100
+      , 1_000_000 -- 1 ADA in lovelace
+      , 36_000_000_000 -- ~36k ADA, typical epoch fees
+      , 380_000_000_000_000_000 -- ~38B ADA, typical epoch out_sum
+      , 45_000_000_000_000_000 -- total ADA supply in lovelace
+      , maxBound -- Word128 max
+      ]
 
 -- DbInt65 specific roundtrip test function
 runDbInt65Roundtrip :: DbInt65 -> DbInt65
@@ -185,18 +228,6 @@ runDbWord64Roundtrip (DbWord64 w) =
 runMaybeDbWord64Roundtrip :: Maybe DbWord64 -> Maybe DbWord64
 runMaybeDbWord64Roundtrip Nothing = Nothing
 runMaybeDbWord64Roundtrip (Just value) = Just (runDbWord64Roundtrip value)
-
--- Word128 specific roundtrip test function
-runWord128Roundtrip :: Word128 -> Word128
-runWord128Roundtrip (Word128 hi lo) =
-  -- Extract components and convert to Int64 (simulating DB storage)
-  let hiInt64 = fromIntegral hi :: Int64
-      loInt64 = fromIntegral lo :: Int64
-
-      -- Convert back to Word64 and reconstruct (simulating DB retrieval)
-      hiBack = fromIntegral hiInt64 :: Word64
-      loBack = fromIntegral loInt64 :: Word64
-   in Word128 hiBack loBack
 
 -- Generators from original code
 genAda :: Gen Ada

--- a/cardano-db/test/cardano-db-test.cabal
+++ b/cardano-db/test/cardano-db-test.cabal
@@ -41,6 +41,7 @@ library
                       , cardano-slotting
                       , extra
                       , hedgehog
+                      , scientific
                       , text
                       , time
                       , transformers

--- a/cardano-db/test/test-db.hs
+++ b/cardano-db/test/test-db.hs
@@ -5,6 +5,7 @@ import Data.Maybe (isNothing)
 import System.Directory (getCurrentDirectory)
 import System.Environment (lookupEnv, setEnv)
 import System.FilePath ((</>))
+import qualified Test.IO.Cardano.Db.EpochCalc
 import qualified Test.IO.Cardano.Db.Insert
 import qualified Test.IO.Cardano.Db.Migration
 import qualified Test.IO.Cardano.Db.PGConfig
@@ -28,5 +29,6 @@ main = do
       , Test.IO.Cardano.Db.Insert.tests
       , Test.IO.Cardano.Db.TotalSupply.tests
       , Test.IO.Cardano.Db.Rollback.tests
+      , Test.IO.Cardano.Db.EpochCalc.tests
       , Test.IO.Cardano.Db.PGConfig.tests
       ]


### PR DESCRIPTION
# Description

This fixes #2118 

The reported `epoch.out_sum` / `epoch.fees` corruption at cold-cache epoch boundaries was caused by two bugs introduced in the Persistent → Hasql migration: `word128Decoder` read only the coefficient of the Scientific returned by Hasql's numeric decoder and dropped `base10Exponent`, so values that PostgreSQL normalised (e.g. `380_000_000_000_000_000` → `Scientific 38 16`) decoded as `38`; and `queryCalcEpochEntryStmt` decoded `SUM(tx.out_sum) / SUM(tx.fee)` (both numeric) as `int8` and packed the result into the low 64 bits of a `Word128` via `Word128 0 (fromIntegral _)`. The fix decodes Scientific via floor (honouring the exponent) and reconstructs the full `Word128` from the proper numeric decoder.

While auditing the codebase for the same anti-patterns I found and fixed several related bugs in the same family but were in non critical paths (db tools, test helpers).

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
