### PR TITLE
feat(offchain): add --allow-private-offchain-urls flag

### DIFF
--- a/cardano-chain-gen/test/Test/Cardano/Db/Mock/Config.hs
+++ b/cardano-chain-gen/test/Test/Cardano/Db/Mock/Config.hs
@@ -325,6 +325,7 @@ mkSyncNodeParams staticDir mutableDir CommandLineArgs {..} = do
       , enpForceIndexes = claForceIndexes
       , enpHasInOut = True
       , enpMaybeRollback = Nothing
+      , enpAllowPrivateOffChainUrls = False
       }
 
 ------------------------------------------------------------------------------

--- a/cardano-db-sync/app/cardano-db-sync.hs
+++ b/cardano-db-sync/app/cardano-db-sync.hs
@@ -104,6 +104,7 @@ pRunDbSyncNode = do
     <*> pForceIndexes
     <*> pHasInOut
     <*> optional pRollbackSlotNo
+    <*> pAllowPrivateOffChainUrls
 
 pConfigFile :: Parser ConfigFile
 pConfigFile =
@@ -170,6 +171,19 @@ pHasCache =
     False
     ( Opt.long "disable-cache"
         <> Opt.help "Disables the db-sync caches. Reduces memory usage but it takes longer to sync."
+    )
+
+pAllowPrivateOffChainUrls :: Parser Bool
+pAllowPrivateOffChainUrls =
+  Opt.flag
+    False
+    True
+    ( Opt.long "allow-private-offchain-urls"
+        <> Opt.help
+          ( "Allow the off-chain pool and vote metadata fetchers to connect to "
+              <> "URLs whose host or resolved IP is in a private, loopback, or "
+              <> "link-local range. Intended for local-cluster testing; off by default."
+          )
     )
 
 pSocketPath :: Parser SocketPath

--- a/cardano-db-sync/app/http-get-json-metadata.hs
+++ b/cardano-db-sync/app/http-get-json-metadata.hs
@@ -105,8 +105,8 @@ runHttpGetPool poolUrl mHash =
   where
     httpGet :: ExceptT OffChainFetchError IO SimplifiedOffChainPoolData
     httpGet = do
-      request <- parseOffChainUrl $ OffChainPoolUrl poolUrl
-      manager <- liftIO newRestrictedManager
+      request <- parseOffChainUrl False $ OffChainPoolUrl poolUrl
+      manager <- liftIO (newRestrictedManager False)
       httpGetOffChainPoolData manager request poolUrl mHash
 
     reportSuccess :: SimplifiedOffChainPoolData -> IO ()
@@ -124,7 +124,7 @@ runHttpGetVote voteUrl mHash vtype =
   reportSuccess =<< runOrThrowIO (runExceptT httpGet)
   where
     httpGet :: ExceptT OffChainFetchError IO SimplifiedOffChainVoteData
-    httpGet = httpGetOffChainVoteData [] voteUrl mHash vtype
+    httpGet = httpGetOffChainVoteData False [] voteUrl mHash vtype
 
     reportSuccess :: SimplifiedOffChainVoteData -> IO ()
     reportSuccess spod = do

--- a/cardano-db-sync/app/test-http-get-json-metadata.hs
+++ b/cardano-db-sync/app/test-http-get-json-metadata.hs
@@ -41,7 +41,7 @@ main = do
       let poolUrl = toUrl testPoolOffChain
           mHash = Just $ toHash testPoolOffChain
       eres <- runExceptT $ do
-        request <- parseOffChainUrl (OffChainPoolUrl poolUrl)
+        request <- parseOffChainUrl False (OffChainPoolUrl poolUrl)
         httpGetOffChainPoolData manager request poolUrl mHash
       case eres of
         Left err -> do

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -369,6 +369,7 @@ test-suite test
                         Cardano.DbSync.Era.Shelley.Generic.ScriptDataTest
                         Cardano.DbSync.Era.Shelley.Generic.ScriptTest
                         Cardano.DbSync.Gen
