### PR TITLE
Count epoch block txs by id and clamp block-range sampling

### DIFF
--- a/cardano-db-tool/src/Cardano/DbTool/Validate/BlockProperties.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/Validate/BlockProperties.hs
@@ -51,16 +51,24 @@ validateBlockTimesInPast = do
     showFirst (mEpoch, mBlockNo, time) =
       mconcat ["epoch ", show mEpoch, " block ", show mBlockNo, " time ", show time]
 
+-- The random start block and how many blocks to sample, clamped so the range
+-- never underflows on a database with fewer than testBlocks blocks.
+sampleWindow :: Word64 -> Word64 -> (Word64, Word64)
+sampleWindow blkCount testBlocks =
+  let count = min testBlocks blkCount
+   in (blkCount - count, count)
+
 validataBlockNosContiguous :: Word64 -> IO ()
 validataBlockNosContiguous blkCount = do
-  startBlock <- Random.randomRIO (0, blkCount - testBlocks)
+  let (maxStart, count) = sampleWindow blkCount testBlocks
+  startBlock <- Random.randomRIO (0, maxStart)
   putStrF $
     "Block numbers ["
       ++ show startBlock
       ++ " .. "
-      ++ show (startBlock + testBlocks)
+      ++ show (startBlock + count)
       ++ "] are contiguous: "
-  blockNos <- DB.runDbStandaloneSilent $ DB.queryBlockNoList startBlock testBlocks
+  blockNos <- DB.runDbStandaloneSilent $ DB.queryBlockNoList startBlock count
   case checkContinguous blockNos of
     Nothing -> putStrLn $ greenText "ok"
     Just xs -> error $ redText "failed: " ++ show xs
@@ -79,14 +87,15 @@ validataBlockNosContiguous blkCount = do
 
 validateTimestampsOrdered :: Word64 -> IO ()
 validateTimestampsOrdered blkCount = do
-  startBlock <- Random.randomRIO (0, blkCount - testBlocks)
+  let (maxStart, count) = sampleWindow blkCount testBlocks
+  startBlock <- Random.randomRIO (0, maxStart)
   putStrF $
     "Block time stamps for blocks ["
       ++ show startBlock
       ++ " .. "
-      ++ show (startBlock + testBlocks)
+      ++ show (startBlock + count)
       ++ "] are ordered: "
-  ts <- DB.runDbStandaloneSilent $ DB.queryBlockTimestamps startBlock testBlocks
+  ts <- DB.runDbStandaloneSilent $ DB.queryBlockTimestamps startBlock count
   if List.nubOrd ts == ts
     then putStrLn $ greenText "ok"
     else error $ redText "failed: " ++ show ts

--- a/cardano-db-tool/src/Cardano/DbTool/Validate/BlockTxs.hs
+++ b/cardano-db-tool/src/Cardano/DbTool/Validate/BlockTxs.hs
@@ -51,9 +51,9 @@ validateBlockTxs epoch = do
                 ++ show (veTxCountActual ve)
             )
 
-validateBlockCount :: (Word64, Word64) -> DB.DbM (Either ValidateError ())
-validateBlockCount (blockNo, txCountExpected) = do
-  txCountActual <- DB.queryBlockTxCount $ DB.BlockId $ fromIntegral blockNo
+validateBlockCount :: (DB.BlockId, Word64, Word64) -> DB.DbM (Either ValidateError ())
+validateBlockCount (blockId, blockNo, txCountExpected) = do
+  txCountActual <- DB.queryBlockTxCount blockId
   pure $
     if txCountActual == txCountExpected
       then Right ()

--- a/cardano-db/cardano-db.cabal
+++ b/cardano-db/cardano-db.cabal
@@ -152,7 +152,8 @@ test-suite test-db
   main-is:              test-db.hs
   hs-source-dirs:       test
 
