### PR TITLE
Fix pool_relay.port signed-16-bit overflow (#2135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for cardano-db-sync
 
+## Unreleased
+- Fix `pool_relay.port` corruption introduced by issue [#2135](https://github.com/IntersectMBO/cardano-db-sync/issues/2135) in 13.7.0.0 - 13.7.1.0. Relay ports above 32767 were encoded as a signed 16-bit integer and wrapped to negative values (`port - 65536`) in the `int4` column. The encoder now uses `int4`, and a startup migration repairs already-stored rows by adding 65536 to every negative port. The migration is a no-op on a clean or freshly synced database.
+
 ## 13.7.1.0
 - Auto-repair `epoch.out_sum` / `epoch.fees` / `epoch.tx_count` / `epoch.blk_count` corruption introduced by issue [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) in 13.7.0.0 - 13.7.0.4. A startup migration recomputes every epoch row from the underlying `tx` / `block` tables and rewrites only the rows whose stored values disagree. Adds a one-time 5-15 minute delay on the first startup after upgrade on a mainnet-sized database; subsequent restarts and fresh syncs are unaffected. Operators on older release lines who do not upgrade can apply the same fix manually via [`scripts/fix-epoch-table.sql`](scripts/fix-epoch-table.sql).
 

--- a/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Generic.hs
+++ b/cardano-chain-gen/src/Cardano/Mock/Forging/Tx/Generic.hs
@@ -326,7 +326,9 @@ consPoolParams poolId rwCred owners =
     , sppMargin = minBound
     , sppAccountAddress = AccountAddress Testnet (AccountId rwCred)
     , sppOwners = Set.fromList owners
-    , sppRelays = StrictSeq.singleton $ SingleHostAddr SNothing SNothing SNothing
+    , -- Port 41950 is > 32767 on purpose so that pool_relay.port exercises the full
+      -- unsigned Word16 range (regression coverage for issue #2135).
+      sppRelays = StrictSeq.singleton $ SingleHostAddr (SJust (Port 41950)) SNothing SNothing
     , sppMetadata = SJust $ PoolMetadata (fromJust $ textToUrl 64 "best.pool") (let !(SBS.SBS ba) = SBS.toShort "89237365492387654983275634298756" in ByteArray ba)
     }
 

--- a/cardano-db/src/Cardano/Db/Schema/Core/Pool.hs
+++ b/cardano-db/src/Cardano/Db/Schema/Core/Pool.hs
@@ -221,7 +221,10 @@ poolRelayEncoder =
     , poolRelayIpv6 >$< E.param (E.nullable E.text)
     , poolRelayDnsName >$< E.param (E.nullable E.text)
     , poolRelayDnsSrvName >$< E.param (E.nullable E.text)
-    , poolRelayPort >$< E.param (E.nullable $ fromIntegral >$< E.int2)
+    , -- NB: the SQL column is int4 and the field is an unsigned Word16, so it must
+      -- be encoded as int4. Using int2 (signed 16-bit) wraps ports > 32767 to
+      -- negative values (port - 65536). See issue #2135.
+      poolRelayPort >$< E.param (E.nullable $ fromIntegral >$< E.int4)
     ]
 
 -- |

--- a/cardano-db/src/Cardano/Db/Statement/ChainGen.hs
+++ b/cardano-db/src/Cardano/Db/Statement/ChainGen.hs
@@ -26,6 +26,7 @@ import qualified Cardano.Db.Schema.Core.GovernanceAndVoting as SGV
 import qualified Cardano.Db.Schema.Core.MultiAsset as MultiAsset
 import qualified Cardano.Db.Schema.Core.Pool as SCP
 import qualified Cardano.Db.Schema.Core.StakeDelegation as SCSD
+import qualified Cardano.Db.Schema.Ids as Id
 import qualified Cardano.Db.Schema.Variants as SV
 import qualified Cardano.Db.Schema.Variants.TxOutAddress as SVA
 import qualified Cardano.Db.Schema.Variants.TxOutCore as SVC
@@ -836,6 +837,33 @@ queryPoolRelayCount :: DbM Word64
 queryPoolRelayCount =
   runSession mkDbCallStack $
     HsqlSes.statement () (countAll @SCP.PoolRelay)
+
+-- | The @pool_relay.port@ of a single relay, looked up by row id and decoded straight
+-- from the int4 column. A relay port is an unsigned Word16 (0-65535), so the result must
+-- never be negative; a negative value would mean a port > 32767 was wrapped by a
+-- signed-16-bit encoder. Used as regression coverage for issue #2135.
+queryPoolRelayPortStmt :: HsqlStmt.Statement Int64 (Maybe Int64)
+queryPoolRelayPortStmt =
+  HsqlStmt.Statement sql encoder decoder True
+  where
+    relayTableN = tableName (Proxy @SCP.PoolRelay)
+    sql =
+      TextEnc.encodeUtf8 $
+        Text.concat
+          [ "SELECT port"
+          , " FROM " <> relayTableN
+          , " WHERE id = $1"
+          , " LIMIT 1"
+          ]
+    encoder = HsqlE.param (HsqlE.nonNullable HsqlE.int8)
+    decoder =
+      HsqlD.singleRow $
+        HsqlD.column (HsqlD.nullable (fromIntegral <$> HsqlD.int4))
+
+queryPoolRelayPort :: Id.PoolRelayId -> DbM (Maybe Int64)
+queryPoolRelayPort relayId =
+  runSession mkDbCallStack $
+    HsqlSes.statement (Id.getPoolRelayId relayId) queryPoolRelayPortStmt
 
 ------------------------------------------------------------------------------
 -- Database Column Order Information

--- a/cardano-db/test/Test/IO/Cardano/Db/Insert.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Insert.hs
@@ -23,6 +23,7 @@ tests =
     , testCase "Insert first block" insertFirstTest
     , testCase "Insert twice" insertTwice
     , testCase "Insert foreign key missing" insertForeignKeyMissing
+    , testCase "Insert pool relay with large port" insertPoolRelayLargePort
     ]
 
 insertZeroTest :: IO ()
