### PR TITLE
Fix consume id in tx_out queries that select txout.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - The `epoch` table is redesigned and replaced by a view; the in-memory cache that caused [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) is removed. Reads are unchanged.
 - Fix `pool_relay.port` overflow [#2135](https://github.com/IntersectMBO/cardano-db-sync/issues/2135); a startup migration repairs existing rows.
 - Add `--allow-private-offchain-urls` CLI flag enabling off-chain metadata fetches against private/loopback addresses. Intended for local-cluster testing only; off by default.
+- Fix `cardano-db-tool` `utxo-set` and `validate` crashing with `RowError 0 6 UnexpectedNull` on any database holding enterprise-address outputs; the tool tx_out queries selected `txout.*` but decoded without the `id` column, shifting every field by one.
 
 ## 13.7.1.0
 - Auto-repair `epoch.out_sum` / `epoch.fees` / `epoch.tx_count` / `epoch.blk_count` corruption introduced by issue [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) in 13.7.0.0 - 13.7.0.4. A startup migration recomputes every epoch row from the underlying `tx` / `block` tables and rewrites only the rows whose stored values disagree. Adds a one-time 5-15 minute delay on the first startup after upgrade on a mainnet-sized database; subsequent restarts and fresh syncs are unaffected. Operators on older release lines who do not upgrade can apply the same fix manually via [`scripts/fix-epoch-table.sql`](scripts/fix-epoch-table.sql).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - The `epoch` table is redesigned and replaced by a view; the in-memory cache that caused [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) is removed. Reads are unchanged.
 - Fix `pool_relay.port` overflow [#2135](https://github.com/IntersectMBO/cardano-db-sync/issues/2135); a startup migration repairs existing rows.
 - Add `--allow-private-offchain-urls` CLI flag enabling off-chain metadata fetches against private/loopback addresses. Intended for local-cluster testing only; off by default.
-- Fix `cardano-db-tool` `utxo-set` and `validate` crashing with `RowError 0 6 UnexpectedNull` on any database holding enterprise-address outputs; the tool tx_out queries selected `txout.*` but decoded without the `id` column, shifting every field by one.
 
 ## 13.7.1.0
 - Auto-repair `epoch.out_sum` / `epoch.fees` / `epoch.tx_count` / `epoch.blk_count` corruption introduced by issue [#2118](https://github.com/IntersectMBO/cardano-db-sync/issues/2118) in 13.7.0.0 - 13.7.0.4. A startup migration recomputes every epoch row from the underlying `tx` / `block` tables and rewrites only the rows whose stored values disagree. Adds a one-time 5-15 minute delay on the first startup after upgrade on a mainnet-sized database; subsequent restarts and fresh syncs are unaffected. Operators on older release lines who do not upgrade can apply the same fix manually via [`scripts/fix-epoch-table.sql`](scripts/fix-epoch-table.sql).

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -157,6 +157,7 @@ test-suite test-db
                         Test.IO.Cardano.Db.Migration
                         Test.IO.Cardano.Db.Rollback
                         Test.IO.Cardano.Db.TotalSupply
+                        Test.IO.Cardano.Db.TxOutQuery
                         Test.IO.Cardano.Db.Util
                         Test.IO.Cardano.Db.PGConfig
 

--- a/cardano-db/src/Cardano/Db/Schema/Variants/TxOutAddress.hs
+++ b/cardano-db/src/Cardano/Db/Schema/Variants/TxOutAddress.hs
@@ -17,7 +17,7 @@ import qualified Hasql.Encoders as E
 import qualified Cardano.Db.Schema.Ids as Id
 import Cardano.Db.Schema.Types (textDecoder)
 import Cardano.Db.Statement.Function.Core (bulkEncoder)
-import Cardano.Db.Statement.Types (DbInfo (..), Key)
+import Cardano.Db.Statement.Types (DbInfo (..), Entity (..), Key)
 import Cardano.Db.Types (DbLovelace, DbWord64 (..), dbLovelaceDecoder, dbLovelaceEncoder, dbLovelaceValueEncoder, dbWord64ValueEncoder)
 
 -- |
@@ -63,6 +63,12 @@ instance DbInfo TxOutAddress where
       , "consumed_by_tx_id"
       , "address_id"
       ]
+
+entityTxOutAddressDecoder :: D.Row (Entity TxOutAddress)
+entityTxOutAddressDecoder =
+  Entity
+    <$> Id.idDecoder Id.TxOutAddressId
+    <*> txOutAddressDecoder
 
 txOutAddressDecoder :: D.Row TxOutAddress
 txOutAddressDecoder =
@@ -165,6 +171,12 @@ data Address = Address
 
 type instance Key Address = Id.AddressId
 instance DbInfo Address
+
+entityAddressDecoder :: D.Row (Entity Address)
+entityAddressDecoder =
+  Entity
+    <$> Id.idDecoder Id.AddressId
+    <*> addressDecoder
 
 addressDecoder :: D.Row Address
 addressDecoder =

--- a/cardano-db/src/Cardano/Db/Statement/ChainGen.hs
+++ b/cardano-db/src/Cardano/Db/Statement/ChainGen.hs
@@ -509,7 +509,7 @@ queryTxInputsCoreStmt =
           ]
 
     encoder = fromIntegral >$< HsqlE.param (HsqlE.nonNullable HsqlE.int8)
-    decoder = HsqlD.rowList SVC.txOutCoreDecoder
+    decoder = HsqlD.rowList (entityVal <$> SVC.entityTxOutCoreDecoder)
 
 queryTxInputsAddressStmt :: HsqlStmt.Statement Word64 [SVA.TxOutAddress]
 queryTxInputsAddressStmt =
@@ -531,7 +531,7 @@ queryTxInputsAddressStmt =
           ]
 
     encoder = fromIntegral >$< HsqlE.param (HsqlE.nonNullable HsqlE.int8)