+                        Cardano.DbSync.OffChain.HttpTest
                         Cardano.DbSync.OffChain.VoteTest
                         Cardano.DbSync.Util.AddressTest
                         Cardano.DbSync.Util.Bech32Test

--- a/cardano-db-sync/cardano-db-sync.cabal
+++ b/cardano-db-sync/cardano-db-sync.cabal
@@ -404,5 +404,6 @@ test-suite test
                       , iohk-monitoring
                       , hedgehog
                       , hedgehog-quickcheck
+                      , network
                       , ouroboros-consensus:cardano
                       , text

--- a/cardano-db-sync/src/Cardano/DbSync.hs
+++ b/cardano-db-sync/src/Cardano/DbSync.hs
@@ -302,6 +302,7 @@ extractSyncOptions snp aop snc =
           forceTxIn'
     , soptInsertOptions = iopts
     , soptSnapshotInterval = dncSnapshotInterval snc
+    , soptAllowPrivateOffChainUrls = enpAllowPrivateOffChainUrls snp
     }
   where
     maybeKeepMNames =

--- a/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Api/Types.hs
@@ -71,6 +71,11 @@ data SyncOptions = SyncOptions
   , soptPruneConsumeMigration :: !DB.PruneConsumeMigration
   , soptInsertOptions :: !InsertOptions
   , soptSnapshotInterval :: !SnapshotIntervalConfig
+  , soptAllowPrivateOffChainUrls :: !Bool
+  -- ^ When 'True', the off-chain HTTP fetcher accepts URLs whose host or
+  -- resolved IP is in a private / loopback / link-local range. Set from
+  -- the @--allow-private-offchain-urls@ CLI flag; off by default. Intended
+  -- for local-cluster testing only.
   }
   deriving (Show)
 

--- a/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/Config/Types.hs
@@ -115,6 +115,10 @@ data SyncNodeParams = SyncNodeParams
   , enpForceIndexes :: !Bool
   , enpHasInOut :: !Bool
   , enpMaybeRollback :: !(Maybe SlotNo)
+  , enpAllowPrivateOffChainUrls :: !Bool
+  -- ^ When 'True', the off-chain HTTP fetcher (pool and vote metadata) does not
+  -- reject URLs whose host or resolved IP is in a private / loopback / link-local
+  -- range. Intended for local-cluster testing only; off by default.
   }
   deriving (Show)
 

--- a/cardano-db-sync/src/Cardano/DbSync/OffChain.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/OffChain.hs
@@ -24,7 +24,7 @@ module Cardano.DbSync.OffChain (
 import Cardano.BM.Trace (Trace, logInfo)
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Api (determineIsolationLevel, getInsertOptions, getTrace)
-import Cardano.DbSync.Api.Types (InsertOptions (..), SyncEnv (..))
+import Cardano.DbSync.Api.Types (InsertOptions (..), SyncEnv (..), SyncOptions (..))
 import Cardano.DbSync.Config.Types
 import Cardano.DbSync.OffChain.Http
 import Cardano.DbSync.OffChain.Query
@@ -253,13 +253,14 @@ runFetchOffChainPoolThread syncEnv = do
               DB.runDbTransLogged trce dbEnv mIsolationLevel $
                 loadOffChainPoolWorkQueue trce (envOffChainPoolWorkQueue threadSyncEnv)
             poolq <- atomically $ flushTBQueue (envOffChainPoolWorkQueue threadSyncEnv)
-            manager <- newRestrictedManager
+            manager <- newRestrictedManager allowPrivate
             now <- liftIO Time.getPOSIXTime
-            mapM_ (queuePoolInsert <=< fetchOffChainPoolData trce manager now) poolq
+            mapM_ (queuePoolInsert <=< fetchOffChainPoolData trce allowPrivate manager now) poolq
       )
   where
     trce = getTrace syncEnv
     iopts = getInsertOptions syncEnv
+    allowPrivate = soptAllowPrivateOffChainUrls (envOptions syncEnv)
 
     queuePoolInsert :: OffChainPoolResult -> IO ()
     queuePoolInsert = atomically . writeTBQueue (envOffChainPoolResultQueue syncEnv)
