### PR TITLE
Fix duplicate off-chain vote metadata child rows (#1966)

### DIFF
--- a/cardano-db-sync/src/Cardano/DbSync/OffChain.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/OffChain.hs
@@ -152,11 +152,8 @@ insertOffChainVoteResults trce resultQueue = do
         insertBulkOffChainVoteFetchErrors errors
       -- Process metadata in a pipeline if any
       unless (null metadataWithAccessors) $ do
-        -- Insert the parent rows and get back, for each NEWLY inserted parent, its accessor
-        -- paired with the new row id. Parents that were already stored are not returned, so we
-        -- never re-insert their child rows (this is the fix for the duplicate-rows bug, #1966).
+        -- Only newly-inserted parents are returned, so we never re-insert their children (#1966).
         newMetadata <- insertMetadataWithIds metadataWithAccessors
-        -- Now prepare all the related data for bulk inserts
         let allGovActions = catMaybes [offChainVoteGovAction acc ocvdId | (acc, ocvdId) <- newMetadata]
             allDrepData = catMaybes [offChainVoteDrep acc ocvdId | (acc, ocvdId) <- newMetadata]
             allAuthors = concatMap (uncurry offChainVoteAuthors) newMetadata
@@ -184,12 +181,7 @@ insertOffChainVoteResults trce resultQueue = do
                   HsqlP.statement allExternalUpdates DB.insertBulkOffChainVoteExternalUpdatesStmt
               pure ()
 
-    -- Insert the off-chain vote metadata rows and return, for each NEWLY inserted parent, its
-    -- accessor paired with the new row id. Anchors whose (voting_anchor_id, hash) is already
-    -- stored are skipped by `insertBulkOffChainVoteDataReturningNew` (ON CONFLICT DO NOTHING) and
-    -- so are not returned, which prevents re-inserting (duplicating) their child rows. Repeats
-    -- within a single batch are collapsed by keying on (voting_anchor_id, hash), and matching is
-    -- by natural key rather than list order, so it is robust to RETURNING ordering.
+    -- Dedup the batch by (voting_anchor_id, hash) and return accessors only for newly-inserted parents.
     insertMetadataWithIds ::
       [(DB.OffChainVoteData, OffChainVoteAccessors)] ->
       DB.DbM [(OffChainVoteAccessors, DB.OffChainVoteDataId)]

--- a/cardano-db-sync/src/Cardano/DbSync/OffChain.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/OffChain.hs
@@ -37,7 +37,7 @@ import Control.Concurrent.Class.MonadSTM.Strict (
   isEmptyTBQueue,
   writeTBQueue,
  )
-import Data.List (nubBy)
+import qualified Data.Map.Strict as Map
 import Data.Time.Clock.POSIX (POSIXTime)
 import qualified Data.Time.Clock.POSIX as Time
 import GHC.IO.Exception (userError)
@@ -152,14 +152,16 @@ insertOffChainVoteResults trce resultQueue = do
         insertBulkOffChainVoteFetchErrors errors
       -- Process metadata in a pipeline if any
       unless (null metadataWithAccessors) $ do
-        -- First insert all metadata and collect the IDs
-        metadataIds <- insertMetadataWithIds metadataWithAccessors
+        -- Insert the parent rows and get back, for each NEWLY inserted parent, its accessor
+        -- paired with the new row id. Parents that were already stored are not returned, so we
+        -- never re-insert their child rows (this is the fix for the duplicate-rows bug, #1966).
+        newMetadata <- insertMetadataWithIds metadataWithAccessors
         -- Now prepare all the related data for bulk inserts
-        let allGovActions = catMaybes [offChainVoteGovAction acc id | (_, acc, id) <- metadataIds]
-            allDrepData = catMaybes [offChainVoteDrep acc id | (_, acc, id) <- metadataIds]
-            allAuthors = concatMap (\(_, acc, id) -> offChainVoteAuthors acc id) metadataIds
-            allReferences = concatMap (\(_, acc, id) -> offChainVoteReferences acc id) metadataIds
-            allExternalUpdates = concatMap (\(_, acc, id) -> offChainVoteExternalUpdates acc id) metadataIds
+        let allGovActions = catMaybes [offChainVoteGovAction acc ocvdId | (acc, ocvdId) <- newMetadata]
+            allDrepData = catMaybes [offChainVoteDrep acc ocvdId | (acc, ocvdId) <- newMetadata]
+            allAuthors = concatMap (\(acc, ocvdId) -> offChainVoteAuthors acc ocvdId) newMetadata
+            allReferences = concatMap (\(acc, ocvdId) -> offChainVoteReferences acc ocvdId) newMetadata
+            allExternalUpdates = concatMap (\(acc, ocvdId) -> offChainVoteExternalUpdates acc ocvdId) newMetadata
         -- Execute all bulk inserts in a pipeline
         DB.runSession DB.mkDbCallStack $
           HsqlSes.pipeline $
@@ -182,27 +184,29 @@ insertOffChainVoteResults trce resultQueue = do
                   HsqlP.statement allExternalUpdates DB.insertBulkOffChainVoteExternalUpdatesStmt
               pure ()
 
-    -- Helper function to insert metadata and get back IDs
+    -- Insert the off-chain vote metadata rows and return, for each NEWLY inserted parent, its
+    -- accessor paired with the new row id. Anchors whose (voting_anchor_id, hash) is already
+    -- stored are skipped by `insertBulkOffChainVoteDataReturningNew` (ON CONFLICT DO NOTHING) and
+    -- so are not returned, which prevents re-inserting (duplicating) their child rows. Repeats
+    -- within a single batch are collapsed by keying on (voting_anchor_id, hash), and matching is
+    -- by natural key rather than list order, so it is robust to RETURNING ordering.
     insertMetadataWithIds ::
       [(DB.OffChainVoteData, OffChainVoteAccessors)] ->
-      DB.DbM [(DB.OffChainVoteData, OffChainVoteAccessors, DB.OffChainVoteDataId)]
+      DB.DbM [(OffChainVoteAccessors, DB.OffChainVoteDataId)]
     insertMetadataWithIds metadataWithAccessors = do
-      -- Extract just the metadata for insert and deduplicate by unique key
-      let metadata = map fst metadataWithAccessors
-          deduplicatedMetadata =
-            nubBy
-              ( \a b ->
-                  DB.offChainVoteDataVotingAnchorId a
-                    == DB.offChainVoteDataVotingAnchorId b
-                    && DB.offChainVoteDataHash a
-                      == DB.offChainVoteDataHash b
-              )
-              metadata
-      -- Insert and get IDs
-      ids <- DB.insertBulkOffChainVoteData deduplicatedMetadata
-
-      -- Return original data with IDs (note: length mismatch possible if duplicates were removed)
-      pure $ zipWith (\(md, acc) id -> (md, acc, id)) metadataWithAccessors ids
+      let byKey =
+            Map.fromListWith
+              (\_new old -> old)
+              [ ((DB.offChainVoteDataVotingAnchorId md, DB.offChainVoteDataHash md), (md, acc))
+              | (md, acc) <- metadataWithAccessors
+              ]
+          dedupedMetadata = map fst (Map.elems byKey)
+      newRows <- DB.insertBulkOffChainVoteDataReturningNew dedupedMetadata
+      pure
+        [ (acc, ocvdId)
+        | (anchorId, hash, ocvdId) <- newRows
+        , Just (_, acc) <- [Map.lookup (anchorId, hash) byKey]
+        ]
 
     -- Bulk insert for errors (you'll need to create this statement)
     insertBulkOffChainVoteFetchErrors :: [DB.OffChainVoteFetchError] -> DB.DbM ()

--- a/cardano-db-sync/src/Cardano/DbSync/OffChain.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/OffChain.hs
@@ -159,9 +159,9 @@ insertOffChainVoteResults trce resultQueue = do
         -- Now prepare all the related data for bulk inserts
         let allGovActions = catMaybes [offChainVoteGovAction acc ocvdId | (acc, ocvdId) <- newMetadata]
             allDrepData = catMaybes [offChainVoteDrep acc ocvdId | (acc, ocvdId) <- newMetadata]
-            allAuthors = concatMap (\(acc, ocvdId) -> offChainVoteAuthors acc ocvdId) newMetadata
-            allReferences = concatMap (\(acc, ocvdId) -> offChainVoteReferences acc ocvdId) newMetadata
-            allExternalUpdates = concatMap (\(acc, ocvdId) -> offChainVoteExternalUpdates acc ocvdId) newMetadata
+            allAuthors = concatMap (uncurry offChainVoteAuthors) newMetadata
+            allReferences = concatMap (uncurry offChainVoteReferences) newMetadata
+            allExternalUpdates = concatMap (uncurry offChainVoteExternalUpdates) newMetadata
         -- Execute all bulk inserts in a pipeline
         DB.runSession DB.mkDbCallStack $
           HsqlSes.pipeline $

--- a/cardano-db/src/Cardano/Db/Statement/Function/Core.hs
+++ b/cardano-db/src/Cardano/Db/Statement/Function/Core.hs
@@ -43,12 +43,8 @@ data ResultType c r where
 -- | The bulk insert result type
 data ResultTypeBulk a where
   NoResultBulk :: ResultTypeBulk () -- No results returned
-  WithResultBulk :: HsqlD.Result [a] -> ResultTypeBulk [a] -- Return generated IDs (RETURNING id)
-
-  -- | Return the given columns via @RETURNING@, decoded with the supplied result decoder.
-  -- Useful when the caller needs more than the @id@ (e.g. to match returned rows back to their
-  -- inputs by natural key when @ON CONFLICT DO NOTHING@ only returns the newly-inserted rows).
-  WithResultBulkColumns :: [Text.Text] -> HsqlD.Result [a] -> ResultTypeBulk [a]
+  WithResultBulk :: HsqlD.Result [a] -> ResultTypeBulk [a] -- Return generated IDs
+  WithResultBulkColumns :: [Text.Text] -> HsqlD.Result [a] -> ResultTypeBulk [a] -- Return given columns via RETURNING
 
 -- | Creates a parameter encoder for an array of values from a single-value encoder
 bulkEncoder :: HsqlE.NullableOrNot HsqlE.Value a -> HsqlE.Params [a]

--- a/cardano-db/src/Cardano/Db/Statement/Function/Core.hs
+++ b/cardano-db/src/Cardano/Db/Statement/Function/Core.hs
@@ -13,6 +13,7 @@ import Cardano.Db.Error (DbCallStack, DbSessionError (..), formatSessionError)
 import Cardano.Db.Statement.Types (Entity (..))
 import Cardano.Db.Types (DbEnv (..), DbM (..))
 import Cardano.Prelude (MonadIO (..), ask, throwIO)
+import qualified Data.Text as Text
 import qualified Hasql.Decoders as HsqlD
 import qualified Hasql.Encoders as HsqlE
 import qualified Hasql.Session as HsqlS
@@ -42,7 +43,12 @@ data ResultType c r where
 -- | The bulk insert result type
 data ResultTypeBulk a where
   NoResultBulk :: ResultTypeBulk () -- No results returned
-  WithResultBulk :: HsqlD.Result [a] -> ResultTypeBulk [a] -- Return generated IDs
+  WithResultBulk :: HsqlD.Result [a] -> ResultTypeBulk [a] -- Return generated IDs (RETURNING id)
+
+  -- | Return the given columns via @RETURNING@, decoded with the supplied result decoder.
+  -- Useful when the caller needs more than the @id@ (e.g. to match returned rows back to their
+  -- inputs by natural key when @ON CONFLICT DO NOTHING@ only returns the newly-inserted rows).
+  WithResultBulkColumns :: [Text.Text] -> HsqlD.Result [a] -> ResultTypeBulk [a]
 
 -- | Creates a parameter encoder for an array of values from a single-value encoder
 bulkEncoder :: HsqlE.NullableOrNot HsqlE.Value a -> HsqlE.Params [a]

--- a/cardano-db/src/Cardano/Db/Statement/Function/InsertBulk.hs
+++ b/cardano-db/src/Cardano/Db/Statement/Function/InsertBulk.hs
@@ -111,6 +111,8 @@ insertBulkWith conflictStrategy removeJsonb extract enc returnIds =
         (decoder, shouldReturnId) = case returnIds of
           NoResultBulk -> (HsqlD.noResult, "")
           WithResultBulk dec -> (dec, " RETURNING id")
+          WithResultBulkColumns cols dec ->
+            (dec, " RETURNING " <> Text.intercalate ", " cols)
 
         sql =
           TextEnc.encodeUtf8 $

--- a/cardano-db/src/Cardano/Db/Statement/OffChain.hs
+++ b/cardano-db/src/Cardano/Db/Statement/OffChain.hs
@@ -455,17 +455,8 @@ insertBulkOffChainVoteAuthorsStmt =
 
 --------------------------------------------------------------------------------
 
--- | Bulk-insert @off_chain_vote_data@ rows, returning the natural key + id of only the rows that
--- were *newly* inserted.
---
--- Uses @ON CONFLICT (hash, voting_anchor_id) DO NOTHING RETURNING voting_anchor_id, hash, id@:
--- an anchor whose metadata is already stored conflicts and is skipped, so it is NOT returned.
--- This is what makes off-chain vote insertion idempotent - the caller inserts the child rows
--- (drep data, authors, references, ...) only for the returned (newly-inserted) parents, so
--- re-processing the same anchor never duplicates children (issue #1966).
---
--- The previous behaviour used @DO UPDATE ... RETURNING id@, which returned the existing id on a
--- re-fetch and so caused the children to be inserted again.
+-- ON CONFLICT DO NOTHING, so only newly-inserted rows are returned; the caller inserts children
+-- only for those, keeping re-fetches idempotent (#1966).
 insertBulkOffChainVoteDataReturningNewStmt ::
   HsqlStmt.Statement [SO.OffChainVoteData] [(Id.VotingAnchorId, ByteString, Id.OffChainVoteDataId)]
 insertBulkOffChainVoteDataReturningNewStmt =
@@ -488,7 +479,7 @@ insertBulkOffChainVoteDataReturningNewStmt =
       , map SO.offChainVoteDataIsValid xs
       )
 
-    -- RETURNING voting_anchor_id, hash, id (column order matches the WithResultBulkColumns list).
+    -- Column order matches the RETURNING list above.
     newRowsDecoder :: HsqlD.Result [(Id.VotingAnchorId, ByteString, Id.OffChainVoteDataId)]
     newRowsDecoder =
       HsqlD.rowList $
@@ -545,8 +536,7 @@ insertBulkOffChainVoteDrepDataStmt =
       , map SO.offChainVoteDrepDataImageHash xs
       )
 
--- | Run the bulk DRep-data insert as its own session. Production batches this in a pipeline with
--- the other child inserts; this wrapper exists for callers/tests that insert DRep data directly.
+-- Standalone session wrapper; production batches this in a pipeline with the other child inserts.
 insertBulkOffChainVoteDrepData :: [SO.OffChainVoteDrepData] -> DbM ()
 insertBulkOffChainVoteDrepData xs =
   runSession mkDbCallStack $ HsqlSes.statement xs insertBulkOffChainVoteDrepDataStmt

--- a/cardano-db/src/Cardano/Db/Statement/OffChain.hs
+++ b/cardano-db/src/Cardano/Db/Statement/OffChain.hs
@@ -455,14 +455,26 @@ insertBulkOffChainVoteAuthorsStmt =
 
 --------------------------------------------------------------------------------
 
-insertBulkOffChainVoteDataStmt :: HsqlStmt.Statement [SO.OffChainVoteData] [Id.OffChainVoteDataId]
-insertBulkOffChainVoteDataStmt =
+-- | Bulk-insert @off_chain_vote_data@ rows, returning the natural key + id of only the rows that
+-- were *newly* inserted.
+--
+-- Uses @ON CONFLICT (hash, voting_anchor_id) DO NOTHING RETURNING voting_anchor_id, hash, id@:
+-- an anchor whose metadata is already stored conflicts and is skipped, so it is NOT returned.
+-- This is what makes off-chain vote insertion idempotent - the caller inserts the child rows
+-- (drep data, authors, references, ...) only for the returned (newly-inserted) parents, so
+-- re-processing the same anchor never duplicates children (issue #1966).
+--
+-- The previous behaviour used @DO UPDATE ... RETURNING id@, which returned the existing id on a
+-- re-fetch and so caused the children to be inserted again.
+insertBulkOffChainVoteDataReturningNewStmt ::
+  HsqlStmt.Statement [SO.OffChainVoteData] [(Id.VotingAnchorId, ByteString, Id.OffChainVoteDataId)]
+insertBulkOffChainVoteDataReturningNewStmt =
   insertBulkWith
-    (ReplaceWithColumns (uniqueFields (Proxy @SO.OffChainVoteData))) -- ON CONFLICT DO UPDATE to ensure we get IDs back
+    (IgnoreWithColumns (uniqueFields (Proxy @SO.OffChainVoteData))) -- ON CONFLICT (hash, voting_anchor_id) DO NOTHING
     False
     extractOffChainVoteData
     SO.offChainVoteDataBulkEncoder
-    (WithResultBulk $ Id.idBulkDecoder Id.OffChainVoteDataId)
+    (WithResultBulkColumns ["voting_anchor_id", "hash", "id"] newRowsDecoder)
   where
     extractOffChainVoteData :: [SO.OffChainVoteData] -> ([Id.VotingAnchorId], [ByteString], [Text], [ByteString], [Maybe Text], [Text], [Maybe Text], [Maybe Bool])
     extractOffChainVoteData xs =
@@ -476,9 +488,19 @@ insertBulkOffChainVoteDataStmt =
       , map SO.offChainVoteDataIsValid xs
       )
 
-insertBulkOffChainVoteData :: [SO.OffChainVoteData] -> DbM [Id.OffChainVoteDataId]
-insertBulkOffChainVoteData offChainVoteData = do
-  -- Check existence and filter in one pass
+    -- RETURNING voting_anchor_id, hash, id (column order matches the WithResultBulkColumns list).
+    newRowsDecoder :: HsqlD.Result [(Id.VotingAnchorId, ByteString, Id.OffChainVoteDataId)]
+    newRowsDecoder =
+      HsqlD.rowList $
+        (,,)
+          <$> Id.idDecoder Id.VotingAnchorId
+          <*> HsqlD.column (HsqlD.nonNullable HsqlD.bytea)
+          <*> Id.idDecoder Id.OffChainVoteDataId
+
+insertBulkOffChainVoteDataReturningNew ::
+  [SO.OffChainVoteData] -> DbM [(Id.VotingAnchorId, ByteString, Id.OffChainVoteDataId)]
+insertBulkOffChainVoteDataReturningNew offChainVoteData = do
+  -- Only insert rows whose voting anchor exists (the FK is `noreference`, so we guard it here).
   existenceResults <-
     runSession mkDbCallStack $
       HsqlS.pipeline $ do
@@ -496,12 +518,11 @@ insertBulkOffChainVoteData offChainVoteData = do
         , exists
         ]
 
-  -- Run the bulk insert and return the generated IDs
   if null filteredOffChainVoteData
     then pure []
     else
       runSession mkDbCallStack $
-        HsqlSes.statement filteredOffChainVoteData insertBulkOffChainVoteDataStmt
+        HsqlSes.statement filteredOffChainVoteData insertBulkOffChainVoteDataReturningNewStmt
 
 --------------------------------------------------------------------------------
 
@@ -523,6 +544,20 @@ insertBulkOffChainVoteDrepDataStmt =
       , map SO.offChainVoteDrepDataImageUrl xs
       , map SO.offChainVoteDrepDataImageHash xs
       )
+
+-- | Run the bulk DRep-data insert as its own session. Production batches this in a pipeline with
+-- the other child inserts; this wrapper exists for callers/tests that insert DRep data directly.
+insertBulkOffChainVoteDrepData :: [SO.OffChainVoteDrepData] -> DbM ()
+insertBulkOffChainVoteDrepData xs =
+  runSession mkDbCallStack $ HsqlSes.statement xs insertBulkOffChainVoteDrepDataStmt
+
+countOffChainVoteData :: DbM Word64
+countOffChainVoteData =
+  runSession mkDbCallStack $ HsqlSes.statement () (countAll @SO.OffChainVoteData)
+
+countOffChainVoteDrepData :: DbM Word64
+countOffChainVoteDrepData =
+  runSession mkDbCallStack $ HsqlSes.statement () (countAll @SO.OffChainVoteDrepData)
 
 --------------------------------------------------------------------------------
 queryNewVoteWorkQueueDataStmt :: HsqlStmt.Statement Int [(Id.VotingAnchorId, ByteString, VoteUrl, AnchorType)]

--- a/cardano-db/test/Test/IO/Cardano/Db/Insert.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Insert.hs
@@ -10,6 +10,7 @@ import Control.Monad (void)
 import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import Data.Maybe (fromJust)
+import qualified Data.Text as Text
 import Data.Time.Clock
 import Test.IO.Cardano.Db.Util
 import Test.Tasty (TestTree, testGroup)
@@ -24,6 +25,7 @@ tests =
     , testCase "Insert twice" insertTwice
     , testCase "Insert foreign key missing" insertForeignKeyMissing
     , testCase "Insert pool relay with large port" insertPoolRelayLargePort
+    , testCase "Off-chain vote data re-fetch does not duplicate children" insertOffChainVoteDataNoDuplicateChildren
     ]
 
 insertZeroTest :: IO ()
@@ -121,6 +123,89 @@ insertPoolRelayLargePort =
         , poolRelayDnsSrvName = Nothing
         , poolRelayPort = Just p
         }
+
+-- | Regression test for issue #1966: re-processing the off-chain metadata of an anchor that is
+-- already stored must NOT duplicate its child rows.
+--
+-- We insert the parent twice (simulating the anchor being fetched twice) and, as production does,
+-- insert the DRep child only for the parents reported as newly inserted. The second insert
+-- conflicts on @(voting_anchor_id, hash)@ and is skipped, so no second child row is created.
+-- A unique anchor (hash + url derived from the current time) keeps the test independent of any
+-- rows left by other test cases; assertions are on the row-count delta.
+insertOffChainVoteDataNoDuplicateChildren :: IO ()
+insertOffChainVoteDataNoDuplicateChildren = do
+  t <- getCurrentTime
+  -- Full timestamp (incl. date) so the anchor is unique per run even when the test DB is reused
+  -- (rows persist: the suite commits and deleteAllBlocks does not cascade to voting_anchor).
+  let stamp = filter (/= ' ') (show t)
+      vaHash = BS.take 32 (BS.pack stamp <> BS.replicate 32 'v')
+      ocvdHash = BS.take 32 (BS.pack stamp <> BS.replicate 32 'o')
+      vaUrl = VoteUrl ("anchor://dedup/" <> Text.pack stamp)
+  runDbStandaloneSilent $ do
+    deleteAllBlocks
+    slid <- insertSlotLeader testSlotLeader
+    bid <- insertCheckUniqueBlock (blockZero slid)
+    vaid <- insertVotingAnchor (drepVotingAnchor vaUrl vaHash bid)
+    let ocvd = drepOffChainVoteData vaid ocvdHash
+
+    parentsBefore <- countOffChainVoteData
+    childrenBefore <- countOffChainVoteDrepData
+
+    -- First fetch: parent is new, so one child is inserted.
+    new1 <- insertBulkOffChainVoteDataReturningNew [ocvd]
+    insertBulkOffChainVoteDrepData [drepData ocvdId | (_, _, ocvdId) <- new1]
+
+    -- Re-fetch the same anchor: parent already exists, so nothing new -> no extra child.
+    new2 <- insertBulkOffChainVoteDataReturningNew [ocvd]
+    insertBulkOffChainVoteDrepData [drepData ocvdId | (_, _, ocvdId) <- new2]
+
+    parentsAfter <- countOffChainVoteData
+    childrenAfter <- countOffChainVoteDrepData
+
+    assertBool
+      ("re-fetch should report no new parents, got " ++ show (length new2))
+      (null new2)
+    assertBool
+      ("off_chain_vote_data delta should be 1, got " ++ show (parentsAfter - parentsBefore))
+      (parentsAfter == parentsBefore + 1)
+    assertBool
+      ("off_chain_vote_drep_data delta should be 1 (not 2), got " ++ show (childrenAfter - childrenBefore))
+      (childrenAfter == childrenBefore + 1)
+
+drepVotingAnchor :: VoteUrl -> ByteString -> BlockId -> VotingAnchor
+drepVotingAnchor url dataHash bid =
+  VotingAnchor
+    { votingAnchorUrl = url
+    , votingAnchorDataHash = dataHash
+    , votingAnchorType = DrepAnchor
+    , votingAnchorBlockId = bid
+    }
+
+drepOffChainVoteData :: VotingAnchorId -> ByteString -> OffChainVoteData
+drepOffChainVoteData vaid dataHash =
+  OffChainVoteData
+    { offChainVoteDataVotingAnchorId = vaid
+    , offChainVoteDataHash = dataHash
+    , offChainVoteDataJson = "{}"
+    , offChainVoteDataBytes = "{}"
+    , offChainVoteDataWarning = Nothing
+    , offChainVoteDataLanguage = ""
+    , offChainVoteDataComment = Nothing
+    , offChainVoteDataIsValid = Just True
+    }
+
+drepData :: OffChainVoteDataId -> OffChainVoteDrepData
+drepData ocvdId =
+  OffChainVoteDrepData
+    { offChainVoteDrepDataOffChainVoteDataId = ocvdId
+    , offChainVoteDrepDataPaymentAddress = Nothing
+    , offChainVoteDrepDataGivenName = "Test DRep"
+    , offChainVoteDrepDataObjectives = Nothing
+    , offChainVoteDrepDataMotivations = Nothing
+    , offChainVoteDrepDataQualifications = Nothing
+    , offChainVoteDrepDataImageUrl = Nothing
+    , offChainVoteDrepDataImageHash = Nothing
+    }
 
 blockZero :: SlotLeaderId -> Block
 blockZero slid =

--- a/cardano-db/test/Test/IO/Cardano/Db/Insert.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/Insert.hs
@@ -124,19 +124,11 @@ insertPoolRelayLargePort =
         , poolRelayPort = Just p
         }
 