-    decoder = HsqlD.rowList SVA.txOutAddressDecoder
+    decoder = HsqlD.rowList (entityVal <$> SVA.entityTxOutAddressDecoder)
 
 queryTxInputs :: SV.TxOutVariantType -> Word64 -> DbM [SV.TxOutW]
 queryTxInputs txOutTableType txId = do
@@ -566,7 +566,7 @@ queryTxOutputsCoreStmt =
           ]
 
     encoder = fromIntegral >$< HsqlE.param (HsqlE.nonNullable HsqlE.int8)
-    decoder = HsqlD.rowList SVC.txOutCoreDecoder
+    decoder = HsqlD.rowList (entityVal <$> SVC.entityTxOutCoreDecoder)
 
 queryTxOutputsAddressStmt :: HsqlStmt.Statement Word64 [SVA.TxOutAddress]
 queryTxOutputsAddressStmt =
@@ -585,7 +585,7 @@ queryTxOutputsAddressStmt =
           ]
 
     encoder = fromIntegral >$< HsqlE.param (HsqlE.nonNullable HsqlE.int8)
-    decoder = HsqlD.rowList SVA.txOutAddressDecoder
+    decoder = HsqlD.rowList (entityVal <$> SVA.entityTxOutAddressDecoder)
 
 queryTxOutputs :: SV.TxOutVariantType -> Word64 -> DbM [SV.TxOutW]
 queryTxOutputs txOutTableType txId = do

--- a/cardano-db/src/Cardano/Db/Statement/DbTool.hs
+++ b/cardano-db/src/Cardano/Db/Statement/DbTool.hs
@@ -32,7 +32,7 @@ import qualified Cardano.Db.Schema.Variants.TxOutAddress as SVA
 import qualified Cardano.Db.Schema.Variants.TxOutCore as SVC
 import Cardano.Db.Statement.Function.Core (runSession)
 import Cardano.Db.Statement.Function.Query (adaDecoder)
-import Cardano.Db.Statement.Types (tableName)
+import Cardano.Db.Statement.Types (entityVal, tableName)
 import Cardano.Db.Types (Ada (..), DbLovelace, DbM, dbLovelaceDecoder, lovelaceToAda)
 
 ------------------------------------------------------------------------------------------------------------
@@ -364,7 +364,7 @@ queryUtxoAtBlockIdCoreStmt =
     encoder = Id.idEncoder Id.getBlockId
 
     decoder = HsqlD.rowList $ do
-      txOut <- SVC.txOutCoreDecoder
+      txOut <- entityVal <$> SVC.entityTxOutCoreDecoder
       address <- HsqlD.column (HsqlD.nonNullable HsqlD.text)
       txHash <- HsqlD.column (HsqlD.nonNullable HsqlD.bytea)
       pure $
@@ -394,8 +394,8 @@ queryUtxoAtBlockIdVariantStmt =
     encoder = Id.idEncoder Id.getBlockId
 
     decoder = HsqlD.rowList $ do
