### PR TITLE
Fix DRep image base64 data URI stripping (#1966)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - The `epoch` table is redesigned and replaced by a view; the in-memory cache that caused [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) is removed. Reads are unchanged.
 - Fix `pool_relay.port` overflow [#2135](https://github.com/IntersectMBO/cardano-db-sync/issues/2135); a startup migration repairs existing rows.
 - Add `--allow-private-offchain-urls` CLI flag enabling off-chain metadata fetches against private/loopback addresses. Intended for local-cluster testing only; off by default.
+- Fix off-chain DRep metadata image handling: when `body.image.contentUrl` is an inline base64 data URI (`data:<mime>;base64,...`), store it verbatim in `off_chain_vote_drep_data.image_url` instead of stripping the `data:<mime>;base64,` prefix (#1966).
 
 ## 13.7.1.0
 - Auto-repair `epoch.out_sum` / `epoch.fees` / `epoch.tx_count` / `epoch.blk_count` corruption introduced by issue [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) in 13.7.0.0 - 13.7.0.4. A startup migration recomputes every epoch row from the underlying `tx` / `block` tables and rewrites only the rows whose stored values disagree. Adds a one-time 5-15 minute delay on the first startup after upgrade on a mainnet-sized database; subsequent restarts and fresh syncs are unaffected. Operators on older release lines who do not upgrade can apply the same fix manually via [`scripts/fix-epoch-table.sql`](scripts/fix-epoch-table.sql).

--- a/cardano-db-sync/src/Cardano/DbSync/OffChain/Vote/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/OffChain/Vote/Types.hs
@@ -279,14 +279,13 @@ instance FromJSON DrepBody where
 instance FromJSON Image where
   parseJSON v = withObjectV v "Image" $ \o -> do
     curl <- o .: "contentUrl"
-    case Text.stripPrefix "data:" (textValue curl) of
-      Just ctb
-        | (_, tb) <- Text.break (== '/') ctb
-        , Text.isPrefixOf "/" tb
-        , (_, b) <- Text.break (== ';') tb
-        , Just imageData <- Text.stripPrefix ";base64," b ->
-            pure $ Image (TextValue imageData) Nothing
-      _ -> fromImageUrl <$> parseJSON v
+    -- An inline image is a data URI (CIP-119: "data:<content/type>;base64,..."); the contentUrl
+    -- IS the image and there is no separate sha256. Store it verbatim - do NOT strip the
+    -- "data:<mime>;base64," prefix (issue #1966). A regular URL instead carries a sha256, handled
+    -- by the ImageUrl decoder below.
+    if Text.isPrefixOf "data:" (textValue curl)
+      then pure $ Image curl Nothing
+      else fromImageUrl <$> parseJSON v
     where
       withObjectV v' s p = withObject s p v'
 

--- a/cardano-db-sync/src/Cardano/DbSync/OffChain/Vote/Types.hs
+++ b/cardano-db-sync/src/Cardano/DbSync/OffChain/Vote/Types.hs
@@ -279,10 +279,7 @@ instance FromJSON DrepBody where
 instance FromJSON Image where
   parseJSON v = withObjectV v "Image" $ \o -> do
     curl <- o .: "contentUrl"
-    -- An inline image is a data URI (CIP-119: "data:<content/type>;base64,..."); the contentUrl
-    -- IS the image and there is no separate sha256. Store it verbatim - do NOT strip the
-    -- "data:<mime>;base64," prefix (issue #1966). A regular URL instead carries a sha256, handled
-    -- by the ImageUrl decoder below.
+    -- Inline images are data URIs (CIP-119); store the contentUrl verbatim, don't strip the prefix (#1966).
     if Text.isPrefixOf "data:" (textValue curl)
       then pure $ Image curl Nothing
       else fromImageUrl <$> parseJSON v

--- a/cardano-db-sync/test/Cardano/DbSync/OffChain/VoteTest.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/OffChain/VoteTest.hs
@@ -28,9 +28,7 @@ tests =
       , ("image contentUrl base64 data URI keeps its prefix (#1966)", prop_imageDataUriKeepsPrefix)
       ]
 
--- | Regression test for issue #1966: when an image's @contentUrl@ is an inline base64 data URI
--- (@data:<mime>;base64,...@), db-sync must store the value verbatim, NOT strip the
--- @data:<mime>;base64,@ prefix. CIP-119 defines @contentUrl@ as the full data URI for inline images.
+-- | Regression test for #1966: an inline base64 data URI contentUrl is stored verbatim, not stripped.
 prop_imageDataUriKeepsPrefix :: Property
 prop_imageDataUriKeepsPrefix = withTests 1 $ property $ do
   let dataUri =

--- a/cardano-db-sync/test/Cardano/DbSync/OffChain/VoteTest.hs
+++ b/cardano-db-sync/test/Cardano/DbSync/OffChain/VoteTest.hs
@@ -6,6 +6,7 @@ module Cardano.DbSync.OffChain.VoteTest (tests) where
 import qualified Cardano.Db as DB
 import Cardano.DbSync.Error (runOrThrowIO)
 import Cardano.DbSync.OffChain.Http (parseAndValidateVoteData)
+import qualified Cardano.DbSync.OffChain.Vote.Types as Vote
 import Cardano.Prelude hiding ((%))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as AesonKey
@@ -24,7 +25,22 @@ tests =
       , ("parseAndValidateVoteData handles invalid CIP format (type error)", prop_parseInvalidCIPFormat)
       , ("parseAndValidateVoteData handles valid JSON but invalid structure", prop_parseValidJsonInvalidStructure)
       , ("parseAndValidateVoteData handles unparseable JSON", prop_parseUnparseableJson)
+      , ("image contentUrl base64 data URI keeps its prefix (#1966)", prop_imageDataUriKeepsPrefix)
       ]
+
+-- | Regression test for issue #1966: when an image's @contentUrl@ is an inline base64 data URI
+-- (@data:<mime>;base64,...@), db-sync must store the value verbatim, NOT strip the
+-- @data:<mime>;base64,@ prefix. CIP-119 defines @contentUrl@ as the full data URI for inline images.
+prop_imageDataUriKeepsPrefix :: Property
+prop_imageDataUriKeepsPrefix = withTests 1 $ property $ do
+  let dataUri =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==" ::
+          Text.Text
+      payload = Aeson.encode (Aeson.object ["contentUrl" Aeson..= dataUri])
+  annotate "image_url must keep the data:<mime>;base64, prefix"
+  case Aeson.eitherDecode' payload :: Either [Char] Vote.Image of
+    Left err -> annotate err >> failure
+    Right img -> Vote.textValue (Vote.content img) === dataUri
 
 -- | Test that we can parse valid CIP-119 format correctly
 -- Scenario: Valid JSON + Valid CIP schema -> is_valid = true


### PR DESCRIPTION
When an off-chain DRep metadata image is an inline base64 data URI (`data:<mime>;base64,...`), db-sync stored only the base64 payload in `off_chain_vote_drep_data.image_url`, stripping the `data:<mime>;base64,` prefix (and the MIME type), so the stored value was neither the source contentUrl nor a usable data URI.

CIP-119 defines `contentUrl` as the full data URI for inline images, so store it verbatim. The `Image` JSON decoder now keeps any `data:`-scheme contentUrl as-is; regular URL images (which carry a sha256) are unchanged.

Adds a regression test asserting a base64 data-URI contentUrl is decoded without losing its prefix.

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
