### PR TITLE
Support custom PGPASSFILE in docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for cardano-db-sync
 
+## Unreleased
+- Update Docker configuration to allow PostgreSQL connection details to be provided via Docker secrets or a `.pgpass` file using the `PGPASSFILE` environment variable.
+
 ## 13.7.2.1
 - The `epoch` table is redesigned and replaced by a view; the in-memory cache that caused [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) is removed. Reads are unchanged.
 - Fix `pool_relay.port` overflow [#2135](https://github.com/IntersectMBO/cardano-db-sync/issues/2135); a startup migration repairs existing rows.

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -75,28 +75,36 @@ entrypoint. Possible values are:
  * sanchonet
  * shelley_qa
 
-#### `POSTGRES_HOST` (required)
+#### `POSTGRES_HOST`
 
-The PostgreSQL server host to connect to.
+The PostgreSQL server host to connect to. This variable is ignored if `PGPASSFILE` is set.
 
-#### `POSTGRES_PORT` (required)
+#### `POSTGRES_PORT`
 
-Specifies the PostgreSQL server port to connect to.
+Specifies the PostgreSQL server port to connect to. This variable is ignored if `PGPASSFILE` is set.
 
-#### `POSTGRES_USER` (required)
+#### `POSTGRES_DB`
 
-The PostgreSQL server user to connect as.
+The PostgreSQL database name to connect to. If left unset, the value is read from `/run/secrets/postgres_db`. Both the variable and the file are ignored if `PGPASSFILE` is set.
 
-#### `POSTGRES_PASSWORD` (required)
+#### `POSTGRES_USER`
 
-Specifies the PostgreSQL server password to connect as.
+The PostgreSQL server user to connect as. If left unset, the value is read from `/run/secrets/postgres_user`. Both the variable and the file are ignored if `PGPASSFILE` is set.
+
+#### `POSTGRES_PASSWORD`
+
+Specifies the PostgreSQL server password to connect as. If left unset, the value is read from `/run/secrets/postgres_password`. Both the variable and the file are ignored if `PGPASSFILE` is set.
+
+#### `PGPASSFILE`
+
+Path to a file containing PostgreSQL connection information. Note that `PGPASSFILE` with Docker secrets is preferred when Docker secrets are available.
 
 #### `RESTORE_SNAPSHOT` (optional)
 
 Specifies a `cardano-db-sync` snapshot archive to download and restore from. If omitted,
 it will sync from genesis. see [Restoring From Snapshots](#restoring-from-snapshots)
 
-### `DB_SYNC_CONFIG` (optional)
+#### `DB_SYNC_CONFIG` (optional)
 
 Overrides the `db-sync-config.json` provided by the network configuration. See [Overriding
 Network Configuration](#overriding-network-configuration).
@@ -206,21 +214,29 @@ entrypoint. Possible values are:
  * sanchonet
  * shelley_qa
 
-#### `POSTGRES_HOST` (required)
+#### `POSTGRES_HOST`
 
-The PostgreSQL server host to connect to.
+The PostgreSQL server host to connect to. This variable is ignored if `PGPASSFILE` is set.
 
-#### `POSTGRES_PORT` (required)
+#### `POSTGRES_PORT`
 
-Specifies the PostgreSQL server port to connect to.
+Specifies the PostgreSQL server port to connect to. This variable is ignored if `PGPASSFILE` is set.
 
-#### `POSTGRES_USER` (required)
+#### `POSTGRES_DB`
 
-The PostgreSQL server user to connect as.
+The PostgreSQL database name to connect to. If left unset, the value is read from `/run/secrets/postgres_db`. Both the variable and the file are ignored if `PGPASSFILE` is set.
 
-#### `POSTGRES_PASSWORD` (required)
+#### `POSTGRES_USER`
 
-Specifies the PostgreSQL server password to connect as.
+The PostgreSQL server user to connect as. If left unset, the value is read from `/run/secrets/postgres_user`. Both the variable and the file are ignored if `PGPASSFILE` is set.
+
+#### `POSTGRES_PASSWORD`
+
+Specifies the PostgreSQL server password to connect as. If left unset, the value is read from `/run/secrets/postgres_password`. Both the variable and the file are ignored if `PGPASSFILE` is set.
+
+#### `PGPASSFILE`
+
+Path to a file containing PostgreSQL connection information. Note that `PGPASSFILE` with Docker secrets is preferred when Docker secrets are available.
 
 #### `SMASH_USER` (optional)
 

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -134,7 +134,7 @@ let
         #!${runtimeShell}
 
         ${genPgpass}
-        export PGPASSFILE=/configuration/pgpass
+        export PGPASSFILE=''${PGPASSFILE:-/configuration/pgpass}
 
         ${setupTmp}
 
@@ -228,7 +228,7 @@ let
         #!${runtimeShell}
 
         ${genPgpass}
-        export PGPASSFILE=/configuration/pgpass
+        export PGPASSFILE=''${PGPASSFILE:-/configuration/pgpass}
 
         ${setupTmp}
 
@@ -254,10 +254,13 @@ let
   # Scripts supporting entrypoint
   genPgpass = writeScript "gen-pgpass" ''
     #!${runtimeShell}
+    if [ -n "''${PGPASSFILE:-}" ]; then
+       exit 0
+    fi
     mkdir -p /configuration
     if [ -f /configuration/pgpass ]; then
        # No need to generate pgpass
-      exit 0
+       exit 0
     fi
 
     SECRET_DIR=/run/secrets

--- a/nix/nixos/cardano-db-sync-service.nix
+++ b/nix/nixos/cardano-db-sync-service.nix
@@ -286,7 +286,6 @@ in {
           done
         fi
 
-        mkdir -p log-dir
         ${dbSyncCommand}'';
     };
     systemd.services.cardano-db-sync = {


### PR DESCRIPTION
# Description
PR for Issue  #2149
Update Docker configuration to allow PostgreSQL connection details to be provided via Docker secrets or a .pgpass file using the PGPASSFILE environment variable. This makes the individual POSTGRES_* variables optional.

# Checklist

- [x] Commit sequence broadly makes sense
- [x] Commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Any changes are noted in the [changelog](https://github.com/IntersectMBO/cardano-db-sync/blob/master/db-sync/CHANGELOG.md)
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) on version 0.17.0.0 (which can be run with `scripts/fourmolize.sh`)
- [x] Self-reviewed the diff

# Migrations

- [ ] The pr causes a [breaking change](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/migrations.md) of type a,b or c
- [ ] If there is a breaking change, the pr includes a database migration and/or a fix process for old values, so that upgrade is possible
- [ ] Resyncing and running the migrations provided will result in the same database semantically

If there is a breaking change, especially a big one, please add a justification here. Please elaborate
more what the migration achieves, what it cannot achieve or why a migration is not possible.