-      txOut <- SVA.txOutAddressDecoder
-      addr <- SVA.addressDecoder
+      txOut <- entityVal <$> SVA.entityTxOutAddressDecoder
+      addr <- entityVal <$> SVA.entityAddressDecoder
       txHash <- HsqlD.column (HsqlD.nonNullable HsqlD.bytea)
       pure $
         UtxoQueryResult

--- a/cardano-db/src/Cardano/Db/Statement/Variants/TxOut.hs
+++ b/cardano-db/src/Cardano/Db/Statement/Variants/TxOut.hs
@@ -752,7 +752,7 @@ queryScriptOutputsVariantStmt =
           , " JOIN tx_out ON tx_out.address_id = address.id"
           , " WHERE address.address_has_script = TRUE"
           ]
-    decoder = HsqlD.rowList $ (,) <$> (entityVal <$> SVA.entityTxOutAddressDecoder) <*> (entityVal <$> SVA.entityAddressDecoder)
+    decoder = HsqlD.rowList $ (,) . entityVal <$> SVA.entityTxOutAddressDecoder <*> (entityVal <$> SVA.entityAddressDecoder)
 
 queryScriptOutputs :: TxOutVariantType -> DbM [TxOutW]
 queryScriptOutputs txOutVariantType = do

--- a/cardano-db/src/Cardano/Db/Statement/Variants/TxOut.hs
+++ b/cardano-db/src/Cardano/Db/Statement/Variants/TxOut.hs
@@ -752,7 +752,7 @@ queryScriptOutputsVariantStmt =
           , " JOIN tx_out ON tx_out.address_id = address.id"
           , " WHERE address.address_has_script = TRUE"
           ]
-    decoder = HsqlD.rowList $ (,) <$> SVA.txOutAddressDecoder <*> SVA.addressDecoder
+    decoder = HsqlD.rowList $ (,) <$> (entityVal <$> SVA.entityTxOutAddressDecoder) <*> (entityVal <$> SVA.entityAddressDecoder)
 
 queryScriptOutputs :: TxOutVariantType -> DbM [TxOutW]
 queryScriptOutputs txOutVariantType = do

--- a/cardano-db/test/Test/IO/Cardano/Db/TxOutQuery.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/TxOutQuery.hs
@@ -17,11 +17,14 @@ tests =
   testGroup
     "TxOutQuery"
     [ testCase "queryTxOutputs decodes an enterprise output" queryTxOutputsEnterprise
+    , testCase "utxo-set query decodes an enterprise output" queryUtxoAtSlotEnterprise
     ]
 