@@ -291,12 +292,13 @@ runFetchOffChainVoteThread syncEnv = do
                 loadOffChainVoteWorkQueue trce (envOffChainVoteWorkQueue threadSyncEnv)
             voteq <- atomically $ flushTBQueue (envOffChainVoteWorkQueue threadSyncEnv)
             now <- liftIO Time.getPOSIXTime
-            mapM_ (queueVoteInsert <=< fetchOffChainVoteData gateways now) voteq
+            mapM_ (queueVoteInsert <=< fetchOffChainVoteData allowPrivate gateways now) voteq
       )
   where
     trce = getTrace syncEnv
     iopts = getInsertOptions syncEnv
     gateways = dncIpfsGateway $ envSyncNodeConfig syncEnv
+    allowPrivate = soptAllowPrivateOffChainUrls (envOptions syncEnv)
 
     queueVoteInsert :: OffChainVoteResult -> IO ()
     queueVoteInsert = atomically . writeTBQueue (envOffChainVoteResultQueue syncEnv)
@@ -308,12 +310,12 @@ tDelay = threadDelay 300_000_000
 ---------------------------------------------------------------------------------------------------------------------------------
 -- Fetch OffChain data
 ---------------------------------------------------------------------------------------------------------------------------------
-fetchOffChainPoolData :: Trace IO Text -> Http.Manager -> Time.POSIXTime -> OffChainPoolWorkQueue -> IO OffChainPoolResult
-fetchOffChainPoolData _tracer manager time oPoolWorkQ =
+fetchOffChainPoolData :: Trace IO Text -> Bool -> Http.Manager -> Time.POSIXTime -> OffChainPoolWorkQueue -> IO OffChainPoolResult
+fetchOffChainPoolData _tracer allowPrivate manager time oPoolWorkQ =
   convert <<$>> runExceptT $ do
     let url = oPoolWqUrl oPoolWorkQ
         metaHash = oPoolWqMetaHash oPoolWorkQ
-    request <- parseOffChainUrl $ OffChainPoolUrl url
+    request <- parseOffChainUrl allowPrivate $ OffChainPoolUrl url
     httpGetOffChainPoolData manager request url (Just metaHash)
   where
     convert :: Either OffChainFetchError SimplifiedOffChainPoolData -> OffChainPoolResult
@@ -339,12 +341,12 @@ fetchOffChainPoolData _tracer manager time oPoolWorkQ =
               , DB.offChainPoolFetchErrorRetryCount = retryCount (oPoolWqRetry oPoolWorkQ)
               }
 
-fetchOffChainVoteData :: [Text] -> Time.POSIXTime -> OffChainVoteWorkQueue -> IO OffChainVoteResult
-fetchOffChainVoteData gateways time oVoteWorkQ =
+fetchOffChainVoteData :: Bool -> [Text] -> Time.POSIXTime -> OffChainVoteWorkQueue -> IO OffChainVoteResult
+fetchOffChainVoteData allowPrivate gateways time oVoteWorkQ =
   convert <<$>> runExceptT $ do
     let url = oVoteWqUrl oVoteWorkQ
         metaHash = oVoteWqMetaHash oVoteWorkQ
-    httpGetOffChainVoteData gateways url (Just metaHash) (oVoteWqType oVoteWorkQ)
+    httpGetOffChainVoteData allowPrivate gateways url (Just metaHash) (oVoteWqType oVoteWorkQ)
   where
     convert :: Either OffChainFetchError SimplifiedOffChainVoteData -> OffChainVoteResult
     convert eres =

--- a/cardano-db-sync/src/Cardano/DbSync/OffChain/Http.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/OffChain/Http.hs
@@ -81,32 +81,34 @@ httpGetOffChainPoolData manager request purl expectedMetaHash = do
     url = OffChainPoolUrl purl
 
 httpGetOffChainVoteData ::
+  Bool ->
   [Text] ->
   VoteUrl ->
   Maybe VoteMetaHash ->
   DB.AnchorType ->
   ExceptT OffChainFetchError IO SimplifiedOffChainVoteData
