### PR TITLE
test(uniqueness): assert pool_stat is unique per (pool_hash_id, epoch_no)

### DIFF
--- a/scripts/test-uniqueness.sql
+++ b/scripts/test-uniqueness.sql
@@ -78,6 +78,7 @@ BEGIN
   _total := _total + 1; _passed := _passed + check_unique('pool_retire', 'announced_tx_id', 'cert_index');
   _total := _total + 1; _passed := _passed + check_unique('pool_relay', 'update_id', 'ipv4', 'ipv6', 'dns_name');
   _total := _total + 1; _passed := _passed + check_unique('pool_owner', 'addr_id', 'pool_update_id');
+  _total := _total + 1; _passed := _passed + check_unique('pool_stat', 'pool_hash_id', 'epoch_no');
 
   -- =====================================================
   -- EPOCH / PROTOCOL PARAMS (dropped in migration-2-0021)


### PR DESCRIPTION
- added one line check in the POOLS section (covers #1986 / #1901 / #1987)

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