--- | Regression test for issue #1966: re-processing the off-chain metadata of an anchor that is
--- already stored must NOT duplicate its child rows.
---
--- We insert the parent twice (simulating the anchor being fetched twice) and, as production does,
--- insert the DRep child only for the parents reported as newly inserted. The second insert
--- conflicts on @(voting_anchor_id, hash)@ and is skipped, so no second child row is created.
--- A unique anchor (hash + url derived from the current time) keeps the test independent of any
--- rows left by other test cases; assertions are on the row-count delta.
+-- Regression test for #1966: re-fetching an already-stored anchor must not duplicate its children.
 insertOffChainVoteDataNoDuplicateChildren :: IO ()
 insertOffChainVoteDataNoDuplicateChildren = do
   t <- getCurrentTime
-  -- Full timestamp (incl. date) so the anchor is unique per run even when the test DB is reused
-  -- (rows persist: the suite commits and deleteAllBlocks does not cascade to voting_anchor).
+  -- Unique per run so the test is independent of rows left by other cases.
   let stamp = filter (/= ' ') (show t)
       vaHash = BS.take 32 (BS.pack stamp <> BS.replicate 32 'v')
       ocvdHash = BS.take 32 (BS.pack stamp <> BS.replicate 32 'o')


### PR DESCRIPTION
Re-processing the off-chain metadata of an already-stored voting anchor duplicated its child rows (off_chain_vote_drep_data, off_chain_vote_author, off_chain_vote_reference, off_chain_vote_external_update, off_chain_vote_gov_action_data). The parent insert used ON CONFLICT DO UPDATE ... RETURNING id, so a re-fetch returned the existing id, and the children - which have no uniqueness and were plain-inserted - were written again.

Make insertion idempotent: insertBulkOffChainVoteDataReturningNew uses ON CONFLICT DO NOTHING RETURNING (voting_anchor_id, hash, id) so only newly inserted parents come back, and the orchestration inserts child rows only for those, matched by natural key. Adds a WithResultBulkColumns result mode for a custom RETURNING column list. Prevents new duplicates; existing rows on synced DBs are unaffected.

Adds a regression test (cardano-db test-db) asserting a re-fetch creates no duplicate child rows.

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