-httpGetOffChainVoteData gateways vurl metaHash anchorType = do
+httpGetOffChainVoteData allowPrivate gateways vurl metaHash anchorType = do
   case useIpfsGatewayMaybe vurl gateways of
-    Nothing -> httpGetOffChainVoteDataSingle vurl metaHash anchorType
+    Nothing -> httpGetOffChainVoteDataSingle allowPrivate vurl metaHash anchorType
     Just [] -> left $ OCFErrNoIpfsGateway (OffChainVoteUrl vurl)
     Just urls -> tryAllGatewaysRec urls []
   where
     tryAllGatewaysRec [] acc = left $ OCFErrIpfsGatewayFailures (OffChainVoteUrl vurl) (reverse acc)
     tryAllGatewaysRec (url : rest) acc = do
-      msocd <- liftIO $ runExceptT $ httpGetOffChainVoteDataSingle url metaHash anchorType
+      msocd <- liftIO $ runExceptT $ httpGetOffChainVoteDataSingle allowPrivate url metaHash anchorType
       case msocd of
         Right socd -> pure socd
         Left err -> tryAllGatewaysRec rest (err : acc)
 
 httpGetOffChainVoteDataSingle ::
+  Bool ->
   VoteUrl ->
   Maybe VoteMetaHash ->
   DB.AnchorType ->
   ExceptT OffChainFetchError IO SimplifiedOffChainVoteData
-httpGetOffChainVoteDataSingle vurl metaHash anchorType = do
-  manager <- liftIO newRestrictedManager
-  request <- parseOffChainUrl url
+httpGetOffChainVoteDataSingle allowPrivate vurl metaHash anchorType = do
+  manager <- liftIO (newRestrictedManager allowPrivate)
+  request <- parseOffChainUrl allowPrivate url
   let req = httpGetBytes manager request 3000000 3000000 url
   httpRes <- handleExceptT (convertHttpException url) req
   (respBS, respLBS, mContentType) <- hoistEither httpRes
@@ -217,8 +219,8 @@ isPossiblyJsonObject bs =
 -------------------------------------------------------------------------------------
 -- Url
 -------------------------------------------------------------------------------------
-parseOffChainUrl :: OffChainUrlType -> ExceptT OffChainFetchError IO Http.Request
-parseOffChainUrl url = do
+parseOffChainUrl :: Bool -> OffChainUrlType -> ExceptT OffChainFetchError IO Http.Request
+parseOffChainUrl allowPrivate url = do
   let urlText = Text.pack $ showUrl url
   unless (Text.isPrefixOf "https://" urlText || Text.isPrefixOf "http://" urlText) $
     left $
@@ -228,7 +230,7 @@ parseOffChainUrl url = do
     left $
       OCFErrUrlParseFail url "Only GET requests are allowed"
   let hostBS = Http.host request
-  when (isLocalhostHost hostBS) $
+  when (not allowPrivate && isLocalhostHost hostBS) $
     left $
       OCFErrUrlParseFail url "Access to localhost is not allowed"
   pure $ applyContentType request
@@ -283,13 +285,17 @@ useIpfsGatewayMaybe vu gateways =
 -- Restricted Manager
 -------------------------------------------------------------------------------------
 
--- | Create a restricted 'Http.ManagerSettings' that blocks connections to
--- private, loopback, and link-local IP addresses. The restriction is
--- checked at connect time on the resolved IP, so it applies to redirects
--- and prevents DNS rebinding attacks.
-newRestrictedManager :: IO Http.Manager
-newRestrictedManager = do
-  (settings, _mProxyRestricted) <- mkRestrictedManagerSettings offchainRestriction Nothing Nothing
+-- | Create the off-chain HTTP manager. When 'allowPrivate' is 'False' (the
+-- default), connections to private, loopback, and link-local IP addresses are
+-- blocked at connect time via 'offchainRestriction'. The restriction is checked
+-- on the resolved IP, so it applies to redirects and prevents DNS rebinding
+-- attacks. When 'allowPrivate' is 'True' the restriction is replaced with a
+-- no-op that allows every address — this is intended for local-cluster testing
+-- only and is wired in from the @--allow-private-offchain-urls@ CLI flag.
+newRestrictedManager :: Bool -> IO Http.Manager
+newRestrictedManager allowPrivate = do
+  let restriction = if allowPrivate then permissiveRestriction else offchainRestriction
+  (settings, _mProxyRestricted) <- mkRestrictedManagerSettings restriction Nothing Nothing
   Http.newManager settings
 
 offchainRestriction :: Restriction