@@ -95,6 +96,31 @@ insertForeignKeyMissing = do
 
     count2 <- countOffChainPoolFetchError
     assertBool (show count2 ++ "/= 0") (count2 == 0)
+
+-- Regression test for issue #2135: relay ports above 32767 used to be encoded as a
+-- signed int2, which wrapped them to negative values (port - 65536) in the int4 column.
+-- A port is an unsigned Word16, so the value read back must equal the value inserted.
+insertPoolRelayLargePort :: IO ()
+insertPoolRelayLargePort =
+  runDbStandaloneSilent $ do
+    -- 41950 > 32767, so it exercises the half of the Word16 range that used to wrap.
+    relayId <- insertPoolRelay (poolRelayWithPort 41950)
+    port <- queryPoolRelayPort relayId
+    assertBool
+      ("Expected port Just 41950 but got " ++ show port)
+      (port == Just 41950)
+  where
+    -- pool_relay.update_id has no foreign key (dropped in migration-2-0025), so a
+    -- standalone relay row can be inserted without a parent pool_update.
+    poolRelayWithPort p =
+      PoolRelay
+        { poolRelayUpdateId = PoolUpdateId 1
+        , poolRelayIpv4 = Just "127.0.0.1"
+        , poolRelayIpv6 = Nothing
+        , poolRelayDnsName = Nothing
+        , poolRelayDnsSrvName = Nothing
+        , poolRelayPort = Just p
+        }
 
 blockZero :: SlotLeaderId -> Block
 blockZero slid =

--- a/schema/migration-2-0050-20260617.sql
+++ b/schema/migration-2-0050-20260617.sql
@@ -1,0 +1,22 @@
+-- Repair pool_relay.port rows where the old int2 encoder wrapped values >32767 to negative. See #2135.
+
+CREATE FUNCTION migrate() RETURNS void AS $$
+DECLARE
+  next_version int ;
+BEGIN
+  SELECT stage_two + 1 INTO next_version FROM schema_version ;
+  IF next_version = 50 THEN
+
+    UPDATE pool_relay
+      SET port = port + 65536
+      WHERE port < 0 ;
+
+    UPDATE schema_version SET stage_two = next_version ;
+    RAISE NOTICE 'DB has been migrated to stage_two version %', next_version ;
+  END IF ;
+END ;
+$$ LANGUAGE plpgsql ;
+
+SELECT migrate() ;
+
+DROP FUNCTION migrate() ;


### PR DESCRIPTION
Fixes #2135

The pool_relay encoder serialized the unsigned Word16 port as a signed int2, so relay ports above 32767 wrapped to negative values (port - 65536). The pool_relay.port SQL column is int4, so the wrapped value was stored verbatim.

- Encode the port as int4 to match the column and preserve the full 0-65535 range.
- Add migration-2-0049 to repair already-stored rows by adding 65536 to every negative port (no-op on a clean or freshly synced database).
- Add a cardano-db IO regression test that inserts a relay with port 41950 and asserts it round-trips (fails with the old int2 encoder, reading back -23586).
- Give the chain-gen test relay a port > 32767 so the end-to-end pool path also exercises the full range.

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
