### PR TITLE
docs(schema): document epoch views and correct stale generator note

### DIFF
--- a/doc/schema.md
+++ b/doc/schema.md
@@ -933,7 +933,7 @@ A table for new committee proposed on a GovActionProposal. New in 13.2-Conway.
 |-|-|-|
 | `id` | integer (64) |  |
 | `gov_action_proposal_id` | integer (64) | The GovActionProposal table index for this new committee. This can be null for genesis committees. |
-| `quorum_numerator` | integer (64) | The proposed quorum nominator. |
+| `quorum_numerator` | integer (64) | The proposed quorum numerator. |
 | `quorum_denominator` | integer (64) | The proposed quorum denominator. |
 
 ### `committee_member`

--- a/doc/schema.md
+++ b/doc/schema.md
@@ -1,6 +1,6 @@
 # Schema Documentation for cardano-db-sync
 
-**Note:** This file is auto-generated from the documentation in cardano-db/src/Cardano/Db/Schema/BaseSchema.hs by the command `cabal run -- gen-schema-docs doc/schema.md`. This document should only be updated during the release process and updated on the release branch.
+**Note:** This file is maintained manually and should be updated on the release branch whenever the database schema changes. (It was previously auto-generated, but the generator was removed during the Persistent->Hasql migration.)
 
 ### `schema_version`
 
@@ -179,7 +179,37 @@ A table containing metadata about the chain. There will probably only ever be on
 
 ### `epoch`
 
-Aggregation of data within an epoch.
+A view aggregating data within an epoch. As of schema stage-two v49 (migration-2-0049) `epoch` is a view, not a table: the `UNION ALL` of `epoch_finalized` (materialised past epochs) and `epoch_current` (the live, in-progress epoch). It returns rows only when epoch sync is enabled (see `epoch_sync_enabled`); otherwise it is empty.
+
+| Column name | Type | Description |
+|-|-|-|
+| `id` | integer (64) |  |
+| `out_sum` | numeric | The sum of the transaction output values (in Lovelace) in this epoch. |
+| `fees` | numeric | The sum of the fees (in Lovelace) in this epoch. |
+| `tx_count` | integer (64) | The number of transactions in this epoch. |
+| `blk_count` | integer (64) | The number of blocks in this epoch. |
+| `no` | integer (64) | The epoch number. |
+| `start_time` | timestamp | The epoch start time. |
+| `end_time` | timestamp | The epoch end time. |
+
+### `epoch_current`
+
+A view computing aggregates for the current (not-yet-finalized) epoch live from `block` and `tx`. Excludes any epoch already present in `epoch_finalized`, and returns rows only when epoch sync is enabled (see `epoch_sync_enabled`).
+
+| Column name | Type | Description |
+|-|-|-|
+| `id` | integer (64) | Synthetic id (epoch number + 1). |
+| `out_sum` | numeric | The sum of the transaction output values (in Lovelace) in this epoch. |
+| `fees` | numeric | The sum of the fees (in Lovelace) in this epoch. |
+| `tx_count` | integer (64) | The number of transactions in this epoch. |
+| `blk_count` | integer (64) | The number of blocks in this epoch. |
+| `no` | integer (64) | The epoch number. |
+| `start_time` | timestamp | The epoch start time. |
+| `end_time` | timestamp | The epoch end time. |
+
+### `epoch_finalized`
+
+Materialised aggregates for finalized (completed) epochs. Together with `epoch_current` it backs the `epoch` view.
 
 * Primary Id: `id`
 
@@ -190,9 +220,20 @@ Aggregation of data within an epoch.
 | `fees` | lovelace | The sum of the fees (in Lovelace) in this epoch. |
 | `tx_count` | word31type | The number of transactions in this epoch. |
 | `blk_count` | word31type | The number of blocks in this epoch. |
-| `no` | word31type | The epoch number. |
+| `no` | word31type | The epoch number (unique). |
 | `start_time` | timestamp | The epoch start time. |
 | `end_time` | timestamp | The epoch end time. |
+
+### `epoch_sync_enabled`
+
+A single-row toggle controlling whether the `epoch` and `epoch_current` views return data.
+
+* Primary Id: `singleton`
+
+| Column name | Type | Description |
+|-|-|-|
+| `singleton` | boolean | Always `TRUE`; enforces a single row. |
+| `enabled` | boolean | Whether epoch aggregation (the `epoch` / `epoch_current` views) is enabled. |
 
 ### `ada_pots`
 


### PR DESCRIPTION
## Document epoch views and correct stale generator note

epoch is now a view (migration-2-0049), not a table: document it as the UNION of `epoch_finalized` + `epoch_current`, and add the new `epoch_current` view and `epoch_finalized` / `epoch_sync_enabled` tables. Also correct the header note - the schema-doc generator (BaseSchema.hs / gen-schema-docs) was removed in the Persistent->Hasql rewrite, so the file is now maintained manually.

# Description

Add your description here, if it fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense
- [ ] Commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [ ] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [ ] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