@@ -297,6 +303,11 @@ offchainRestriction = addressRestriction $ \addr ->
   if isPrivateAddr (Socket.addrAddress addr)
     then Just $ connectionRestricted ("Access to private, loopback, or link-local IP address is not allowed: " ++) addr
     else Nothing
+
+-- | A 'Restriction' that allows every resolved address. Selected by
+-- 'newRestrictedManager' when @--allow-private-offchain-urls@ is set.
+permissiveRestriction :: Restriction
+permissiveRestriction = addressRestriction $ const Nothing
 
 isPrivateAddr :: Socket.SockAddr -> Bool
 isPrivateAddr (Socket.SockAddrInet _ hostAddr) =

--- a/cardano-db-sync/src/Cardano/DbSync/OffChain/Http.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/OffChain/Http.hs
@@ -8,6 +8,8 @@ module Cardano.DbSync.OffChain.Http (
   parseAndValidateVoteData,
   parseOffChainUrl,
   newRestrictedManager,
+  -- Exported for testing.
+  isPrivateAddr,
 ) where
 
 import qualified Cardano.Crypto.Hash.Blake2b as Crypto

--- a/cardano-db-sync/test/Cardano/DbSync/Gen.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/Gen.hs
@@ -79,6 +79,7 @@ syncNodeParams =
     <*> Gen.bool
     <*> Gen.bool
     <*> pure Nothing
+    <*> Gen.bool
 
 syncNodeConfig :: Logging.Configuration -> Gen SyncNodeConfig
 syncNodeConfig loggingCfg =

--- a/cardano-db-sync/test/Cardano/DbSync/OffChain/HttpTest.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/OffChain/HttpTest.hs
@@ -4,11 +4,12 @@
 module Cardano.DbSync.OffChain.HttpTest (tests) where
 
 import qualified Cardano.Db as DB
-import Cardano.DbSync.OffChain.Http (parseOffChainUrl)
+import Cardano.DbSync.OffChain.Http (isPrivateAddr, parseOffChainUrl)
 import Cardano.DbSync.Types (OffChainFetchError (..), OffChainUrlType (..))
 import Cardano.Prelude
 import qualified Data.Text as Text
 import Hedgehog
+import qualified Network.Socket as Socket
 
 tests :: IO Bool
 tests =
@@ -30,6 +31,10 @@ tests =
       ,
         ( "parseOffChainUrl rejects non-HTTP schemes in either mode"
         , prop_rejectsNonHttpSchemes
+        )
+      ,
+        ( "isPrivateAddr classifies IPv4, IPv6, and IPv4-mapped IPv6 addresses"
+        , prop_isPrivateAddrClassification
         )
       ]
 
@@ -116,3 +121,48 @@ prop_rejectsNonHttpSchemes = withTests 1 $ property $ do
         Right _ -> do
           annotate "Expected rejection but parse succeeded"
           failure