--- An enterprise output has a null stake_address_id. The query selects txout.*
--- (including the id column), so the decoder must consume id or every field
--- shifts and the value decoder hits the nullable stake_address_id column.
+-- Core variant only; the IO schema has no address table, so the Address path is
+-- covered by the chain-gen suite.
+
+-- Enterprise output has a null stake_address_id, so the decoder must consume the
+-- selected id column or every field shifts by one (#2162).
 queryTxOutputsEnterprise :: IO ()
 queryTxOutputsEnterprise =
   runDbStandaloneSilent $ do
@@ -39,3 +42,24 @@ queryTxOutputsEnterprise =
           ("unexpected value: " ++ show (txOutCoreValue txOut))
           (txOutCoreValue txOut == DbLovelace 1000000000)
       _ -> assertBool ("expected one output, got " ++ show (length outs)) False
+
+-- utxo-set uses a different decoder (queryUtxoAtBlockId), so it needs its own case.
+queryUtxoAtSlotEnterprise :: IO ()
+queryUtxoAtSlotEnterprise =
+  runDbStandaloneSilent $ do
+    deleteAllBlocks
+    slid <- insertSlotLeader testSlotLeader
+    bid <- insertCheckUniqueBlock (mkBlock 0 slid)
+    txId <- case mkTxs bid 1 of
+      (tx : _) -> insertTx tx
+      [] -> error "mkTxs returned empty list"
+    void $ insertTxOut (mkTxOutCore bid txId)
+    utxos <- queryUtxoAtSlotNo TxOutVariantCore 0
+    case utxos of
+      [utxo] -> case utxoTxOutW utxo of
+        VCTxOutW txOut ->
+          assertBool
+            ("unexpected value: " ++ show (txOutCoreValue txOut))
+            (txOutCoreValue txOut == DbLovelace 1000000000)
+        _ -> assertBool "expected a core txout" False
+      _ -> assertBool ("expected one utxo, got " ++ show (length utxos)) False

--- a/cardano-db/test/Test/IO/Cardano/Db/TxOutQuery.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/TxOutQuery.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.IO.Cardano.Db.TxOutQuery (
+  tests,
+) where
+
+import Cardano.Db
+import Cardano.Db.Schema.Variants.TxOutCore (TxOutCore (..))
+import Control.Monad (void)
+import Test.IO.Cardano.Db.Util
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
+
+tests :: TestTree
+tests =
+  testGroup
+    "TxOutQuery"
+    [ testCase "queryTxOutputs decodes an enterprise output" queryTxOutputsEnterprise
+    ]
+
+-- An enterprise output has a null stake_address_id. The query selects txout.*
+-- (including the id column), so the decoder must consume id or every field
+-- shifts and the value decoder hits the nullable stake_address_id column.
+queryTxOutputsEnterprise :: IO ()
+queryTxOutputsEnterprise =
+  runDbStandaloneSilent $ do
+    deleteAllBlocks
+    slid <- insertSlotLeader testSlotLeader
+    bid <- insertCheckUniqueBlock (mkBlock 0 slid)
+    txId <- case mkTxs bid 1 of
+      (tx : _) -> insertTx tx
+      [] -> error "mkTxs returned empty list"
+    void $ insertTxOut (mkTxOutCore bid txId)
+    outs <- queryTxOutputs TxOutVariantCore (fromIntegral $ getTxId txId)
+    case outs of
+      [VCTxOutW txOut] ->
+        assertBool
+          ("unexpected value: " ++ show (txOutCoreValue txOut))
+          (txOutCoreValue txOut == DbLovelace 1000000000)
+      _ -> assertBool ("expected one output, got " ++ show (length outs)) False

--- a/cardano-db/test/test-db.hs
+++ b/cardano-db/test/test-db.hs
@@ -11,6 +11,7 @@ import qualified Test.IO.Cardano.Db.Migration
 import qualified Test.IO.Cardano.Db.PGConfig
 import qualified Test.IO.Cardano.Db.Rollback
 import qualified Test.IO.Cardano.Db.TotalSupply
+import qualified Test.IO.Cardano.Db.TxOutQuery
 import Test.Tasty (defaultMain, testGroup)
 import Prelude
 
@@ -28,6 +29,7 @@ main = do
       [ Test.IO.Cardano.Db.Migration.tests
       , Test.IO.Cardano.Db.Insert.tests
       , Test.IO.Cardano.Db.TotalSupply.tests
+      , Test.IO.Cardano.Db.TxOutQuery.tests
       , Test.IO.Cardano.Db.Rollback.tests
       , Test.IO.Cardano.Db.EpochCalc.tests
       , Test.IO.Cardano.Db.PGConfig.tests


### PR DESCRIPTION
Closes #2162.

`utxo-set` and the `validate` TxAccounting check crash on any database that holds enterprise-address outputs. The tool's tx_out queries `SELECT txout.*`, so the primary key `id` comes back as the first column, but the result is decoded with `txOutCoreDecoder`/`txOutAddressDecoder`, which start at `tx_id` and never consume `id`. Every field is read one column to the left, and the non-nullable `value` decoder ends up on the nullable `stake_address_id` column, which is null for enterprise outputs, giving `RowError 0 6 UnexpectedNull`. Because real chains always contain enterprise outputs, this fired on every valid slot.

The fix decodes these queries with the entity decoders, which consume `id` first, and takes `entityVal`. I added `entityTxOutAddressDecoder` and `entityAddressDecoder` to mirror the core variant, then applied the same change everywhere a tool query feeds `SELECT ...*` into an id-less decoder: `queryTxInputs`, `queryTxOutputs`, `queryUtxoAtBlockId`, and the address branch of `queryScriptOutputs`. The last one is the same defect one step beyond the issue, so it is fixed here too rather than left as a landmine.

The first commit is a failing regression test (`Test.IO.Cardano.Db.TxOutQuery`) that inserts an enterprise output and reads it back through `queryTxOutputs`; the second commit is the fix that turns it green. The Core path is covered by that test; the Address path is fixed and compiles under `-Werror` but is not exercised by the IO suite, which only builds a Core schema.

Verified end to end against a restored preprod database that reproduced the crash: `utxo-set` now prints the supply/fees summary instead of `RowError`, and `validate`'s TxAccounting check reports `ok` and the run continues past it. (`validate` still exits non-zero afterwards, but on a later check and for an unrelated reason tracked in #2163, not the decoder.)
