### PR TITLE
Clarify that shelley.enable only gates transaction-era certificates

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -441,6 +441,8 @@ Shelley Properties:
 
 Enables or disables data related to shelley: all certificates, withdrawals, and param
 proposals. Does not control `epoch_stake` and `rewards`, For this check `ledger`.
+This governs transaction-era certificates only; genesis-era stake and pool registrations
+are always inserted regardless of this setting.
 
 `shelley.enable`
 


### PR DESCRIPTION
The `shelley.enable` docs say it enables or disables "all certificates", but genesis-era stake and pool registrations are inserted regardless of this flag. That makes the wording misleading.

This adds one sentence to configuration.md noting the flag only gates transaction-era certificates. Docs only, no code change.