+
+-- | Table-driven coverage of 'isPrivateAddr'. The IPv4-mapped IPv6 rows are
+-- the regression set for the SSRF gap fixed in PR #2132 (e.g. @::ffff:127.0.0.1@
+-- previously slipped past the IPv6 branch because the mapped IPv4 was not unwrapped).
+prop_isPrivateAddrClassification :: Property
+prop_isPrivateAddrClassification = withTests 1 $ property $ do
+  for_ classificationCases $ \(name, addr, expected) -> do
+    annotate name
+    isPrivateAddr addr === expected
+
+classificationCases :: [([Char], Socket.SockAddr, Bool)]
+classificationCases =
+  -- IPv4-mapped IPv6 — the cases PR #2132 fixed.
+  [ ("::ffff:127.0.0.1 (loopback)", mkV6 (0, 0, 0, 0, 0, 0xFFFF, 0x7F00, 0x0001), True)
+  , ("::ffff:10.0.0.1 (RFC1918)", mkV6 (0, 0, 0, 0, 0, 0xFFFF, 0x0A00, 0x0001), True)
+  , ("::ffff:192.168.1.1 (RFC1918)", mkV6 (0, 0, 0, 0, 0, 0xFFFF, 0xC0A8, 0x0101), True)
+  , ("::ffff:172.16.0.1 (RFC1918)", mkV6 (0, 0, 0, 0, 0, 0xFFFF, 0xAC10, 0x0001), True)
+  , ("::ffff:169.254.1.1 (link-local)", mkV6 (0, 0, 0, 0, 0, 0xFFFF, 0xA9FE, 0x0101), True)
+  , ("::ffff:0.0.0.0 (this-network)", mkV6 (0, 0, 0, 0, 0, 0xFFFF, 0x0000, 0x0000), True)
+  , ("::ffff:224.0.0.1 (multicast)", mkV6 (0, 0, 0, 0, 0, 0xFFFF, 0xE000, 0x0001), True)
+  , ("::ffff:8.8.8.8 (public)", mkV6 (0, 0, 0, 0, 0, 0xFFFF, 0x0808, 0x0808), False)
+  , ("::ffff:1.1.1.1 (public)", mkV6 (0, 0, 0, 0, 0, 0xFFFF, 0x0101, 0x0101), False)
+  , -- Native IPv6 — regression guard for the pre-existing IPv6 rules.
+    (":: (unspecified)", mkV6 (0, 0, 0, 0, 0, 0, 0, 0), True)
+  , ("::1 (loopback)", mkV6 (0, 0, 0, 0, 0, 0, 0, 1), True)
+  , ("fc00::1 (ULA)", mkV6 (0xFC00, 0, 0, 0, 0, 0, 0, 1), True)
+  , ("fd00::1 (ULA)", mkV6 (0xFD00, 0, 0, 0, 0, 0, 0, 1), True)
+  , ("fe80::1 (link-local)", mkV6 (0xFE80, 0, 0, 0, 0, 0, 0, 1), True)
+  , ("2001:db8::1 (documentation)", mkV6 (0x2001, 0x0DB8, 0, 0, 0, 0, 0, 1), False)
+  , -- IPv4 — regression guard, including range edges.
+    ("127.0.0.1 (loopback)", mkV4 (127, 0, 0, 1), True)
+  , ("10.0.0.1 (RFC1918)", mkV4 (10, 0, 0, 1), True)
+  , ("192.168.1.1 (RFC1918)", mkV4 (192, 168, 1, 1), True)
+  , ("172.16.0.1 (RFC1918)", mkV4 (172, 16, 0, 1), True)
+  , ("172.32.0.1 (above RFC1918)", mkV4 (172, 32, 0, 1), False)
+  , ("169.254.1.1 (link-local)", mkV4 (169, 254, 1, 1), True)
+  , ("100.64.0.1 (CGNAT)", mkV4 (100, 64, 0, 1), True)
+  , ("100.128.0.1 (above CGNAT)", mkV4 (100, 128, 0, 1), False)
+  , ("198.18.0.1 (benchmarking)", mkV4 (198, 18, 0, 1), True)
+  , ("224.0.0.1 (multicast)", mkV4 (224, 0, 0, 1), True)
+  , ("8.8.8.8 (public)", mkV4 (8, 8, 8, 8), False)
+  ]
+  where
+    mkV4 t = Socket.SockAddrInet 0 (Socket.tupleToHostAddress t)
+    mkV6 t = Socket.SockAddrInet6 0 0 (Socket.tupleToHostAddress6 t) 0