-  other-modules:        Test.IO.Cardano.Db.EpochCalc
+  other-modules:        Test.IO.Cardano.Db.EpochBlockTxs
+                        Test.IO.Cardano.Db.EpochCalc
                         Test.IO.Cardano.Db.Insert
                         Test.IO.Cardano.Db.Migration
                         Test.IO.Cardano.Db.Rollback

--- a/cardano-db/src/Cardano/Db/Statement/DbTool.hs
+++ b/cardano-db/src/Cardano/Db/Statement/DbTool.hs
@@ -871,7 +871,7 @@ queryOutputsAddress saId =
 
 --------------------------------------------------------------------------------
 
-queryEpochBlockNumbersStmt :: HsqlStmt.Statement Word64 [(Word64, Word64)]
+queryEpochBlockNumbersStmt :: HsqlStmt.Statement Word64 [(Id.BlockId, Word64, Word64)]
 queryEpochBlockNumbersStmt =
   HsqlStmt.Statement sql encoder decoder True
   where
@@ -880,7 +880,7 @@ queryEpochBlockNumbersStmt =
     sql =
       TextEnc.encodeUtf8 $
         Text.concat
-          [ "SELECT COALESCE(block_no, 0), tx_count"
+          [ "SELECT id, COALESCE(block_no, 0), tx_count"
           , " FROM " <> blockTableN
           , " WHERE epoch_no = $1"
           ]
@@ -888,10 +888,11 @@ queryEpochBlockNumbersStmt =
     encoder = fromIntegral >$< HsqlE.param (HsqlE.nonNullable HsqlE.int8)
 
     decoder = HsqlD.rowList $ do
+      blockId <- Id.idDecoder Id.BlockId
       blockNo <- HsqlD.column (HsqlD.nonNullable $ fromIntegral <$> HsqlD.int8)
       txCount <- HsqlD.column (HsqlD.nonNullable $ fromIntegral <$> HsqlD.int8)
-      pure (blockNo, txCount)
+      pure (blockId, blockNo, txCount)
 
-queryEpochBlockNumbers :: Word64 -> DbM [(Word64, Word64)]
+queryEpochBlockNumbers :: Word64 -> DbM [(Id.BlockId, Word64, Word64)]
 queryEpochBlockNumbers epoch =
   runSession mkDbCallStack $ HsqlSes.statement epoch queryEpochBlockNumbersStmt

--- a/cardano-db/test/Test/IO/Cardano/Db/EpochBlockTxs.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/EpochBlockTxs.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.IO.Cardano.Db.EpochBlockTxs (
+  tests,
+) where
+
+import Cardano.Db
+import Control.Monad (void)
+import Test.IO.Cardano.Db.Util
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
+
+tests :: TestTree
+tests =
+  testGroup
+    "EpochBlockTxs"
+    [ testCase "epoch block tx count is looked up by block id" epochBlockTxCountUsesId
+    ]
+
+-- block_no and the surrogate block.id diverge on a real chain (an EBB has a null
+-- block_no but a positive id). The epoch block-tx check must count transactions
+-- by block.id, not by block_no, or it reads the wrong (or no) block.
+epochBlockTxCountUsesId :: IO ()
+epochBlockTxCountUsesId =
+  runDbStandaloneSilent $ do
+    deleteAllBlocks
+    slid <- insertSlotLeader testSlotLeader
+    let blk = (mkBlock 0 slid) {blockTxCount = 1}
+    bid <- insertCheckUniqueBlock blk
+    case mkTxs bid 1 of
+      (tx : _) -> void $ insertTx tx
+      [] -> error "mkTxs returned empty list"
+    rows <- queryEpochBlockNumbers 0
+    case rows of
+      [(blockNo, expected)] -> do
+        actual <- queryBlockTxCount (BlockId (fromIntegral blockNo))
+        assertBool
+          ("expected tx count " ++ show expected ++ " but got " ++ show actual)
+          (actual == expected)
+      _ -> assertBool ("expected one block row, got " ++ show (length rows)) False

--- a/cardano-db/test/Test/IO/Cardano/Db/EpochBlockTxs.hs
+++ b/cardano-db/test/Test/IO/Cardano/Db/EpochBlockTxs.hs
@@ -32,8 +32,8 @@ epochBlockTxCountUsesId =
       [] -> error "mkTxs returned empty list"
     rows <- queryEpochBlockNumbers 0
     case rows of
-      [(blockNo, expected)] -> do
-        actual <- queryBlockTxCount (BlockId (fromIntegral blockNo))
+      [(blockId, _blockNo, expected)] -> do
+        actual <- queryBlockTxCount blockId
         assertBool
           ("expected tx count " ++ show expected ++ " but got " ++ show actual)
           (actual == expected)

--- a/cardano-db/test/test-db.hs
+++ b/cardano-db/test/test-db.hs
@@ -5,6 +5,7 @@ import Data.Maybe (isNothing)
 import System.Directory (getCurrentDirectory)
 import System.Environment (lookupEnv, setEnv)
 import System.FilePath ((</>))
+import qualified Test.IO.Cardano.Db.EpochBlockTxs
 import qualified Test.IO.Cardano.Db.EpochCalc
 import qualified Test.IO.Cardano.Db.Insert
 import qualified Test.IO.Cardano.Db.Migration
@@ -26,6 +27,7 @@ main = do
     testGroup
       "Database"
       [ Test.IO.Cardano.Db.Migration.tests
+      , Test.IO.Cardano.Db.EpochBlockTxs.tests
       , Test.IO.Cardano.Db.Insert.tests
       , Test.IO.Cardano.Db.TotalSupply.tests
       , Test.IO.Cardano.Db.Rollback.tests


### PR DESCRIPTION
Closes #2170.

Two `cardano-db-tool validate` checks were quietly wrong. Both were only visible once the error-isolation change in #2163 stops `validate` aborting on the first failure, so they were surfaced during review of that work.

The epoch block-tx check counted transactions with `queryBlockTxCount`, which keys on `block.id`, but fed it the `block_no` returned by `queryEpochBlockNumbers`. `block_no` and the surrogate `block.id` diverge on any real chain - an EBB has a null `block_no` and a positive id, and the id is just a sequence - so the check looked up the wrong block and reported false tx-count mismatches on mainnet, preprod, and preview. `queryEpochBlockNumbers` now returns the block id alongside `block_no`, and the check counts by the id while still printing `block_no` in the message. The shared `queryBlockTxCount` was always correct and is used correctly by sync's genesis validation; only this validator misused it.

The block-property checks (contiguous block numbers, ordered timestamps) picked a random start with `blkCount - 100000` in `Word64`, which underflows to an enormous value on any database with fewer than 100000 blocks - local/private clusters and DBs early in their first sync. That produced absurd ranges like `Block numbers [12258611005600085411 .. ...]` (and a false "ok" on the empty result). A small `sampleWindow` helper now clamps the window to the available block count, so the range is always valid. This never affected preprod, preview, or mainnet, which are all far past 100000 blocks.

The first commit adds a failing regression test in the `cardano-db` IO suite that models the id/block_no divergence (a block with a null `block_no` and a positive id, one transaction) and asserts the returned identifier counts the right block; the second commit is the fix. Bug 2 was verified end to end against a small local db-sync database, where the range now reads `Block numbers [0 .. 16608]` instead of the underflowed value.

Marked WIP/draft. Note this overlaps `Validate/BlockTxs.hs` with #2163 (which changes how the same check reports failures), so expect a small merge conflict there - the two changes are complementary: this PR fixes the check's logic, #2163 fixes its reporting and exit code. Bug 1 is only observable through `validate` end to end once #2162 and #2163 are also present (otherwise the run crashes at, or aborts before, the later checks), so the unit test is its standalone verification here.
