### PR TITLE
fix hostPlatform rename warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,10 @@
 {
   description = "cardano-db-sync";
 
+  nixConfig = {
+    abort-on-warn = true;
+  };
+
   inputs = {
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     utils.url = "github:numtide/flake-utils";
@@ -314,7 +318,7 @@
                 reinstallableLibGhc = false;
               })
 
-              (pkgs.lib.mkIf pkgs.hostPlatform.isMusl
+              (pkgs.lib.mkIf pkgs.stdenv.hostPlatform.isMusl
                 (let
                   ghcOptions = [
                     # libpq static is pretty broken in nixpkgs. We can't rely on the
@@ -423,7 +427,7 @@
                   packages.cardano-db.components.tests.test-db.doCheck = false;
                 })
 
-              ({ lib, pkgs, config, ... }: lib.mkIf pkgs.hostPlatform.isMacOS {
+              ({ lib, pkgs, config, ... }: lib.mkIf pkgs.stdenv.hostPlatform.isMacOS {
                 # PostgreSQL tests fail in Hydra on MacOS with:
                 #
                 #     FATAL:  could not create shared memory segment: No space left on device


### PR DESCRIPTION
# Description

`evaluation warning: 'hostPlatform' has been renamed to/replaced by 'stdenv.hostPlatform'`
# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.

this change also changes warnings into fatal errors, so they cant be ignored in the future