--- a/cardano-db-sync/test/Cardano/DbSync/OffChain/HttpTest.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/OffChain/HttpTest.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Cardano.DbSync.OffChain.HttpTest (tests) where
+
+import qualified Cardano.Db as DB
+import Cardano.DbSync.OffChain.Http (parseOffChainUrl)
+import Cardano.DbSync.Types (OffChainFetchError (..), OffChainUrlType (..))
+import Cardano.Prelude
+import qualified Data.Text as Text
+import Hedgehog
+
+tests :: IO Bool
+tests =
+  checkParallel $
+    Group
+      "Cardano.DbSync.OffChain.Http"
+      [
+        ( "parseOffChainUrl rejects localhost-family hosts by default"
+        , prop_rejectsLocalhostByDefault
+        )
+      ,
+        ( "parseOffChainUrl accepts localhost-family hosts when allowPrivate=True"
+        , prop_acceptsLocalhostWhenAllowed
+        )
+      ,
+        ( "parseOffChainUrl accepts public hosts in either mode"
+        , prop_acceptsPublicHosts
+        )
+      ,
+        ( "parseOffChainUrl rejects non-HTTP schemes in either mode"
+        , prop_rejectsNonHttpSchemes
+        )
+      ]
+
+-- | URLs whose host string matches @isLocalhostHost@ in
+-- 'Cardano.DbSync.OffChain.Http'.
+localhostUrls :: [Text]
+localhostUrls =
+  [ "http://localhost/metadata.json"
+  , "http://localhost:23299/pool2.json"
+  , "http://127.0.0.1/metadata.json"
+  , "http://[::1]/metadata.json"
+  , "http://10.5.5.5/metadata.json"
+  , "http://192.168.1.1/metadata.json"
+  ]
+
+-- | URLs that should always parse successfully.
+publicUrls :: [Text]
+publicUrls =
+  [ "https://example.com/metadata.json"
+  , "http://example.com/metadata.json"
+  , "https://tinyurl.com/yvkfs7pr"
+  ]
+
+asPoolUrl :: Text -> OffChainUrlType
+asPoolUrl = OffChainPoolUrl . DB.PoolUrl
+
+prop_rejectsLocalhostByDefault :: Property
+prop_rejectsLocalhostByDefault = withTests 1 $ property $ do
+  for_ localhostUrls $ \url -> do
+    annotateShow url
+    result <- liftIO $ runExceptT $ parseOffChainUrl False (asPoolUrl url)
+    case result of
+      Left (OCFErrUrlParseFail _ msg) -> do
+        annotate (Text.unpack msg)
+        msg === "Access to localhost is not allowed"
+      Left other -> do
+        annotateShow other
+        failure
+      Right _ -> do
+        annotate "Expected rejection but parse succeeded"
+        failure
+
+prop_acceptsLocalhostWhenAllowed :: Property
+prop_acceptsLocalhostWhenAllowed = withTests 1 $ property $ do
+  for_ localhostUrls $ \url -> do
+    annotateShow url
+    result <- liftIO $ runExceptT $ parseOffChainUrl True (asPoolUrl url)
+    case result of
+      Right _ -> success
+      Left err -> do
+        annotateShow err
+        failure
+
+prop_acceptsPublicHosts :: Property
+prop_acceptsPublicHosts = withTests 1 $ property $ do
+  for_ publicUrls $ \url -> do
+    for_ [False, True] $ \allowPrivate -> do
+      annotateShow (allowPrivate, url)
+      result <- liftIO $ runExceptT $ parseOffChainUrl allowPrivate (asPoolUrl url)
+      case result of
+        Right _ -> success
+        Left err -> do
+          annotateShow err
+          failure
+
+prop_rejectsNonHttpSchemes :: Property
+prop_rejectsNonHttpSchemes = withTests 1 $ property $ do
+  let nonHttp =
+        [ "ftp://example.com/x.json"
+        , "file:///etc/passwd"
+        , "javascript:alert(1)"
+        ]
+  for_ nonHttp $ \url -> do
+    for_ [False, True] $ \allowPrivate -> do
+      annotateShow (allowPrivate, url)
+      result <- liftIO $ runExceptT $ parseOffChainUrl allowPrivate (asPoolUrl url)
+      case result of
+        Left (OCFErrUrlParseFail _ msg) -> do
+          annotate (Text.unpack msg)
+          msg === "Only HTTP/HTTPS URLs are allowed"
+        Left other -> do
+          annotateShow other
+          failure
+        Right _ -> do
+          annotate "Expected rejection but parse succeeded"
+          failure

--- a/cardano-db-sync/test/Main.hs
+++ b/cardano-db-sync/test/Main.hs
@@ -4,6 +4,7 @@ import qualified Cardano.DbSync.ApiTest as Api
 import qualified Cardano.DbSync.Config.TypesTest as Types
 import qualified Cardano.DbSync.Era.Shelley.Generic.ScriptDataTest as ScriptData
 import qualified Cardano.DbSync.Era.Shelley.Generic.ScriptTest as Script
+import qualified Cardano.DbSync.OffChain.HttpTest as HttpTest
 import qualified Cardano.DbSync.OffChain.VoteTest as VoteTest
 import qualified Cardano.DbSync.Util.AddressTest as Address
 import qualified Cardano.DbSync.Util.Bech32Test as Bech32
@@ -25,4 +26,5 @@ main =
     , Types.tests
     , Api.tests
     , VoteTest.tests
+    , HttpTest.tests
     ]

--- a/doc/command-line-options.md
+++ b/doc/command-line-options.md
@@ -13,6 +13,7 @@
   - `--disable-cache`: Disables the db-sync caches. Reduces memory usage but it takes longer to sync.
   - `--rollback-to-slot SLOTNO`: Force a rollback to the specified slot, if the given slot doesn't exist it will use the next greater slot. See [Manual Rollbacks](manual-rollbacks.md) for details.
   - `--disable-in-out`: Disables the `tx_in` and `tx_out` table.
+  - `--allow-private-offchain-urls`: Allows the off-chain pool and vote metadata fetchers to connect to URLs whose host or resolved IP is in a private, loopback, or link-local range. Off by default. Intended for local-cluster testing.
 
 - **Deprecated Options (for historical reference only):**
   - For more details, refer to [Configuration Documentation](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/configuration.md)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -618,6 +618,10 @@ When enabled, the same URL restrictions apply as `offchain_pool_data` (HTTPS req
 
 **Migration Note**: Prior to version 13.7.0.1, governance vote metadata fetching was controlled by the `governance` flag.
 
+### Bypassing the URL restriction for local-cluster testing
+
+The private-IP restriction is enforced for every production deployment and cannot be disabled via configuration. For local-cluster test setups whose pools or governance anchors are served from `http://localhost:.../...` URLs, the `--allow-private-offchain-urls` CLI flag (see [command-line-options.md](command-line-options.md)) replaces the restriction with a no-op so the fetchers can connect to private, loopback, and link-local addresses. The flag is off by default and is intended for testing only.
+
 ## Pool Stat
 
 `pool_stat`


### PR DESCRIPTION
# Description

cardano-db-sync's off-chain pool and vote metadata fetchers reject URLs whose host or resolved IP is in a private, loopback, or link-local range as an SSRF mitigation.

 Local-cluster test setups whose metadata is served from http://localhost:.../poolN.json or similar therefore cannot exercise the success path of the fetcher.

This adds an opt-in CLI flag that replaces both layers of the restriction with a no-op for the duration of the run, intended
for local-cluster testing only. Off by default; the existing restriction continues to apply to every production deployment.

* New SyncNodeParams field enpAllowPrivateOffChainUrls plumbed through SyncOptions (soptAllowPrivateOffChainUrls) into the off-chain fetcher threads.
* parseOffChainUrl now takes a Bool: when True the isLocalhostHost rejection is skipped.
* newRestrictedManager now takes a Bool: when True it installs a permissiveRestriction (addressRestriction returning Nothing for every address) instead of offchainRestriction, so DNS-resolved private IPs are no longer blocked at connect time either.
* New Hedgehog suite Cardano.DbSync.OffChain.HttpTest covering both modes for localhost/127./[::1]/10./192.168. plus a public URL and non-HTTP schemes.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
